### PR TITLE
chore: added AssetBreakdown type and exported it from the sdk

### DIFF
--- a/src/commons/types/index.ts
+++ b/src/commons/types/index.ts
@@ -629,23 +629,25 @@ export type UnifiedBalanceResponseData = {
   errored: boolean;
 };
 
+export type AssetBreakdown = {
+  balance: string;
+  balanceInFiat: number;
+  chain: {
+    id: number;
+    logo: string;
+    name: string;
+  };
+  contractAddress: `0x${string}`;
+  decimals: number;
+  isNative?: boolean;
+  universe: Universe;
+};
+
 export type UserAssetDatum = {
   abstracted?: boolean;
   balance: string;
   balanceInFiat: number;
-  breakdown: {
-    balance: string;
-    balanceInFiat: number;
-    chain: {
-      id: number;
-      logo: string;
-      name: string;
-    };
-    contractAddress: `0x${string}`;
-    decimals: number;
-    isNative?: boolean;
-    universe: Universe;
-  }[];
+  breakdown: AssetBreakdown[];
   decimals: number;
   icon?: string;
   symbol: string;

--- a/src/commons/types/index.ts
+++ b/src/commons/types/index.ts
@@ -639,7 +639,6 @@ export type AssetBreakdown = {
   };
   contractAddress: `0x${string}`;
   decimals: number;
-  isNative?: boolean;
   universe: Universe;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export type {
   SUPPORTED_TOKENS,
   ChainMetadata,
   TokenMetadata,
+  AssetBreakdown,
 } from './commons';
 
 export {

--- a/src/sdk/ca-base/index.ts
+++ b/src/sdk/ca-base/index.ts
@@ -11,6 +11,7 @@ export type {
   RequestArguments,
   RFF,
   UserAssetDatum as UserAsset,
+  AssetBreakdown,
   BridgeStepType,
   SwapStepType,
 } from '../../commons';


### PR DESCRIPTION
have to get breadown type like this right now, which is cumbersome 

UserAsset["breakdown"][0]