### PR TITLE
fix: getBalance now fetches from vsc and ankr to support all chains

### DIFF
--- a/packages/commons/types/index.ts
+++ b/packages/commons/types/index.ts
@@ -16,19 +16,6 @@ type TokenInfo = {
   symbol: string;
 };
 
-type SwapBalances = {
-  assets: UserAssetDatum[];
-  balances: {
-    amount: string;
-    chainID: number;
-    decimals: number;
-    priceUSD: string;
-    tokenAddress: `0x${string}`;
-    universe: Universe;
-    value: number;
-  }[];
-};
-
 type NexusNetwork = 'mainnet' | 'testnet';
 
 export interface BlockTransaction {
@@ -349,6 +336,7 @@ export type Chain = {
   };
   id: number;
   name: string;
+  ankrName: string;
   nativeCurrency: {
     decimals: number;
     name: string;
@@ -574,6 +562,7 @@ export type ChainListType = {
   getTokenByAddress(chainID: number, address: `0x${string}`): TokenInfo | undefined;
   getNativeToken(chainID: number): TokenInfo;
   getChainByID(id: number): Chain | undefined;
+  getAnkrNameList(): string[];
 };
 
 export type RequestHandlerInput = {
@@ -747,12 +736,10 @@ export type UserAssetDatum = {
     contractAddress: `0x${string}`;
     decimals: number;
     isNative?: boolean;
-    priceUSD?: string;
     universe: Universe;
   }[];
   decimals: number;
   icon?: string;
-  priceInUsd?: string;
   symbol: string;
 };
 
@@ -775,6 +762,5 @@ export type {
   NexusNetwork,
   TransactionReceipt,
   SwapIntent,
-  SwapBalances,
   SetAllowanceInput,
 };

--- a/packages/commons/types/swap-types.ts
+++ b/packages/commons/types/swap-types.ts
@@ -199,29 +199,26 @@ export type AnkrAsset = {
   tokenType: 'ERC20' | 'NATIVE';
 };
 
-export type AnkrBalances = {
-  assets: {
-    balance: string;
-    balanceUSD: string;
-    chainID: number;
-    priceUSD: string;
-    tokenAddress: `0x${string}`;
-    tokenData: {
-      decimals: number;
-      icon: string;
-      name: string;
-      symbol: string;
-    };
-    universe: Universe;
-  }[];
-  totalBalanceInUSD: string;
+export type AnkrBalance = {
+  balance: string;
+  balanceUSD: string;
+  chainID: number;
+  tokenAddress: `0x${string}`;
+  tokenData: {
+    decimals: number;
+    icon: string;
+    name: string;
+    symbol: string;
+  };
+  universe: Universe;
 };
+
+export type AnkrBalances = AnkrBalance[];
 
 export type Balances = {
   amount: string;
   chain_id: number;
   decimals: number;
-  priceUSD: string;
   token_address: `0x${string}`;
   universe: Universe;
   value: number;

--- a/packages/core/sdk/ca-base/ca.ts
+++ b/packages/core/sdk/ca-base/ca.ts
@@ -193,10 +193,10 @@ export class CA {
       throw new Error('CA not initialized');
     }
     const { assets } = await getBalances({
+      networkHint: this._networkConfig.NETWORK_HINT,
       evmAddress: (await this._evm.client.requestAddresses())[0],
       chainList: this.chainList,
       filter: false,
-      removeTransferFee: false,
       vscDomain: this._networkConfig.VSC_DOMAIN,
       fuelAddress: this._fuel?.address,
     });

--- a/packages/core/sdk/ca-base/chains.ts
+++ b/packages/core/sdk/ca-base/chains.ts
@@ -111,6 +111,10 @@ class ChainList {
 
     return convertToHexAddressByUniverse(vc, chain.universe);
   }
+
+  getAnkrNameList() {
+    return this.chains.map((c) => c.ankrName).filter((n) => n !== '');
+  }
 }
 
 const TESTNET_CHAINS: Chain[] = [
@@ -142,6 +146,7 @@ const TESTNET_CHAINS: Chain[] = [
     },
     id: 421614,
     name: 'Arbitrum Sepolia',
+    ankrName: '',
     nativeCurrency: {
       decimals: 18,
       name: 'Ether',
@@ -189,6 +194,7 @@ const TESTNET_CHAINS: Chain[] = [
     },
     id: 11155420,
     name: 'OP Sepolia',
+    ankrName: '',
     nativeCurrency: {
       decimals: 18,
       name: 'Ether',
@@ -229,6 +235,7 @@ const TESTNET_CHAINS: Chain[] = [
     },
     id: 80002,
     name: 'Amoy',
+    ankrName: '',
     nativeCurrency: {
       decimals: 18,
       name: 'POL',
@@ -269,6 +276,7 @@ const TESTNET_CHAINS: Chain[] = [
     },
     id: 84532,
     name: 'Base Sepolia',
+    ankrName: '',
     nativeCurrency: {
       decimals: 18,
       name: 'Ether',
@@ -316,6 +324,7 @@ const TESTNET_CHAINS: Chain[] = [
     },
     id: MONAD_TESTNET_CHAIN_ID,
     name: 'Monad Testnet',
+    ankrName: '',
     nativeCurrency: {
       decimals: 18,
       name: 'Monad',
@@ -351,6 +360,7 @@ const TESTNET_CHAINS: Chain[] = [
     },
     id: 11155111,
     name: 'Ethereum Sepolia',
+    ankrName: '',
     nativeCurrency: {
       decimals: 18,
       name: 'Ether',
@@ -406,6 +416,7 @@ const MAINNET_CHAINS: Chain[] = [
     },
     id: CHAIN_IDS.fuel.mainnet,
     name: 'Fuel Network',
+    ankrName: '',
     nativeCurrency: {
       decimals: 9,
       name: 'Ether',
@@ -454,6 +465,7 @@ const MAINNET_CHAINS: Chain[] = [
     },
     id: SOPHON_CHAIN_ID,
     name: 'Sophon',
+    ankrName: '',
     nativeCurrency: {
       decimals: 18,
       name: 'Sophon',
@@ -489,6 +501,7 @@ const MAINNET_CHAINS: Chain[] = [
     },
     id: KAIA_CHAIN_ID,
     name: 'Kaia Mainnet',
+    ankrName: '',
     nativeCurrency: {
       decimals: 18,
       name: 'Kaia',
@@ -537,6 +550,7 @@ const MAINNET_CHAINS: Chain[] = [
     },
     id: 1,
     name: 'Ethereum Mainnet',
+    ankrName: 'eth',
     nativeCurrency: {
       decimals: 18,
       name: 'Ether',
@@ -593,6 +607,7 @@ const MAINNET_CHAINS: Chain[] = [
     },
     id: 10,
     name: 'OP Mainnet',
+    ankrName: 'optimism',
     nativeCurrency: {
       decimals: 18,
       name: 'Ether',
@@ -648,6 +663,7 @@ const MAINNET_CHAINS: Chain[] = [
     },
     id: 137,
     name: 'Polygon PoS',
+    ankrName: 'polygon',
     nativeCurrency: {
       decimals: 18,
       name: 'POL',
@@ -697,6 +713,7 @@ const MAINNET_CHAINS: Chain[] = [
     },
     id: 8453,
     name: 'Base',
+    ankrName: 'base',
     nativeCurrency: {
       decimals: 18,
       name: 'Ether',
@@ -753,6 +770,7 @@ const MAINNET_CHAINS: Chain[] = [
     },
     id: 42161,
     name: 'Arbitrum One',
+    ankrName: 'arbitrum',
     nativeCurrency: {
       decimals: 18,
       name: 'ETH',
@@ -808,6 +826,7 @@ const MAINNET_CHAINS: Chain[] = [
     },
     id: 534352,
     name: 'Scroll',
+    ankrName: 'scroll',
     nativeCurrency: {
       decimals: 18,
       name: 'Ether',
@@ -862,6 +881,7 @@ const MAINNET_CHAINS: Chain[] = [
       ],
     },
     id: 43114,
+    ankrName: 'avalanche',
     name: 'Avalanche C-Chain',
     nativeCurrency: {
       decimals: 18,
@@ -924,6 +944,7 @@ const MAINNET_CHAINS: Chain[] = [
     },
     id: 0x38,
     name: 'BNB Smart Chain',
+    ankrName: 'bsc',
     nativeCurrency: {
       decimals: 18,
       name: 'BNB',
@@ -977,6 +998,7 @@ const MAINNET_CHAINS: Chain[] = [
       ],
     },
     id: HYPEREVM_CHAIN_ID,
+    ankrName: '',
     name: 'HyperEVM',
     nativeCurrency: {
       decimals: 18,

--- a/packages/core/sdk/ca-base/requestHandlers/common/base.ts
+++ b/packages/core/sdk/ca-base/requestHandlers/common/base.ts
@@ -94,6 +94,7 @@ abstract class BaseRequest implements IRequestHandler {
       this.simulateTx(),
       Promise.all([
         getBalances({
+          networkHint: this.input.options.networkConfig.NETWORK_HINT,
           vscDomain: this.input.options.networkConfig.VSC_DOMAIN,
           evmAddress: this.input.evm.address,
           chainList: this.chainList,

--- a/packages/core/sdk/ca-base/swap/data.ts
+++ b/packages/core/sdk/ca-base/swap/data.ts
@@ -322,7 +322,6 @@ export type FlatBalance = {
   amount: string;
   chainID: number;
   decimals: number;
-  priceUSD: string;
   symbol: string;
   tokenAddress: `0x${string}`;
   universe: Universe;

--- a/packages/core/sdk/ca-base/utils/api.utils.ts
+++ b/packages/core/sdk/ca-base/utils/api.utils.ts
@@ -310,11 +310,23 @@ const getVscReq = (vscDomain: string) => {
   return vscReq;
 };
 
-export const getFuelBalancesForAddress = async (vscDomain: string, address: `0x${string}`) => {
+export const getBalancesFromVSC = async (
+  vscDomain: string,
+  address: `0x${string}`,
+  namespace: 'ETHEREUM' | 'FUEL' = 'ETHEREUM',
+) => {
   const response = await getVscReq(vscDomain).get<{
     balances: UnifiedBalanceResponseData[];
-  }>(`/get-balance/FUEL/${address}`);
+  }>(`/get-balance/${namespace}/${address}`);
   return response.data.balances;
+};
+
+export const getEVMBalancesForAddress = async (vscDomain: string, address: `0x${string}`) => {
+  return getBalancesFromVSC(vscDomain, address);
+};
+
+export const getFuelBalancesForAddress = async (vscDomain: string, address: `0x${string}`) => {
+  return getBalancesFromVSC(vscDomain, address, 'FUEL');
 };
 
 const vscCreateFeeGrant = async (vscDomain: string, address: string) => {


### PR DESCRIPTION
- Aggregation of ankr and vsc balance responses to support all chains
- Removed unused `SwapBalance` type
- Added `ankrName` to type Chain to be able to use with ankr balance fetching
- Removed unused `priceUSD` field