### PR TITLE
feat: return intent with fee data on insufficient balance during simulation

### DIFF
--- a/src/commons/types/index.ts
+++ b/src/commons/types/index.ts
@@ -539,6 +539,9 @@ export type OraclePriceResponse = {
 }[];
 
 export type ReadableIntent = {
+  /** True when the user's available balance cannot cover amount + fees. */
+  isAvailableBalanceInsufficient?: boolean;
+
   allSources: {
     /**
      * @deprecated use chain.id

--- a/src/sdk/ca-base/requestHandlers/bridge.ts
+++ b/src/sdk/ca-base/requestHandlers/bridge.ts
@@ -101,14 +101,17 @@ class BridgeHandler {
   }
 
   public async simulate() {
-    const intent = await this.buildIntent(this.params.sourceChains);
+    const intent = await this.buildIntent(this.params.sourceChains, false);
     return {
       intent: convertIntent(intent, this.params.dstToken, this.options.chainList),
       token: this.params.dstToken,
     };
   }
 
-  private readonly buildIntent = async (sourceChains: number[] = []) => {
+  private readonly buildIntent = async (
+    sourceChains: number[] = [],
+    shouldThrowOnInsufficientBalance = true
+  ) => {
     const tProcessPreIntentSteps = logger.timer('process:preIntentSteps');
 
     const tPreIntentStepsApi = logger.timer('preIntentSteps:API');
@@ -179,6 +182,7 @@ class BridgeHandler {
       gasInToken,
       sourceChains,
       token: this.params.dstToken,
+      shouldThrowOnInsufficientBalance,
     });
     tPreIntentStepsCreateIntent.end();
     tProcessPreIntentSteps.end();
@@ -926,6 +930,8 @@ class BridgeHandler {
     assets: UserAssets;
     feeStore: FeeStore;
     gas: Decimal;
+    /** When false, sets isAvailableBalanceInsufficient flag instead of throwing. */
+    shouldThrowOnInsufficientBalance?: boolean;
     gasInToken: Decimal;
     sourceChains: number[];
     token: TokenInfo;
@@ -1102,11 +1108,14 @@ class BridgeHandler {
     intent.destination.amount = borrow;
 
     if (accountedAmount.lt(borrowWithFee)) {
-      throw Errors.insufficientBalance(
-        `required: ${borrowWithFee.toFixed()} ${
-          token.symbol
-        }, available: ${accountedAmount.toFixed()} ${token.symbol}`
-      );
+      if (input.shouldThrowOnInsufficientBalance !== false) {
+        throw Errors.insufficientBalance(
+          `required: ${borrowWithFee.toFixed()} ${
+            token.symbol
+          }, available: ${accountedAmount.toFixed()} ${token.symbol}`
+        );
+      }
+      intent.isAvailableBalanceInsufficient = true;
     }
 
     if (!gas.equals(0)) {

--- a/src/sdk/ca-base/utils/common.utils.ts
+++ b/src/sdk/ca-base/utils/common.utils.ts
@@ -285,6 +285,7 @@ const convertIntent = (
   };
   tConvertIntent.end();
   return {
+    isAvailableBalanceInsufficient: intent.isAvailableBalanceInsufficient || undefined,
     allSources,
     destination,
     fees: {


### PR DESCRIPTION
## Problem

When `createIntent` detects insufficient balance, it throws `INSUFFICIENT_BALANCE` and discards the fully-constructed intent — including the complete fee breakdown (protocol, solver, collection, fulfilment). This makes it impossible for callers to display bridge fee information in exactly the scenario where users need it most.

The `Intent` type already has an `isAvailableBalanceInsufficient` field, but it is never set to `true` anywhere in the codebase — it's initialized as `false` and stays that way. The guard in `execute()` → `refresh()` that checks this flag is effectively dead code.

## Solution

Add a `shouldThrowOnInsufficientBalance` parameter to `createIntent`/`buildIntent` (default `true`, preserving existing behavior). `simulate()` passes `false`, so it receives the intent with `isAvailableBalanceInsufficient: true` and all fee data intact.

- `simulate()` → flag instead of throw → intent returned with fees
- `execute()` → unchanged, continues to throw
- `refresh()` → unchanged, continues to throw + existing guard

## Changes

- `commons/types/index.ts` — Add optional `isAvailableBalanceInsufficient` to `ReadableIntent`
- `requestHandlers/bridge.ts` — Thread `shouldThrowOnInsufficientBalance` through `buildIntent` → `createIntent`; `simulate()` passes `false`
- `utils/common.utils.ts` — `convertIntent` passes the flag to `ReadableIntent`

## Verification

- `npm run typecheck` — pass
- `npm run build` — pass
- `npm test` — 24/24 pass
- `npm run lint` — pass (1 pre-existing warning in logger.ts)
