### PR TITLE
fix: add explorerURL to requestHandler process function

### DIFF
--- a/packages/commons/types/index.ts
+++ b/packages/commons/types/index.ts
@@ -132,12 +132,12 @@ export interface BridgeParams {
 /**
  * Result structure for bridge transactions.
  */
-export interface BridgeResult {
-  success: boolean;
-  error?: string;
-  explorerUrl?: string;
-  transactionHash?: string; // Add transaction hash property
-}
+export type BridgeResult =
+  | { success: false; error: Error | string }
+  | {
+      success: true;
+      explorerURL: string;
+    };
 
 /**
  * Result structure for swap transactions.
@@ -152,11 +152,16 @@ export interface SwapResult {
 /**
  * Result structure for transfer transactions.
  */
-export interface TransferResult {
-  success: boolean;
-  error?: string;
-  explorerUrl?: string;
-}
+export type TransferResult =
+  | {
+      success: true;
+      transactionHash: string;
+      explorerURL: string;
+    }
+  | {
+      success: false;
+      error: Error;
+    };
 
 export interface SimulationResult {
   intent: ReadableIntent;
@@ -480,7 +485,7 @@ export interface IRequestHandler {
       }
     | undefined
   >;
-  process(): Promise<unknown>;
+  process(): Promise<{ explorerURL: string } | undefined>;
 }
 
 type Network = Extract<Environment, Environment.CERISE | Environment.CORAL | Environment.FOLLY>;

--- a/packages/commons/types/index.ts
+++ b/packages/commons/types/index.ts
@@ -133,10 +133,11 @@ export interface BridgeParams {
  * Result structure for bridge transactions.
  */
 export type BridgeResult =
-  | { success: false; error: Error | string }
+  | { success: false; error: string }
   | {
       success: true;
-      explorerURL: string;
+      explorerUrl: string;
+      transactionHash?: string;
     };
 
 /**
@@ -156,11 +157,11 @@ export type TransferResult =
   | {
       success: true;
       transactionHash: string;
-      explorerURL: string;
+      explorerUrl: string;
     }
   | {
       success: false;
-      error: Error;
+      error: string;
     };
 
 export interface SimulationResult {

--- a/packages/core/sdk/ca-base/query/transfer.ts
+++ b/packages/core/sdk/ca-base/query/transfer.ts
@@ -33,11 +33,19 @@ class TransferQuery {
       throw new Error('ca not applicable');
     }
 
-    await this.handlerResponse.handler.process();
+    let explorerURL = '';
+    const result = await this.handlerResponse.handler.process();
+    if (result) {
+      explorerURL = result.explorerURL;
+    }
     logger.debug('TransferQuery:Exec', {
       state: 'processing completed, going to processTx()',
     });
-    return this.handlerResponse.processTx();
+    const hash = (await this.handlerResponse.processTx()) as Hex;
+    return {
+      hash,
+      explorerURL,
+    };
   };
 
   public async initHandler() {

--- a/packages/core/sdk/index.ts
+++ b/packages/core/sdk/index.ts
@@ -91,17 +91,17 @@ export class NexusSDK extends CA {
    * Cross chain token transfer
    */
   public async bridge(params: BridgeParams): Promise<BridgeResult> {
-    const result: BridgeResult = {
-      success: true,
-      explorerUrl: '',
-    };
     try {
-      await (await this._bridge(params)).exec();
-      // Add explorer URL
+      const result = await (await this._bridge(params)).exec();
+      return {
+        success: true,
+        explorerURL: result?.explorerURL ?? '',
+      };
     } catch (e) {
-      result.success = false;
-    } finally {
-      return result;
+      return {
+        success: false,
+        error: e instanceof Error ? e : new Error(String(e)),
+      };
     }
   }
 
@@ -109,16 +109,18 @@ export class NexusSDK extends CA {
    * Cross chain token transfer to EOA
    */
   public async transfer(params: TransferParams): Promise<TransferResult> {
-    const result: TransferResult = {
-      success: true,
-      explorerUrl: '',
-    };
     try {
-      await (await this._transfer({ ...params, to: params.recipient })).exec();
-    } catch (error) {
-      result.success = false;
-    } finally {
-      return result;
+      const result = await (await this._transfer({ ...params, to: params.recipient })).exec();
+      return {
+        success: true,
+        transactionHash: result.hash,
+        explorerURL: result.explorerURL,
+      };
+    } catch (e) {
+      return {
+        success: false,
+        error: e instanceof Error ? e : new Error(String(e)),
+      };
     }
   }
 

--- a/packages/core/sdk/index.ts
+++ b/packages/core/sdk/index.ts
@@ -95,12 +95,12 @@ export class NexusSDK extends CA {
       const result = await (await this._bridge(params)).exec();
       return {
         success: true,
-        explorerURL: result?.explorerURL ?? '',
+        explorerUrl: result?.explorerURL ?? '',
       };
     } catch (e) {
       return {
         success: false,
-        error: e instanceof Error ? e : new Error(String(e)),
+        error: e instanceof Error ? e.message : String(e),
       };
     }
   }
@@ -114,12 +114,12 @@ export class NexusSDK extends CA {
       return {
         success: true,
         transactionHash: result.hash,
-        explorerURL: result.explorerURL,
+        explorerUrl: result.explorerURL,
       };
     } catch (e) {
       return {
         success: false,
-        error: e instanceof Error ? e : new Error(String(e)),
+        error: e instanceof Error ? e.message : String(e),
       };
     }
   }


### PR DESCRIPTION
- add explorerURL to `requestHandler.process()`
- updated response for `bridge()` and `transfer()` func