### PR TITLE
fix: gas calculation and batching

### DIFF
--- a/src/sdk/ca-base/query/bridgeAndExecute.ts
+++ b/src/sdk/ca-base/query/bridgeAndExecute.ts
@@ -4,8 +4,6 @@ import {
   type Hex,
   http,
   type PublicClient,
-  serializeTransaction,
-  type TransactionReceipt,
   toHex,
   type WalletClient,
 } from 'viem';
@@ -32,6 +30,11 @@ import {
   type UserAssetDatum,
 } from '../../../commons';
 import type { BackendSimulationClient } from '../../../integrations/tenderly';
+import {
+  type ExecuteFeeParams,
+  sendExecuteTransactions,
+} from '../../../services/executeTransactions';
+import { estimateTotalFees, type TxWithGas } from '../../../services/feeEstimation';
 import { isNativeAddress } from '../constants';
 import { Errors } from '../errors';
 import type BridgeHandler from '../requestHandlers/bridge';
@@ -40,15 +43,9 @@ import {
   createExplorerTxURL,
   erc20GetAllowance,
   generateStateOverride,
-  getL1Fee,
-  getPctGasBufferByChain,
   mulDecimals,
-  pctAdditionWithSuggestion,
-  switchChain,
   UserAssets,
-  waitForTxReceipt,
 } from '../utils';
-import { getGasPriceRecommendations } from './gasFeeHistory';
 
 class BridgeAndExecuteQuery {
   constructor(
@@ -114,57 +111,61 @@ class BridgeAndExecuteQuery {
           }
         });
 
-    // 5. simulate approval(?) and execution + fetch gasPrice + fetch unified balance
-    const [gasUsed, gasPriceRecommendations, balances, l1Fee] = await Promise.all([
-      determineGasUsed,
-      getGasPriceRecommendations(dstPublicClient),
-      this.getUnifiedBalances(),
-      getL1Fee(
-        execute.to,
-        dstChain,
-        serializeTransaction({
-          chainId: dstChain.id,
-          data: execute.data ?? '0x',
-          value: execute.value,
-          to: execute.to,
-          type: 'eip1559',
-        })
-      ),
-    ]);
+    const [gasUsed, balances] = await Promise.all([determineGasUsed, this.getUnifiedBalances()]);
 
-    const pctBuffer = getPctGasBufferByChain(dstChain.id);
+    const feeEstimateItems: TxWithGas[] = [
+      ...(approvalTx
+        ? [
+            {
+              tx: {
+                to: approvalTx.to,
+                data: approvalTx.data,
+                value: approvalTx.value,
+              },
+              gasEstimate: gasUsed.approvalGas,
+            },
+          ]
+        : []),
+      {
+        tx: {
+          to: tx.to,
+          data: tx.data,
+          value: tx.value,
+        },
+        gasEstimate: gasUsed.txGas,
+      },
+    ];
 
-    // We ask for more, but suggest lesser than that
-    const [suggestedApprovalGas, approvalGas] = pctAdditionWithSuggestion(
-      gasUsed.approvalGas,
-      pctBuffer
+    const fees = await estimateTotalFees(
+      dstPublicClient,
+      feeEstimateItems,
+      params.execute.gasPrice ?? 'medium'
     );
-    const [suggestedTxGas, txGas] = pctAdditionWithSuggestion(gasUsed.txGas, pctBuffer);
+    const approvalFee = approvalTx ? fees[0] : null;
+    const txFee = fees[approvalTx ? 1 : 0];
 
-    const gasPrice = gasPriceRecommendations[params.execute.gasPrice ?? 'medium'];
-
-    if (gasPrice === 0n) {
+    if (!txFee || txFee.recommended.maxFeePerGas === 0n) {
       throw Errors.gasPriceError({
         chainId: dstChain.id,
       });
     }
 
-    if (approvalTx) {
-      approvalTx.gas = suggestedApprovalGas;
+    if (approvalTx && approvalFee) {
+      approvalTx.gas = approvalFee.recommended.gasLimit;
     }
 
-    tx.gas = suggestedTxGas;
+    tx.gas = txFee.recommended.gasLimit;
 
-    const gasFee = (approvalGas + txGas) * gasPrice + l1Fee;
+    const gasPrice = txFee.recommended.maxFeePerGas;
+    const l1Fee = fees.reduce((sum, fee) => sum + fee.l1Fee, 0n);
+    const gasFee = fees.reduce((sum, fee) => sum + fee.recommended.totalMaxCost, 0n);
 
     logger.debug('BridgeAndExecute:3', {
-      increasedGas: approvalGas + txGas,
-      approvalGas,
-      txGas,
-      gasPriceRecommendations,
+      fees,
       gasPrice,
       balances,
       l1Fee,
+      gasFee,
     });
 
     // 6. Determine gas or token needed via bridge
@@ -188,9 +189,19 @@ class BridgeAndExecuteQuery {
       tx,
       approvalTx,
       gas: {
-        tx: txGas,
-        approval: approvalGas,
+        tx: txFee.recommended.gasLimit,
+        approval: approvalFee?.recommended.gasLimit ?? 0n,
       },
+      feeParams: txFee.recommended.useLegacyPricing
+        ? ({
+            type: 'legacy',
+            gasPrice: txFee.recommended.maxFeePerGas,
+          } satisfies ExecuteFeeParams)
+        : ({
+            type: 'eip1559',
+            maxFeePerGas: txFee.recommended.maxFeePerGas,
+            maxPriorityFeePerGas: txFee.recommended.maxPriorityFeePerGas,
+          } satisfies ExecuteFeeParams),
       token,
       address,
       gasFee,
@@ -258,6 +269,7 @@ class BridgeAndExecuteQuery {
       approvalTx,
       amount,
       gas,
+      feeParams,
       gasPrice,
     } = await this.estimateBridgeAndExecute(params);
 
@@ -342,7 +354,7 @@ class BridgeAndExecuteQuery {
       {
         approvalTx,
         tx,
-        gasPrice,
+        feeParams,
       },
       {
         emit: options?.onEvent,
@@ -592,7 +604,7 @@ class BridgeAndExecuteQuery {
     params: {
       tx: Tx;
       approvalTx: Tx | null;
-      gasPrice?: bigint;
+      feeParams?: ExecuteFeeParams;
     },
     options: {
       emit?: OnEventParam['onEvent'];
@@ -605,61 +617,7 @@ class BridgeAndExecuteQuery {
       requiredConfirmations?: number;
     }
   ) {
-    const { waitForReceipt = true, receiptTimeout = 300000, requiredConfirmations = 1 } = options;
-    await switchChain(options.client, options.chain);
-
-    let approvalHash: Hex | undefined;
-    if (params.approvalTx) {
-      approvalHash = await options.client.sendTransaction({
-        ...params.approvalTx,
-        account: options.address,
-        chain: options.chain,
-      });
-
-      await waitForTxReceipt(approvalHash, options.dstPublicClient, 1);
-      if (options.emit) {
-        options.emit({
-          name: NEXUS_EVENTS.STEP_COMPLETE,
-          args: BRIDGE_STEPS.EXECUTE_APPROVAL_STEP,
-        });
-      }
-    }
-
-    const txHash = await options.client.sendTransaction({
-      ...params.tx,
-      account: options.address,
-      chain: options.chain,
-    });
-
-    if (options.emit) {
-      options.emit({
-        name: NEXUS_EVENTS.STEP_COMPLETE,
-        args: BRIDGE_STEPS.EXECUTE_TRANSACTION_SENT,
-      });
-    }
-
-    let receipt: TransactionReceipt | undefined;
-    if (waitForReceipt) {
-      receipt = await waitForTxReceipt(
-        txHash,
-        options.dstPublicClient,
-        requiredConfirmations,
-        receiptTimeout
-      );
-
-      if (options.emit) {
-        options.emit({
-          name: NEXUS_EVENTS.STEP_COMPLETE,
-          args: BRIDGE_STEPS.EXECUTE_TRANSACTION_CONFIRMED,
-        });
-      }
-    }
-
-    return {
-      txHash,
-      receipt,
-      approvalHash,
-    };
+    return sendExecuteTransactions(params, options);
   }
 
   private readonly bridgeWrapper = async (

--- a/src/sdk/ca-base/query/bridgeAndExecute.ts
+++ b/src/sdk/ca-base/query/bridgeAndExecute.ts
@@ -34,7 +34,7 @@ import {
   type ExecuteFeeParams,
   sendExecuteTransactions,
 } from '../../../services/executeTransactions';
-import { estimateTotalFees, type TxWithGas } from '../../../services/feeEstimation';
+import { estimateFeeContext, finalizeFeeEstimates } from '../../../services/feeEstimation';
 import { isNativeAddress } from '../constants';
 import { Errors } from '../errors';
 import type BridgeHandler from '../requestHandlers/bridge';
@@ -111,35 +111,61 @@ class BridgeAndExecuteQuery {
           }
         });
 
-    const [gasUsed, balances] = await Promise.all([determineGasUsed, this.getUnifiedBalances()]);
-
-    const feeEstimateItems: TxWithGas[] = [
-      ...(approvalTx
-        ? [
-            {
-              tx: {
-                to: approvalTx.to,
-                data: approvalTx.data,
-                value: approvalTx.value,
-              },
-              gasEstimate: gasUsed.approvalGas,
-            },
-          ]
-        : []),
-      {
-        tx: {
-          to: tx.to,
-          data: tx.data,
-          value: tx.value,
-        },
-        gasEstimate: gasUsed.txGas,
-      },
-    ];
-
-    const fees = await estimateTotalFees(
+    const feeContextPromise = estimateFeeContext(
       dstPublicClient,
-      feeEstimateItems,
+      dstChain.id,
+      [
+        ...(approvalTx
+          ? [
+              {
+                tx: {
+                  to: approvalTx.to,
+                  data: approvalTx.data,
+                  value: approvalTx.value,
+                },
+              },
+            ]
+          : []),
+        {
+          tx: {
+            to: tx.to,
+            data: tx.data,
+            value: tx.value,
+          },
+        },
+      ],
       params.execute.gasPrice ?? 'medium'
+    );
+
+    const [gasUsed, balances, feeContext] = await Promise.all([
+      determineGasUsed,
+      this.getUnifiedBalances(),
+      feeContextPromise,
+    ]);
+    const fees = finalizeFeeEstimates(
+      [
+        ...(approvalTx
+          ? [
+              {
+                tx: {
+                  to: approvalTx.to,
+                  data: approvalTx.data,
+                  value: approvalTx.value,
+                },
+                gasEstimate: gasUsed.approvalGas,
+              },
+            ]
+          : []),
+        {
+          tx: {
+            to: tx.to,
+            data: tx.data,
+            value: tx.value,
+          },
+          gasEstimate: gasUsed.txGas,
+        },
+      ],
+      feeContext
     );
     const approvalFee = approvalTx ? fees[0] : null;
     const txFee = fees[approvalTx ? 1 : 0];

--- a/src/sdk/ca-base/query/swapAndExecute.ts
+++ b/src/sdk/ca-base/query/swapAndExecute.ts
@@ -1,15 +1,6 @@
 import { Universe } from '@avail-project/ca-common';
+import { createPublicClient, type Hex, http, type PublicClient, type WalletClient } from 'viem';
 import {
-  createPublicClient,
-  type Hex,
-  http,
-  type PublicClient,
-  serializeTransaction,
-  type TransactionReceipt,
-  type WalletClient,
-} from 'viem';
-import {
-  BRIDGE_STEPS,
   type Chain,
   type ChainListType,
   type ExactOutSwapInput,
@@ -25,23 +16,17 @@ import {
   type Tx,
   type UserAssetDatum,
 } from '../../../commons';
+import {
+  type ExecuteFeeParams,
+  sendExecuteTransactions,
+} from '../../../services/executeTransactions';
+import { estimateTotalFees, type TxWithGas } from '../../../services/feeEstimation';
 import { isNativeAddress } from '../constants';
 import { Errors } from '../errors';
 import { EADDRESS } from '../swap/constants';
 import type { FlatBalance } from '../swap/data';
 import { getTokenInfo, packERC20Approve } from '../swap/utils';
-import {
-  convertTo32BytesHex,
-  equalFold,
-  erc20GetAllowance,
-  getL1Fee,
-  getPctGasBufferByChain,
-  mulDecimals,
-  pctAdditionWithSuggestion,
-  switchChain,
-  waitForTxReceipt,
-} from '../utils';
-import { getGasPriceRecommendations } from './gasFeeHistory';
+import { convertTo32BytesHex, equalFold, erc20GetAllowance, mulDecimals } from '../utils';
 
 class SwapAndExecuteQuery {
   constructor(
@@ -83,58 +68,79 @@ class SwapAndExecuteQuery {
     txs.push(tx);
 
     const determineGasUsed = Promise.resolve({
-      approvalGas: approvalTx ? 70_000n : 0n,
+      approvalGas: approvalTx
+        ? await dstPublicClient
+            .estimateGas({
+              to: approvalTx.to,
+              data: approvalTx.data,
+              value: approvalTx.value,
+              account: address,
+            })
+            .catch(() => 70_000n)
+        : 0n,
       txGas: params.execute.gas,
     });
 
-    // 5. simulate approval(?) and execution + fetch gasPrice + fetch unified balance
-    const [gasUsed, gasPriceRecommendations, balances, dstTokenInfo, l1Fee] = await Promise.all([
+    const [gasUsed, balances, dstTokenInfo] = await Promise.all([
       determineGasUsed,
-      getGasPriceRecommendations(dstPublicClient),
       this.getBalancesForSwap(),
       getTokenInfo(params.toTokenAddress, dstPublicClient, dstChain),
-      getL1Fee(
-        execute.to,
-        dstChain,
-        serializeTransaction({
-          chainId: dstChain.id,
-          data: execute.data ?? '0x',
-          value: execute.value,
-          to: execute.to,
-          type: 'eip1559',
-        })
-      ),
     ]);
 
-    const pctBuffer = getPctGasBufferByChain(toChainId);
-    const [suggestedApprovalGas, approvalGas] = pctAdditionWithSuggestion(
-      gasUsed.approvalGas,
-      pctBuffer
-    );
-    const [suggestedTxGas, txGas] = pctAdditionWithSuggestion(gasUsed.txGas, pctBuffer);
+    const feeEstimateItems: TxWithGas[] = [
+      ...(approvalTx
+        ? [
+            {
+              tx: {
+                to: approvalTx.to,
+                data: approvalTx.data,
+                value: approvalTx.value,
+              },
+              gasEstimate: gasUsed.approvalGas,
+              gasEstimateKind: 'final' as const,
+            },
+          ]
+        : []),
+      {
+        tx: {
+          to: tx.to,
+          data: tx.data,
+          value: tx.value,
+        },
+        gasEstimate: gasUsed.txGas,
+      },
+    ];
 
-    const gasPrice = gasPriceRecommendations[params.execute.gasPrice ?? 'medium'];
-    if (gasPrice === 0n) {
+    const fees = await estimateTotalFees(
+      dstPublicClient,
+      feeEstimateItems,
+      params.execute.gasPrice ?? 'medium'
+    );
+    const approvalFee = approvalTx ? fees[0] : null;
+    const txFee = fees[approvalTx ? 1 : 0];
+
+    if (!txFee || txFee.recommended.maxFeePerGas === 0n) {
       throw Errors.gasPriceError({
         chainId: toChainId,
       });
     }
 
-    if (approvalTx) {
-      approvalTx.gas = suggestedApprovalGas;
+    if (approvalTx && approvalFee) {
+      approvalTx.gas = approvalFee.recommended.gasLimit;
     }
 
-    tx.gas = suggestedTxGas;
+    tx.gas = txFee.recommended.gasLimit;
 
-    const gasFee = (approvalGas + txGas) * gasPrice + l1Fee;
+    const gasPrice = txFee.recommended.maxFeePerGas;
+    const l1Fee = fees.reduce((sum, fee) => sum + fee.l1Fee, 0n);
+    const gasFee = fees.reduce((sum, fee) => sum + fee.recommended.totalMaxCost, 0n);
 
     logger.debug('SwapAndExecute:3', {
-      increasedGas: approvalGas + txGas,
-      approvalGas,
-      txGas,
-      gasPriceRecommendations,
+      fees,
       gasPrice,
       balances,
+      l1Fee,
+      gasFee,
     });
 
     // 6. Determine gas or token needed via bridge
@@ -158,9 +164,19 @@ class SwapAndExecuteQuery {
       tx,
       approvalTx,
       gas: {
-        tx: txGas,
-        approval: approvalGas,
+        tx: txFee.recommended.gasLimit,
+        approval: approvalFee?.recommended.gasLimit ?? 0n,
       },
+      feeParams: txFee.recommended.useLegacyPricing
+        ? ({
+            type: 'legacy',
+            gasPrice: txFee.recommended.maxFeePerGas,
+          } satisfies ExecuteFeeParams)
+        : ({
+            type: 'eip1559',
+            maxFeePerGas: txFee.recommended.maxFeePerGas,
+            maxPriorityFeePerGas: txFee.recommended.maxPriorityFeePerGas,
+          } satisfies ExecuteFeeParams),
       dstTokenInfo,
       address,
       gasFee,
@@ -232,6 +248,7 @@ class SwapAndExecuteQuery {
       approvalTx,
       amount,
       gas,
+      feeParams,
       gasPrice,
       dstTokenInfo,
       gasFee,
@@ -315,7 +332,7 @@ class SwapAndExecuteQuery {
       {
         approvalTx,
         tx,
-        gasPrice,
+        feeParams,
       },
       {
         emit: options?.onEvent,
@@ -431,7 +448,7 @@ class SwapAndExecuteQuery {
     params: {
       tx: Tx;
       approvalTx: Tx | null;
-      gasPrice?: bigint;
+      feeParams?: ExecuteFeeParams;
     },
     options: {
       emit?: OnEventParam['onEvent'];
@@ -444,61 +461,7 @@ class SwapAndExecuteQuery {
       requiredConfirmations?: number;
     }
   ) {
-    const { waitForReceipt = true, receiptTimeout = 300000, requiredConfirmations = 1 } = options;
-    await switchChain(options.client, options.chain);
-
-    let approvalHash: Hex | undefined;
-    if (params.approvalTx) {
-      approvalHash = await options.client.sendTransaction({
-        ...params.approvalTx,
-        account: options.address,
-        chain: options.chain,
-      });
-
-      await waitForTxReceipt(approvalHash, options.dstPublicClient, 1);
-      if (options.emit) {
-        options.emit({
-          name: NEXUS_EVENTS.STEP_COMPLETE,
-          args: BRIDGE_STEPS.EXECUTE_APPROVAL_STEP,
-        });
-      }
-    }
-
-    const txHash = await options.client.sendTransaction({
-      ...params.tx,
-      account: options.address,
-      chain: options.chain,
-    });
-
-    if (options.emit) {
-      options.emit({
-        name: NEXUS_EVENTS.STEP_COMPLETE,
-        args: BRIDGE_STEPS.EXECUTE_TRANSACTION_SENT,
-      });
-    }
-
-    let receipt: TransactionReceipt | undefined;
-    if (waitForReceipt) {
-      receipt = await waitForTxReceipt(
-        txHash,
-        options.dstPublicClient,
-        requiredConfirmations,
-        receiptTimeout
-      );
-
-      if (options.emit) {
-        options.emit({
-          name: NEXUS_EVENTS.STEP_COMPLETE,
-          args: BRIDGE_STEPS.EXECUTE_TRANSACTION_CONFIRMED,
-        });
-      }
-    }
-
-    return {
-      txHash,
-      receipt,
-      approvalHash,
-    };
+    return sendExecuteTransactions(params, options);
   }
 }
 

--- a/src/sdk/ca-base/query/swapAndExecute.ts
+++ b/src/sdk/ca-base/query/swapAndExecute.ts
@@ -20,7 +20,7 @@ import {
   type ExecuteFeeParams,
   sendExecuteTransactions,
 } from '../../../services/executeTransactions';
-import { estimateTotalFees, type TxWithGas } from '../../../services/feeEstimation';
+import { estimateFeeContext, finalizeFeeEstimates } from '../../../services/feeEstimation';
 import { isNativeAddress } from '../constants';
 import { Errors } from '../errors';
 import { EADDRESS } from '../swap/constants';
@@ -67,54 +67,75 @@ class SwapAndExecuteQuery {
 
     txs.push(tx);
 
-    const determineGasUsed = Promise.resolve({
-      approvalGas: approvalTx
-        ? await dstPublicClient
-            .estimateGas({
-              to: approvalTx.to,
-              data: approvalTx.data,
-              value: approvalTx.value,
-              account: address,
-            })
-            .catch(() => 70_000n)
-        : 0n,
-      txGas: params.execute.gas,
-    });
+    const approvalGasPromise = approvalTx
+      ? dstPublicClient
+          .estimateGas({
+            to: approvalTx.to,
+            data: approvalTx.data,
+            value: approvalTx.value,
+            account: address,
+          })
+          .catch(() => 70_000n)
+      : Promise.resolve(0n);
 
-    const [gasUsed, balances, dstTokenInfo] = await Promise.all([
-      determineGasUsed,
+    const feeContextPromise = estimateFeeContext(
+      dstPublicClient,
+      toChainId,
+      [
+        ...(approvalTx
+          ? [
+              {
+                tx: {
+                  to: approvalTx.to,
+                  data: approvalTx.data,
+                  value: approvalTx.value,
+                },
+                gasEstimateKind: 'final' as const,
+              },
+            ]
+          : []),
+        {
+          tx: {
+            to: tx.to,
+            data: tx.data,
+            value: tx.value,
+          },
+        },
+      ],
+      params.execute.gasPrice ?? 'medium'
+    );
+
+    const [approvalGas, balances, dstTokenInfo, feeContext] = await Promise.all([
+      approvalGasPromise,
       this.getBalancesForSwap(),
       getTokenInfo(params.toTokenAddress, dstPublicClient, dstChain),
+      feeContextPromise,
     ]);
-
-    const feeEstimateItems: TxWithGas[] = [
-      ...(approvalTx
-        ? [
-            {
-              tx: {
-                to: approvalTx.to,
-                data: approvalTx.data,
-                value: approvalTx.value,
+    const fees = finalizeFeeEstimates(
+      [
+        ...(approvalTx
+          ? [
+              {
+                tx: {
+                  to: approvalTx.to,
+                  data: approvalTx.data,
+                  value: approvalTx.value,
+                },
+                gasEstimate: approvalGas,
+                gasEstimateKind: 'final' as const,
               },
-              gasEstimate: gasUsed.approvalGas,
-              gasEstimateKind: 'final' as const,
-            },
-          ]
-        : []),
-      {
-        tx: {
-          to: tx.to,
-          data: tx.data,
-          value: tx.value,
+            ]
+          : []),
+        {
+          tx: {
+            to: tx.to,
+            data: tx.data,
+            value: tx.value,
+          },
+          gasEstimate: params.execute.gas,
         },
-        gasEstimate: gasUsed.txGas,
-      },
-    ];
-
-    const fees = await estimateTotalFees(
-      dstPublicClient,
-      feeEstimateItems,
-      params.execute.gasPrice ?? 'medium'
+      ],
+      feeContext
     );
     const approvalFee = approvalTx ? fees[0] : null;
     const txFee = fees[approvalTx ? 1 : 0];

--- a/src/sdk/ca-base/swap/ob.ts
+++ b/src/sdk/ca-base/swap/ob.ts
@@ -788,6 +788,7 @@ class SourceSwapsHandler {
           chain,
           ephemeralAddress: this.options.address.ephemeral,
           ephemeralWallet: this.options.wallet.ephemeral,
+          publicClient,
           value: sbcCalls.value,
         });
 

--- a/src/sdk/ca-base/swap/sbc.ts
+++ b/src/sdk/ca-base/swap/sbc.ts
@@ -3,6 +3,7 @@ import {
   bytesToBigInt,
   type Chain,
   encodeAbiParameters,
+  encodeFunctionData,
   type Hex,
   type PrivateKeyAccount,
   type PublicClient,
@@ -18,6 +19,8 @@ import {
   type SBCTx,
   type Tx,
 } from '../../../commons';
+import type { ExecuteFeeParams } from '../../../services/executeTransactions';
+import { estimateFeeContext, finalizeFeeEstimates } from '../../../services/feeEstimation';
 import { Errors } from '../errors';
 import { createDeadlineFromNow, waitForTxReceipt } from '../utils';
 import { PlatformUtils } from '../utils/platform.utils';
@@ -31,6 +34,101 @@ import {
 } from './utils';
 
 const logger = getLogger();
+
+const spreadFeeParams = (feeParams?: ExecuteFeeParams) => {
+  if (!feeParams) {
+    return {};
+  }
+
+  if (feeParams.type === 'legacy') {
+    return { gasPrice: feeParams.gasPrice };
+  }
+
+  return {
+    maxFeePerGas: feeParams.maxFeePerGas,
+    maxPriorityFeePerGas: feeParams.maxPriorityFeePerGas,
+  };
+};
+
+const buildCaliburExecuteRequest = (input: {
+  calls: Tx[];
+  deadline: bigint;
+  ephemeralAddress: Hex;
+  nonce: bigint;
+  signature: Hex;
+  value: bigint;
+}) => {
+  const args = [
+    {
+      batchedCall: {
+        calls: input.calls,
+        revertOnFailure: true,
+      },
+      deadline: input.deadline,
+      executor: toHex(ZERO_BYTES_20),
+      keyHash: toHex(ZERO_BYTES_32),
+      nonce: input.nonce,
+    },
+    packSignatureAndHookData(input.signature),
+  ] as const;
+
+  return {
+    abi: CaliburABI,
+    address: input.ephemeralAddress,
+    args,
+    functionName: 'execute' as const,
+    value: input.value,
+  };
+};
+
+const estimateCaliburExecuteFee = async (input: {
+  actualAddress: Hex;
+  chain: Chain;
+  publicClient: PublicClient;
+  request: ReturnType<typeof buildCaliburExecuteRequest>;
+}) => {
+  const tx = {
+    to: input.request.address,
+    data: encodeFunctionData({
+      abi: input.request.abi,
+      functionName: input.request.functionName,
+      args: input.request.args,
+    }),
+    value: input.request.value,
+  };
+
+  const gasEstimatePromise = input.publicClient
+    .estimateGas({
+      account: input.actualAddress,
+      to: tx.to,
+      data: tx.data,
+      value: tx.value,
+    })
+    .catch(() => 1_500_000n);
+  const feeContextPromise = estimateFeeContext(
+    input.publicClient,
+    input.chain.id,
+    [{ tx }],
+    'medium'
+  );
+
+  const [gasEstimate, feeContext] = await Promise.all([gasEstimatePromise, feeContextPromise]);
+  const [feeEstimate] = finalizeFeeEstimates([{ tx, gasEstimate }], feeContext);
+
+  return {
+    gas: feeEstimate.recommended.gasLimit,
+    feeParams: feeEstimate.recommended.useLegacyPricing
+      ? ({
+          type: 'legacy',
+          gasPrice: feeEstimate.recommended.maxFeePerGas,
+        } satisfies ExecuteFeeParams)
+      : ({
+          type: 'eip1559',
+          maxFeePerGas: feeEstimate.recommended.maxFeePerGas,
+          maxPriorityFeePerGas: feeEstimate.recommended.maxPriorityFeePerGas,
+        } satisfies ExecuteFeeParams),
+  };
+};
 
 export const createBatchedCallSignature = (
   batchedCalls: Tx[],
@@ -168,6 +266,7 @@ export const caliburExecute = async ({
   chain,
   ephemeralAddress,
   ephemeralWallet,
+  publicClient,
   value,
 }: {
   actualAddress: Hex;
@@ -176,6 +275,7 @@ export const caliburExecute = async ({
   chain: Chain;
   ephemeralAddress: Hex;
   ephemeralWallet: PrivateKeyAccount;
+  publicClient: PublicClient;
   value: bigint;
 }) => {
   const nonce = bytesToBigInt(await PlatformUtils.cryptoGetRandomValues(new Uint8Array(24))) << 64n;
@@ -189,26 +289,27 @@ export const caliburExecute = async ({
     deadline
   );
 
-  return actualWallet.writeContract({
-    abi: CaliburABI,
-    account: actualAddress,
-    address: ephemeralAddress,
-    args: [
-      {
-        batchedCall: {
-          calls,
-          revertOnFailure: true,
-        },
-        deadline,
-        executor: toHex(ZERO_BYTES_20),
-        keyHash: toHex(ZERO_BYTES_32),
-        nonce,
-      },
-      packSignatureAndHookData(signature),
-    ],
-    chain,
-    functionName: 'execute',
+  const request = buildCaliburExecuteRequest({
+    calls,
+    deadline,
+    ephemeralAddress,
+    nonce,
+    signature,
     value,
+  });
+  const { gas, feeParams } = await estimateCaliburExecuteFee({
+    actualAddress,
+    chain,
+    publicClient,
+    request,
+  });
+
+  return actualWallet.writeContract({
+    ...request,
+    account: actualAddress,
+    chain,
+    gas,
+    ...spreadFeeParams(feeParams),
   });
 };
 

--- a/src/sdk/ca-base/swap/utils.ts
+++ b/src/sdk/ca-base/swap/utils.ts
@@ -50,6 +50,7 @@ import {
   type UserAssetDatum,
   type VSCClient,
 } from '../../../commons';
+import { estimateRepresentativeSwapNativeReserveFee } from '../../../services/swapNativeReserveFee';
 import {
   ERC20PermitABI,
   ERC20PermitEIP712Type,
@@ -552,15 +553,6 @@ export const packERC20Approve = (spender: Hex, amount: bigint) => {
   });
 };
 
-const multiplierByChain = (chainID: number) => {
-  switch (chainID) {
-    case 534352:
-      return 100n;
-    default:
-      return 3n;
-  }
-};
-
 export const getAnkrBalances = async (
   walletAddress: `0x${string}`,
   chainList: ChainListType
@@ -612,15 +604,8 @@ export const fetchTransferFees = async (chains: Chain[]): Promise<Map<number, De
   await Promise.all(
     chains.map(async (chain) => {
       try {
-        const client = createPublicClient({
-          transport: http(chain.rpcUrls.default.http[0]),
-        });
-        const fee = await client.estimateFeesPerGas();
-        const multiplier = multiplierByChain(chain.id);
-        feeByChainID.set(
-          chain.id,
-          divDecimals(fee.maxFeePerGas * 1_500_000n * multiplier, chain.nativeCurrency.decimals)
-        );
+        const fee = await estimateRepresentativeSwapNativeReserveFee({ chain });
+        feeByChainID.set(chain.id, divDecimals(fee, chain.nativeCurrency.decimals));
       } catch (e) {
         logger.error('fetchTransferFees', e, { chainID: chain.id });
       }
@@ -798,16 +783,6 @@ export const ankrBalanceToAssets = (
     const removeSource = !!removeSources.find(
       (rs) => rs.chainId === asset.chainID && equalFold(rs.tokenAddress, asset.tokenAddress)
     );
-
-    logger.debug('ankrBalanaceToAssets', {
-      isAllowed,
-      isSupportedToken,
-      allowedSources,
-      token: asset.tokenData.symbol,
-      chainId: asset.chainID,
-      tokenAddress: asset.tokenAddress,
-      removeSource,
-    });
 
     if ((filterWithSupportedTokens && !isSupportedToken) || !isAllowed) {
       continue;

--- a/src/sdk/ca-base/utils/balance.utils.ts
+++ b/src/sdk/ca-base/utils/balance.utils.ts
@@ -60,38 +60,7 @@ const mapMulticallResultToBalance = (input: {
   error: input.error,
 });
 
-const multiplierByChain = (chainID: number) => {
-  switch (chainID) {
-    case 534352:
-      return 100n;
-    default:
-      return 3n;
-  }
-};
-
-const applyNativeTransferFeeBuffer = (input: {
-  chain: Chain;
-  nativeBalance: bigint;
-  maxFeePerGas: bigint;
-}): bigint => {
-  const transferFee = divDecimals(
-    input.maxFeePerGas * 1_500_000n * multiplierByChain(input.chain.id),
-    input.chain.nativeCurrency.decimals
-  );
-  const transferFeeRaw = BigInt(
-    transferFee
-      .mul(Decimal.pow(10, input.chain.nativeCurrency.decimals))
-      .toDecimalPlaces(0)
-      .toString()
-  );
-  return input.nativeBalance > transferFeeRaw ? input.nativeBalance - transferFeeRaw : 0n;
-};
-
-export const getBalance = async (
-  chain: Chain,
-  address: Hex,
-  opts: { removeTransferFee?: boolean } = {}
-): Promise<AnkrBalance[]> => {
+export const getBalance = async (chain: Chain, address: Hex): Promise<AnkrBalance[]> => {
   if (!isAddress(address)) {
     throw Errors.invalidInput(`invalid evm address: ${address}`);
   }
@@ -125,26 +94,13 @@ export const getBalance = async (
     contracts: contracts as Parameters<typeof publicClient.multicall>[0]['contracts'],
     multicallAddress: multicall3Address,
   });
-  const feePromise = opts.removeTransferFee
-    ? publicClient
-        .estimateFeesPerGas()
-        .then((f) => f.maxFeePerGas)
-        .catch(() => null)
-    : Promise.resolve(null);
-  const [rawResponses, maxFeePerGas] = await Promise.all([multicallPromise, feePromise]);
+  const rawResponses = await multicallPromise;
   const responses = rawResponses as Array<
     { status: 'success'; result: bigint } | { status: 'failure'; error: Error }
   >;
 
   const nativeResult = responses[0];
-  let nativeBalance = nativeResult.status === 'success' ? nativeResult.result : 0n;
-  if (opts.removeTransferFee && nativeResult.status === 'success' && maxFeePerGas !== null) {
-    nativeBalance = applyNativeTransferFeeBuffer({
-      chain,
-      nativeBalance,
-      maxFeePerGas,
-    });
-  }
+  const nativeBalance = nativeResult.status === 'success' ? nativeResult.result : 0n;
   const balances: AnkrBalance[] = [
     mapMulticallResultToBalance({
       balance: divDecimals(nativeBalance, chain.nativeCurrency.decimals).toFixed(),
@@ -192,9 +148,7 @@ export const getBalances = async (chains: Chain[], address: Hex): Promise<AnkrBa
     throw Errors.invalidInput(`invalid evm address: ${address}`);
   }
 
-  const chainBalances = await Promise.all(
-    chains.map((chain) => getBalance(chain, address, { removeTransferFee: true }))
-  );
+  const chainBalances = await Promise.all(chains.map((chain) => getBalance(chain, address)));
   return chainBalances.flat();
 };
 
@@ -238,12 +192,6 @@ const deductTransferFees = (
           Decimal.ROUND_FLOOR
         )
       : '0';
-    logger.debug('deductTransferFees', {
-      chainID: balance.chainID,
-      oldBalance: balance.balance,
-      newBalance: adjusted,
-      transferFee: transferFee.toFixed(),
-    });
     return { ...balance, balance: adjusted };
   });
 
@@ -276,10 +224,16 @@ export const getBalancesForSwap = async (input: {
     oraclePrices
   );
 
+  const tfbc: string[] = [];
+  transferFeesByChain.forEach((v, k) => {
+    tfbc.push(`${k}: ${v.toFixed()}`);
+  });
+
   logger.debug('getBalancesForSwap', {
     ankrBalances,
     multicallBalances: multicallBalancesWithOracleUSD,
     oraclePrices,
+    transferFeesByChain: tfbc,
   });
   const mergedBalances = deductTransferFees(
     [...ankrBalances, ...multicallBalancesWithOracleUSD],

--- a/src/sdk/ca-base/utils/common.utils.ts
+++ b/src/sdk/ca-base/utils/common.utils.ts
@@ -44,20 +44,15 @@ import {
   type Intent,
   type OraclePriceResponse,
   type ReadableIntent,
-  SUPPORTED_CHAINS,
   type SupportedChainsAndTokensResult,
   type TokenInfo,
   type UserAssetDatum,
 } from '../../../commons';
+import { estimateRepresentativeDepositTxFee } from '../../../services/depositFeeEstimation';
 import { ChainList } from '../chains';
 import { getLogoFromSymbol, isNativeAddress, ZERO_ADDRESS } from '../constants';
 import { Errors } from '../errors';
-import {
-  createPublicClientWithFallback,
-  L1_GAS_ORACLES,
-  requestTimeout,
-  waitForIntentFulfilment,
-} from './contract.utils';
+import { requestTimeout, waitForIntentFulfilment } from './contract.utils';
 import { cosmosCreateDoubleCheckTx, cosmosFillCheck, cosmosRefundIntent } from './cosmos.utils';
 import { PlatformUtils } from './platform.utils';
 
@@ -522,105 +517,9 @@ const createDepositDoubleCheckTx = (chainID: Uint8Array, cosmos: CosmosOptions, 
   };
 };
 
-const ESTIMATED_DEPOSIT_GAS = 300_000n;
-// Estimated deposit tx calldata: ~750 bytes, 16 gas per non-zero byte
-const ESTIMATED_DEPOSIT_CALLDATA_BYTES = 750n;
-const L1_GAS_PER_BYTE = 16n;
-const ESTIMATED_DEPOSIT_CALLDATA_GAS = ESTIMATED_DEPOSIT_CALLDATA_BYTES * L1_GAS_PER_BYTE;
-
-// ArbGasInfo precompile address for L1 fee estimation
-const ARBITRUM_GAS_INFO_ADDRESS = '0x000000000000000000000000000000000000006C' as const;
-
-const estimateL1FeeForDeposit = async (
-  publicClient: PublicClient,
-  chainId: number
-): Promise<bigint> => {
-  const oracleAddress = L1_GAS_ORACLES[chainId];
-  if (!oracleAddress) {
-    return 0n;
-  }
-
-  try {
-    if (chainId === SUPPORTED_CHAINS.ARBITRUM) {
-      // Use ArbGasInfo.getPricesInWei to get perL1CalldataUnit (price per byte)
-      const prices = await publicClient.readContract({
-        abi: [
-          {
-            name: 'getPricesInWei',
-            type: 'function',
-            inputs: [],
-            outputs: [
-              { name: 'perL2Tx', type: 'uint256' },
-              { name: 'perL1CalldataUnit', type: 'uint256' },
-              { name: 'perStorageCell', type: 'uint256' },
-              { name: 'perArbGasBase', type: 'uint256' },
-              { name: 'perArbGasCongestion', type: 'uint256' },
-              { name: 'perArbGasTotal', type: 'uint256' },
-            ],
-            stateMutability: 'view',
-          },
-        ] as const,
-        address: ARBITRUM_GAS_INFO_ADDRESS,
-        functionName: 'getPricesInWei',
-      });
-      const perL1CalldataUnit = prices[1];
-      // L1 fee = price per byte * calldata bytes, with 1.5x buffer
-      return (perL1CalldataUnit * ESTIMATED_DEPOSIT_CALLDATA_BYTES * 15n) / 10n;
-    } else {
-      // OP Stack chains (Scroll, Base, Optimism)
-      const l1BaseFee = await publicClient.readContract({
-        abi: [
-          {
-            inputs: [],
-            name: 'l1BaseFee',
-            outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-            stateMutability: 'view',
-            type: 'function',
-          },
-        ] as const,
-        address: oracleAddress,
-        functionName: 'l1BaseFee',
-      });
-      // L1 fee with 1.5x buffer for scalar variations
-      return (l1BaseFee * ESTIMATED_DEPOSIT_CALLDATA_GAS * 15n) / 10n;
-    }
-  } catch (e) {
-    logger.debug('Failed to estimate L1 fee, using fallback', { chainId, error: e });
-    return 100_000_000_000_000n; // ~0.0001 ETH fallback
-  }
-};
-
-const estimateGasForDeposit = async (chain: Chain, gas: bigint, feeMultiplier = 120n) => {
-  const publicClient = createPublicClientWithFallback(chain);
-
-  const [gasEstimate, l1Fee] = await Promise.all([
-    publicClient.estimateFeesPerGas(),
-    estimateL1FeeForDeposit(publicClient, chain.id),
-  ]);
-
-  const gasUnitPrice = gasEstimate.maxFeePerGas ?? gasEstimate.gasPrice ?? 0n;
-  if (gasUnitPrice === 0n) {
-    throw Errors.gasPriceError({
-      chainId: chain.id,
-      gasEstimate,
-      l1Fee,
-    });
-  }
-  // Add buffer using feeMultiplier
-  const l2Fee = (gas * gasUnitPrice * feeMultiplier) / 100n;
-  const adjustedL1Fee = (l1Fee * feeMultiplier) / 100n;
-  const totalFee = l2Fee + adjustedL1Fee;
-
-  logger.debug('estimateGasForDeposit', {
-    chain: chain.id,
-    l2Fee,
-    l1Fee,
-    adjustedL1Fee,
-    feeMultiplier,
-    totalFee,
-  });
-
-  return divDecimals(totalFee, chain.nativeCurrency.decimals);
+type DepositDeductionOptions = {
+  destinationChainId?: number;
+  feeMultiplier?: bigint;
 };
 
 const assetListWithDepositDeducted = async (
@@ -632,8 +531,10 @@ const assetListWithDepositDeducted = async (
     decimals: number;
   }[],
   chainList: ChainListType,
-  feeMultiplier: bigint // Percentage multiplier for L1 + L2 fee (100 = 1x, 115 = 1.15x)
+  options: DepositDeductionOptions = {}
 ) => {
+  const { destinationChainId, feeMultiplier = 120n } = options;
+
   const values = balances
     .filter((b) => new Decimal(b.balance).gt(0))
     .sort((a, b) => {
@@ -641,20 +542,33 @@ const assetListWithDepositDeducted = async (
       if (b.chainId === 1) return -1;
       return Decimal.sub(b.balance, a.balance).toNumber();
     });
+  const representativeSourceCount = Math.max(
+    1,
+    values.filter((balance) =>
+      destinationChainId == null ? true : balance.chainId !== destinationChainId
+    ).length
+  );
 
   return Promise.all(
     values.map(async (b) => {
       let balance = new Decimal(b.balance);
-      if (UserAsset.isDeposit(b.contractAddress, b.universe)) {
+      const isDestinationChain = destinationChainId != null && b.chainId === destinationChainId;
+      if (UserAsset.isDeposit(b.contractAddress, b.universe) && !isDestinationChain) {
         const chain = chainList.getChainByID(b.chainId);
         if (!chain) {
           throw Errors.chainNotFound(b.chainId);
         }
 
-        const estimatedGasForDepositValue = await estimateGasForDeposit(
+        const { bufferedTotalFee } = await estimateRepresentativeDepositTxFee({
           chain,
-          ESTIMATED_DEPOSIT_GAS,
-          feeMultiplier
+          vaultAddress: chainList.getVaultContractAddress(chain.id),
+          destinationChainId,
+          feeMultiplier,
+          sourceCount: representativeSourceCount,
+        });
+        const estimatedGasForDepositValue = divDecimals(
+          bufferedTotalFee,
+          chain.nativeCurrency.decimals
         );
 
         logger.debug('estimatedGasForDeposit', {
@@ -715,7 +629,10 @@ class UserAsset {
         universe: b.universe,
       })),
       chainList,
-      120n
+      {
+        destinationChainId: _dstChainId,
+        feeMultiplier: 120n,
+      }
     );
   }
 }
@@ -1006,5 +923,4 @@ export {
   storeIntentHashToStore,
   createRequestTronSignature,
   assetListWithDepositDeducted,
-  ESTIMATED_DEPOSIT_GAS,
 };

--- a/src/sdk/ca-base/utils/rff.utils.ts
+++ b/src/sdk/ca-base/utils/rff.utils.ts
@@ -257,7 +257,10 @@ const calculateMaxBridgeFee = async ({
   const assetsWithDepositRemoved = await assetListWithDepositDeducted(
     assets,
     chainList,
-    120n // 20% buffer on L1 + L2 fee
+    {
+      destinationChainId: dst.chainId,
+      feeMultiplier: 120n,
+    } // 20% explicit fee buffer, plus internal representative deposit buffer
   );
   const borrow = assetsWithDepositRemoved.reduce((accumulator, asset) => {
     if (asset.chainID === dst.chainId) {

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -16,6 +16,8 @@ Only files that are not straightforward get full explanations below. For the sim
   Shared fee estimation engine for chain-aware gas pricing and fee overhead handling. Explained below.
 - `gasFeeHistory.ts`
   Reads fee history from the client and turns it into low/medium/high EIP-1559 recommendations. No extra explanation needed.
+- `swapNativeReserveFee.ts`
+  Builds a representative synthetic `calibur.execute(...)` transaction and prices it with the shared fee engine so swap balance queries can reserve native gas without calling `eth_estimateGas`. Explained below.
 - `walletCapabilities.ts`
   Small helper that checks whether a wallet reports atomic batch support for a set of chain IDs. No extra explanation needed.
 
@@ -23,6 +25,7 @@ Only files that are not straightforward get full explanations below. For the sim
 
 - `feeEstimation.ts`
 - `depositFeeEstimation.ts`
+- `swapNativeReserveFee.ts`
 
 ## `feeEstimation.ts`
 
@@ -250,3 +253,41 @@ The main limitations are intentional:
 - fallback gas may overestimate meaningfully on some chains
 
 That tradeoff is acceptable for usable-balance deduction, where modest overestimation is safer than underestimating the amount of native token that must be reserved.
+
+## `swapNativeReserveFee.ts`
+
+### What this file is for
+
+`swapNativeReserveFee.ts` exists for swap balance queries.
+
+When the SDK prepares balances for swap flows, it wants a usable native balance rather than the full raw native balance. That reserve is needed because source-side native swaps may be executed through `calibur.execute(...)`, and the EOA must still have enough native token left to submit that transaction.
+
+### Why this file exists separately from `feeEstimation.ts`
+
+`feeEstimation.ts` assumes the caller already has a transaction shape.
+
+In the balance-fetch path, the SDK does not have the user's final swap transaction yet, and balance queries are latency-sensitive enough that calling `eth_estimateGas` is not desirable. So this file builds a representative synthetic transaction shape and reuses the shared fee engine only for pricing and L1-overhead handling.
+
+### How it works
+
+This file:
+
+- builds a representative `calibur.execute(...)` transaction
+- uses a fixed gas assumption instead of `eth_estimateGas`
+- calls `estimateFeeContext(...)`
+- finalizes the fee with `finalizeFeeEstimates(...)`
+- applies a synthetic-shape buffer to stay conservative
+
+That gives the balance path:
+
+- chain-aware gas-price recommendations
+- OP/Scroll L1 fee handling
+- Arbitrum L1 posting cost handling
+
+without paying the cost of a real gas estimation during every balance fetch.
+
+### What it intentionally does not do
+
+This file does not try to predict the exact final swap transaction.
+
+It only produces a conservative native reserve estimate for balance deduction. The final submitted swap transaction can still differ in calldata shape, approvals, or sweep behavior.

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -1,0 +1,252 @@
+# Services Explainer
+
+This document exists to make `src/services` easier to reason about for both human developers and LLMs.
+
+The goal is not to restate every line of code. The goal is to explain the intent, boundaries, and non-obvious behavior of the service layer, especially where chain-specific fee logic or synthetic estimation is involved.
+
+Only files that are not straightforward get full explanations below. For the simpler files, this document records what they do and intentionally stops there.
+
+## Service Files
+
+- `depositFeeEstimation.ts`
+  Uses a representative synthetic deposit transaction to estimate source-chain native fee requirements for deposit-like flows. Explained below.
+- `executeTransactions.ts`
+  Sends approval + execute transactions, prefers `wallet_sendCalls` atomic batching when supported, and falls back to sequential sends when it is not. No extra explanation needed.
+- `feeEstimation.ts`
+  Shared fee estimation engine for chain-aware gas pricing and fee overhead handling. Explained below.
+- `gasFeeHistory.ts`
+  Reads fee history from the client and turns it into low/medium/high EIP-1559 recommendations. No extra explanation needed.
+- `walletCapabilities.ts`
+  Small helper that checks whether a wallet reports atomic batch support for a set of chain IDs. No extra explanation needed.
+
+## Files With Detailed Explanations
+
+- `feeEstimation.ts`
+- `depositFeeEstimation.ts`
+
+## `feeEstimation.ts`
+
+### What this file is for
+
+`feeEstimation.ts` is the shared internal fee engine for any flow that already knows the transaction shape and either already has a gas estimate or can obtain one separately.
+
+Its job is to answer:
+
+- what fee model should be used for this chain
+- what gas-price recommendation should be used for the selected speed tier
+- whether the chain has an extra fee component beyond plain L2 execution gas
+- what gas and fee values should actually be recommended back to the caller
+
+This file is intentionally chain-aware. The SDK cannot treat all EVM chains the same because OP Stack chains, Scroll-style oracles, and Arbitrum do not expose fee overheads in the same way.
+
+### Mental model
+
+The file splits fee work into two stages:
+
+1. `estimateFeeContext(...)`
+   Fetches chain-specific pricing context in parallel.
+   This means:
+   - gas-price recommendations from `gasFeeHistory.ts`
+   - per-transaction chain overheads from the relevant fee strategy
+
+2. `finalizeFeeEstimates(...)`
+   Pure function that combines:
+   - resolved transaction gas estimates
+   - the pricing context from step 1
+   - chain-specific buffer rules
+
+This split exists so callers can do their own `Promise.all(...)` with gas estimation. In practice that means gas estimation does not need to block fee-history or L1-overhead work.
+
+### Supported fee models
+
+The core switch is `CHAIN_FEE_MODEL`.
+
+- `OP_STACK`
+  Uses the canonical L1 fee oracle and stores the result as a direct `l1Fee`.
+- `OP_STACK_SCROLL`
+  Uses Scroll's oracle address but follows the same shape as the OP Stack path: a direct `l1Fee`.
+- `ARBITRUM`
+  Uses `gasEstimateL1Component(...)` from the node interface. This does not come back as a direct ETH-denominated `l1Fee` in the current model. Instead, it returns L1 posting cost as gas units, which this file stores in `extraGas`.
+- `DEFAULT`
+  No special chain overhead handling. Only normal gas pricing applies.
+
+### Why `FeeOverhead` has both `l1Fee` and `extraGas`
+
+This is the most important internal shape in the file.
+
+It exists because not all chains expose their extra fee component the same way.
+
+- On OP Stack style chains, the extra cost is naturally represented as a separate `l1Fee`.
+- On Arbitrum, the extra cost is surfaced as extra gas units through `gasEstimateL1Component(...)`.
+
+That is why `FeeOverhead` looks like this:
+
+- `l1Fee`
+  Extra fee already represented as a fee amount.
+- `extraGas`
+  Extra fee represented as gas units that must be added to the transaction gas before pricing.
+
+This is not just a naming detail. It changes how the final recommendation is built.
+
+### Arbitrum behavior
+
+Arbitrum is the main reason this file exists.
+
+For Arbitrum:
+
+- `extraGas` is populated from `gasEstimateL1Component(...)[0]`
+- `l1Fee` remains `0`
+- final gas for pricing becomes `item.gasEstimate + extraGas`
+
+That means Arbitrum's L1 posting cost is folded into the gas budget before pricing rather than attached as a separate `l1Fee`.
+
+The `gasEstimateKind` field exists mainly to prevent double counting here:
+
+- `raw`
+  Means the provided gas estimate does not yet include Arbitrum's L1 component, so `extraGas` should be added.
+- `final`
+  Means the provided gas estimate is already final enough that Arbitrum's extra gas must not be added again.
+
+If this distinction is wrong, Arbitrum fees will be wrong in one of two bad ways:
+
+- too low because the L1 posting component was missed
+- too high because the L1 component was added twice
+
+### Buffering
+
+The file applies chain-specific buffers through `BUFFER_CONFIGS`.
+
+Those buffers affect:
+
+- gas estimate
+- gas price
+- OP-style `l1Fee`
+
+These are not intended to be precise market predictions. They are conservative operational buffers so the wallet is less likely to underfund a transaction between estimation and actual submission.
+
+### Output shape
+
+The final output is `FeeEstimate`.
+
+Important parts:
+
+- `l1Fee`
+  Unbuffered chain overhead represented directly as fee.
+- `l2Fee`
+  Execution fee using total gas and selected gas price.
+- `total`
+  `l1Fee + l2Fee`
+- `recommended`
+  Wallet-oriented values:
+  - `gasLimit`
+  - `maxFeePerGas`
+  - `maxPriorityFeePerGas`
+  - `totalMaxCost`
+  - `useLegacyPricing`
+
+The caller should usually use `recommended.*` for transaction submission and `total` for user-facing fee math.
+
+### What this file is not for
+
+This file is not responsible for:
+
+- obtaining the actual transaction gas estimate for every caller
+- deciding which transactions belong in a composite flow
+- building representative synthetic transactions for balance heuristics
+- sending the transaction
+
+Those concerns belong elsewhere.
+
+## `depositFeeEstimation.ts`
+
+### What this file is for
+
+`depositFeeEstimation.ts` exists because some parts of the SDK need a conservative estimate of the native fee required for a future deposit transaction before the final deposit transaction has actually been assembled.
+
+The main use case is usable-balance deduction for native assets. In that scenario, the SDK wants to avoid showing the full native balance as spendable when a deposit transaction still needs gas on the source chain.
+
+### Why this file cannot be exact
+
+At the point where this service is used, the SDK usually does not yet know the final deposit payload in full detail.
+
+That means it may be missing things like:
+
+- the final set of sources
+- the exact request payload
+- the final signature bytes
+- final per-chain transaction context
+
+So this file does not try to be exact. It tries to be:
+
+- chain-aware
+- internally consistent with the rest of the fee engine
+- conservative enough to avoid overstating usable native balance
+
+### How it works
+
+The file builds a representative synthetic `deposit(...)` call with:
+
+- a vault address
+- a synthetic recipient
+- synthetic sources and destinations
+- a representative signature blob
+- a small non-zero value
+
+The number of sources is controlled by `sourceCount`, because calldata size and deposit complexity grow with the number of sources.
+
+That representative transaction is then priced in two layers:
+
+1. Estimate gas for the representative deposit call.
+2. Reuse `feeEstimation.ts` to price that gas under the source chain's actual fee model.
+
+This is important. Even though the transaction is synthetic, the pricing path is real:
+
+- OP-style chains still go through `getL1Fee(...)`
+- Arbitrum still goes through `gasEstimateL1Component(...)`
+- default chains still use standard gas pricing
+
+### Why there is an internal fallback gas value
+
+`estimateGas(...)` can fail here. One common reason is that representative or RFF-style deposit estimation may happen when the account does not have enough native balance for the node to simulate the call successfully.
+
+Because this service is used for balance deduction, failing closed is better than failing open.
+
+So if `estimateGas(...)` fails, the service falls back to `DEFAULT_REPRESENTATIVE_DEPOSIT_GAS`.
+
+Right now that value is intentionally conservative.
+
+### Why there are two buffers
+
+This file applies two distinct buffers:
+
+1. `feeMultiplier`
+   External caller-controlled multiplier. This lets higher-level balance logic stay conservative.
+
+2. `syntheticBufferMultiplier`
+   Internal buffer that exists because the representative deposit transaction is intentionally smaller and simpler than many real deposit transactions.
+
+The second buffer is important. Without it, the representative estimate would often look more precise than it really is.
+
+### Expected usage
+
+This service is appropriate when the question is:
+
+- how much native balance should be treated as reserved for a likely deposit transaction
+- what is a conservative source-chain fee estimate for a future deposit
+
+This service is not appropriate when the question is:
+
+- what exact fee will the final assembled deposit transaction cost right now
+
+For exact final transaction pricing, the caller should estimate the real transaction directly and then use `feeEstimation.ts` on that real transaction.
+
+### Limitations
+
+The main limitations are intentional:
+
+- synthetic request, not final request
+- synthetic signature, not final signature
+- `sourceCount` is only a hint
+- fallback gas may overestimate meaningfully on some chains
+
+That tradeoff is acceptable for usable-balance deduction, where modest overestimation is safer than underestimating the amount of native token that must be reserved.

--- a/src/services/depositFeeEstimation.ts
+++ b/src/services/depositFeeEstimation.ts
@@ -1,0 +1,134 @@
+import { EVMVaultABI, Universe } from '@avail-project/ca-common';
+import { encodeFunctionData, type Hex, pad } from 'viem';
+import type { Chain } from '../commons';
+import { ZERO_ADDRESS } from '../sdk/ca-base/constants';
+import { createPublicClientWithFallback } from '../sdk/ca-base/utils/contract.utils';
+import {
+  estimateFeeContext,
+  type FeeEstimate,
+  finalizeFeeEstimates,
+  type PriceTier,
+  type TxRequest,
+} from './feeEstimation';
+
+export const DEFAULT_REPRESENTATIVE_DEPOSIT_GAS = 300_000n;
+
+const DEFAULT_PRICE_TIER: PriceTier = 'medium';
+const DEFAULT_FEE_MULTIPLIER = 100n;
+const DEFAULT_SYNTHETIC_DEPOSIT_BUFFER = 130n;
+const REPRESENTATIVE_ACCOUNT = '0x1111111111111111111111111111111111111111' as const;
+const REPRESENTATIVE_SIGNATURE = `0x${'11'.repeat(65)}` as Hex;
+
+type EstimateRepresentativeDepositTxFeeParams = {
+  chain: Chain;
+  vaultAddress: Hex;
+  destinationChainId?: number;
+  sourceCount?: number;
+  feeMultiplier?: bigint;
+  priceTier?: PriceTier;
+  syntheticBufferMultiplier?: bigint;
+};
+
+type RepresentativeDepositFeeEstimate = {
+  tx: TxRequest;
+  gasEstimate: bigint;
+  feeEstimate: FeeEstimate;
+  rawTotalFee: bigint;
+  bufferedTotalFee: bigint;
+};
+
+const applyMultiplier = (value: bigint, multiplier: bigint) => (value * multiplier) / 100n;
+
+const normalizeSourceCount = (sourceCount?: number) => {
+  if (!sourceCount || sourceCount < 1) {
+    return 1;
+  }
+
+  return Math.floor(sourceCount);
+};
+
+const buildRepresentativeDepositTx = (
+  vaultAddress: Hex,
+  destinationChainId: number,
+  sourceCount: number
+): TxRequest => {
+  const paddedZeroAddress = pad(ZERO_ADDRESS, { size: 32 });
+  const paddedRepresentativeAddress = pad(REPRESENTATIVE_ACCOUNT, { size: 32 });
+
+  const request = {
+    sources: Array.from({ length: sourceCount }, (_, index) => ({
+      universe: Universe.ETHEREUM,
+      chainID: BigInt(index + 1),
+      contractAddress: paddedZeroAddress,
+      value: 1n,
+    })),
+    destinationUniverse: Universe.ETHEREUM,
+    destinationChainID: BigInt(destinationChainId),
+    recipientAddress: paddedRepresentativeAddress,
+    destinations: [
+      {
+        contractAddress: paddedZeroAddress,
+        value: 1n,
+      },
+    ],
+    nonce: 1n,
+    expiry: 1n,
+    parties: [
+      {
+        universe: Universe.ETHEREUM,
+        address_: paddedRepresentativeAddress,
+      },
+    ],
+  };
+
+  return {
+    to: vaultAddress,
+    data: encodeFunctionData({
+      abi: EVMVaultABI,
+      functionName: 'deposit',
+      args: [request, REPRESENTATIVE_SIGNATURE, 0n],
+    }),
+    value: 1n,
+  };
+};
+
+export async function estimateRepresentativeDepositTxFee({
+  chain,
+  vaultAddress,
+  destinationChainId = 1,
+  sourceCount,
+  feeMultiplier = DEFAULT_FEE_MULTIPLIER,
+  priceTier = DEFAULT_PRICE_TIER,
+  syntheticBufferMultiplier = DEFAULT_SYNTHETIC_DEPOSIT_BUFFER,
+}: EstimateRepresentativeDepositTxFeeParams): Promise<RepresentativeDepositFeeEstimate> {
+  const client = createPublicClientWithFallback(chain);
+  const tx = buildRepresentativeDepositTx(
+    vaultAddress,
+    destinationChainId,
+    normalizeSourceCount(sourceCount)
+  );
+
+  const gasEstimatePromise = client
+    .estimateGas({
+      account: REPRESENTATIVE_ACCOUNT,
+      to: tx.to,
+      data: tx.data,
+      value: tx.value,
+    })
+    .catch(() => DEFAULT_REPRESENTATIVE_DEPOSIT_GAS);
+  const [feeContext, gasEstimate] = await Promise.all([
+    estimateFeeContext(client, chain.id, [{ tx }], priceTier),
+    gasEstimatePromise,
+  ]);
+  const [feeEstimate] = finalizeFeeEstimates([{ tx, gasEstimate }], feeContext);
+  const explicitlyBufferedFee = applyMultiplier(feeEstimate.total, feeMultiplier);
+  const bufferedTotalFee = applyMultiplier(explicitlyBufferedFee, syntheticBufferMultiplier);
+
+  return {
+    tx,
+    gasEstimate,
+    feeEstimate,
+    rawTotalFee: feeEstimate.total,
+    bufferedTotalFee,
+  };
+}

--- a/src/services/executeTransactions.ts
+++ b/src/services/executeTransactions.ts
@@ -1,0 +1,187 @@
+import type { Hex, PublicClient, TransactionReceipt, WalletClient } from 'viem';
+import { BRIDGE_STEPS, type Chain, NEXUS_EVENTS, type OnEventParam, type Tx } from '../commons';
+import { Errors } from '../sdk/ca-base/errors';
+import { switchChain, waitForTxReceipt } from '../sdk/ca-base/utils';
+import { getAtomicBatchSupport } from './walletCapabilities';
+
+export type ExecuteFeeParams =
+  | {
+      type: 'legacy';
+      gasPrice: bigint;
+    }
+  | {
+      type: 'eip1559';
+      maxFeePerGas: bigint;
+      maxPriorityFeePerGas: bigint;
+    };
+
+type ExecuteSendResult = {
+  txHash: Hex;
+  receipt: TransactionReceipt | undefined;
+  approvalHash: Hex | undefined;
+};
+
+const spreadFeeParams = (feeParams?: ExecuteFeeParams) => {
+  if (!feeParams) {
+    return {};
+  }
+
+  if (feeParams.type === 'legacy') {
+    return { gasPrice: feeParams.gasPrice };
+  }
+
+  return {
+    maxFeePerGas: feeParams.maxFeePerGas,
+    maxPriorityFeePerGas: feeParams.maxPriorityFeePerGas,
+  };
+};
+
+export const sendExecuteTransactions = async (
+  params: {
+    tx: Tx;
+    approvalTx: Tx | null;
+    feeParams?: ExecuteFeeParams;
+  },
+  options: {
+    emit?: OnEventParam['onEvent'];
+    chain: Chain;
+    dstPublicClient: PublicClient;
+    address: Hex;
+    client: WalletClient;
+    waitForReceipt?: boolean;
+    receiptTimeout?: number;
+    requiredConfirmations?: number;
+  }
+): Promise<ExecuteSendResult> => {
+  const { waitForReceipt = true, receiptTimeout = 300000, requiredConfirmations = 1 } = options;
+  await switchChain(options.client, options.chain);
+
+  let approvalHash: Hex | undefined;
+  if (params.approvalTx) {
+    const atomicBatchSupport = await getAtomicBatchSupport(options.client, options.address, [
+      options.chain.id,
+    ]);
+
+    if (atomicBatchSupport.get(options.chain.id)) {
+      const dispatch = await options.client.sendCalls({
+        account: options.address,
+        chain: options.chain,
+        forceAtomic: true,
+        calls: [
+          {
+            to: params.approvalTx.to,
+            data: params.approvalTx.data,
+            value: params.approvalTx.value,
+          },
+          {
+            to: params.tx.to,
+            data: params.tx.data,
+            value: params.tx.value,
+          },
+        ],
+      });
+
+      if (options.emit) {
+        options.emit({
+          name: NEXUS_EVENTS.STEP_COMPLETE,
+          args: BRIDGE_STEPS.EXECUTE_TRANSACTION_SENT,
+        });
+      }
+
+      const batchResult = await options.client.waitForCallsStatus({
+        id: dispatch.id,
+        timeout: receiptTimeout,
+      });
+      const receipts = batchResult.receipts ?? [];
+      approvalHash = receipts[0]?.transactionHash as Hex | undefined;
+      const txHash =
+        (receipts[receipts.length - 1]?.transactionHash as Hex | undefined) ?? approvalHash;
+
+      if (batchResult.status !== 'success' || !txHash) {
+        throw Errors.internal('Atomic execute batch failed');
+      }
+
+      if (options.emit && approvalHash) {
+        options.emit({
+          name: NEXUS_EVENTS.STEP_COMPLETE,
+          args: BRIDGE_STEPS.EXECUTE_APPROVAL_STEP,
+        });
+      }
+
+      let receipt: TransactionReceipt | undefined;
+      if (waitForReceipt) {
+        receipt = await waitForTxReceipt(
+          txHash,
+          options.dstPublicClient,
+          requiredConfirmations,
+          receiptTimeout
+        );
+
+        if (options.emit) {
+          options.emit({
+            name: NEXUS_EVENTS.STEP_COMPLETE,
+            args: BRIDGE_STEPS.EXECUTE_TRANSACTION_CONFIRMED,
+          });
+        }
+      }
+
+      return {
+        txHash,
+        receipt,
+        approvalHash,
+      };
+    }
+
+    approvalHash = await options.client.sendTransaction({
+      ...params.approvalTx,
+      account: options.address,
+      chain: options.chain,
+      ...spreadFeeParams(params.feeParams),
+    });
+
+    await waitForTxReceipt(approvalHash, options.dstPublicClient, 1);
+    if (options.emit) {
+      options.emit({
+        name: NEXUS_EVENTS.STEP_COMPLETE,
+        args: BRIDGE_STEPS.EXECUTE_APPROVAL_STEP,
+      });
+    }
+  }
+
+  const txHash = await options.client.sendTransaction({
+    ...params.tx,
+    account: options.address,
+    chain: options.chain,
+    ...spreadFeeParams(params.feeParams),
+  });
+
+  if (options.emit) {
+    options.emit({
+      name: NEXUS_EVENTS.STEP_COMPLETE,
+      args: BRIDGE_STEPS.EXECUTE_TRANSACTION_SENT,
+    });
+  }
+
+  let receipt: TransactionReceipt | undefined;
+  if (waitForReceipt) {
+    receipt = await waitForTxReceipt(
+      txHash,
+      options.dstPublicClient,
+      requiredConfirmations,
+      receiptTimeout
+    );
+
+    if (options.emit) {
+      options.emit({
+        name: NEXUS_EVENTS.STEP_COMPLETE,
+        args: BRIDGE_STEPS.EXECUTE_TRANSACTION_CONFIRMED,
+      });
+    }
+  }
+
+  return {
+    txHash,
+    receipt,
+    approvalHash,
+  };
+};

--- a/src/services/feeEstimation.ts
+++ b/src/services/feeEstimation.ts
@@ -94,20 +94,30 @@ type RawFeeResult = {
 
 type GasEstimateL1ComponentResult = readonly [bigint, bigint, bigint];
 
+export type FeeOverhead = {
+  l1Fee: bigint;
+  extraGas: bigint;
+};
+
+export type FeeContextItem = Pick<TxWithGas, 'tx' | 'gasEstimateKind'>;
+
+export type FeeContext = {
+  chainId: number;
+  recommendation: Eip1559FeeRecommendation;
+  overheads: FeeOverhead[];
+};
+
 type FeeStrategy = (
   client: PublicClient,
-  items: TxWithGas[],
-  gasPrice: bigint,
+  items: FeeContextItem[],
   chainId: number
-) => Promise<RawFeeResult[]>;
+) => Promise<FeeOverhead[]>;
 
-async function getClientChainId(client: PublicClient): Promise<number> {
-  if (client.chain?.id) {
-    return client.chain.id;
-  }
-
-  return client.getChainId();
-}
+type FeeModelConfig = {
+  buffers: BufferConfig;
+  useLegacyPricing: boolean;
+  strategy: FeeStrategy;
+};
 
 function serializeTxForOracle(chainId: number, tx: TxRequest): `0x${string}` {
   return serializeTransaction({
@@ -154,7 +164,7 @@ function buildFeeEstimate(
 function buildOpStackStrategy(model: FeeModel.OP_STACK | FeeModel.OP_STACK_SCROLL): FeeStrategy {
   const oracle = L1_FEE_ORACLE[model];
 
-  return async (client, items, gasPrice, chainId) => {
+  return async (client, items, chainId) => {
     const l1Fees = await Promise.all(
       items.map((item) => {
         const serialized = serializeTxForOracle(chainId, item.tx);
@@ -167,16 +177,14 @@ function buildOpStackStrategy(model: FeeModel.OP_STACK | FeeModel.OP_STACK_SCROL
       })
     );
 
-    return items.map((item, i) => ({
+    return items.map((_, i) => ({
       l1Fee: l1Fees[i],
-      l2Fee: item.gasEstimate * gasPrice,
-      gasPrice,
-      gasEstimate: item.gasEstimate,
+      extraGas: 0n,
     }));
   };
 }
 
-const arbitrumStrategy: FeeStrategy = async (client, items, gasPrice) => {
+const arbitrumStrategy: FeeStrategy = async (client, items) => {
   const l1Results = await Promise.all(
     items.map((item) => {
       if (item.gasEstimateKind === 'final') {
@@ -192,56 +200,102 @@ const arbitrumStrategy: FeeStrategy = async (client, items, gasPrice) => {
     })
   );
 
-  return items.map((item, i) => {
+  return items.map((_, i) => {
     const l1GasUnits = l1Results[i]?.[0] ?? 0n;
-    const totalGas = item.gasEstimate + l1GasUnits;
 
     return {
       l1Fee: 0n,
-      l2Fee: totalGas * gasPrice,
-      gasPrice,
-      gasEstimate: totalGas,
+      extraGas: l1GasUnits,
     };
   });
 };
 
-const defaultStrategy: FeeStrategy = async (_client, items, gasPrice) =>
-  items.map((item) => ({
+const defaultStrategy: FeeStrategy = async (_client, items) =>
+  items.map(() => ({
     l1Fee: 0n,
-    l2Fee: item.gasEstimate * gasPrice,
-    gasPrice,
-    gasEstimate: item.gasEstimate,
+    extraGas: 0n,
   }));
 
-const strategies: Record<FeeModel, FeeStrategy> = {
-  [FeeModel.OP_STACK]: buildOpStackStrategy(FeeModel.OP_STACK),
-  [FeeModel.OP_STACK_SCROLL]: buildOpStackStrategy(FeeModel.OP_STACK_SCROLL),
-  [FeeModel.ARBITRUM]: arbitrumStrategy,
-  [FeeModel.DEFAULT]: defaultStrategy,
+const FEE_MODEL_CONFIGS: Record<FeeModel, FeeModelConfig> = {
+  [FeeModel.OP_STACK]: {
+    buffers: BUFFER_CONFIGS[FeeModel.OP_STACK],
+    useLegacyPricing: false,
+    strategy: buildOpStackStrategy(FeeModel.OP_STACK),
+  },
+  [FeeModel.OP_STACK_SCROLL]: {
+    buffers: BUFFER_CONFIGS[FeeModel.OP_STACK_SCROLL],
+    useLegacyPricing: false,
+    strategy: buildOpStackStrategy(FeeModel.OP_STACK_SCROLL),
+  },
+  [FeeModel.ARBITRUM]: {
+    buffers: BUFFER_CONFIGS[FeeModel.ARBITRUM],
+    useLegacyPricing: true,
+    strategy: arbitrumStrategy,
+  },
+  [FeeModel.DEFAULT]: {
+    buffers: BUFFER_CONFIGS[FeeModel.DEFAULT],
+    useLegacyPricing: false,
+    strategy: defaultStrategy,
+  },
 };
 
-const LEGACY_PRICING_MODELS = new Set<FeeModel>([FeeModel.ARBITRUM]);
+function getFeeModel(chainId: number): FeeModel {
+  return CHAIN_FEE_MODEL[chainId] ?? FeeModel.DEFAULT;
+}
+
+export async function estimateFeeContext(
+  client: PublicClient,
+  chainId: number,
+  items: FeeContextItem[],
+  priceTier: PriceTier
+): Promise<FeeContext> {
+  const feeModel = getFeeModel(chainId);
+  const [gasPriceRecommendations, overheads] = await Promise.all([
+    getGasPriceRecommendations(client, chainId),
+    FEE_MODEL_CONFIGS[feeModel].strategy(client, items, chainId),
+  ]);
+
+  return {
+    chainId,
+    recommendation: gasPriceRecommendations[priceTier],
+    overheads,
+  };
+}
+
+export function finalizeFeeEstimates(items: TxWithGas[], context: FeeContext): FeeEstimate[] {
+  if (items.length !== context.overheads.length) {
+    throw new Error('finalizeFeeEstimates requires overheads for every transaction');
+  }
+
+  const { buffers, useLegacyPricing } = FEE_MODEL_CONFIGS[getFeeModel(context.chainId)];
+
+  return items.map((item, index) => {
+    const overhead = context.overheads[index];
+    const totalGas = item.gasEstimate + overhead.extraGas;
+
+    return buildFeeEstimate(
+      {
+        l1Fee: overhead.l1Fee,
+        l2Fee: totalGas * context.recommendation.maxFeePerGas,
+        gasPrice: context.recommendation.maxFeePerGas,
+        gasEstimate: totalGas,
+      },
+      buffers,
+      useLegacyPricing,
+      context.recommendation.maxPriorityFeePerGas
+    );
+  });
+}
 
 export async function estimateTotalFees(
   client: PublicClient,
   items: TxWithGas[],
-  priceTier: PriceTier = 'medium',
-  bufferOverrides?: Partial<BufferConfig>
+  chainId: number,
+  priceTier: PriceTier
 ): Promise<FeeEstimate[]> {
   if (items.length === 0) {
     return [];
   }
-
-  const chainId = await getClientChainId(client);
-  const model = CHAIN_FEE_MODEL[chainId] ?? FeeModel.DEFAULT;
-  const buffers = { ...BUFFER_CONFIGS[model], ...bufferOverrides };
-  const useLegacyPricing = LEGACY_PRICING_MODELS.has(model);
-
-  const recommendations = await getGasPriceRecommendations(client);
-  const selected: Eip1559FeeRecommendation = recommendations[priceTier];
-  const rawResults = await strategies[model](client, items, selected.maxFeePerGas, chainId);
-
-  return rawResults.map((raw) =>
-    buildFeeEstimate(raw, buffers, useLegacyPricing, selected.maxPriorityFeePerGas)
-  );
+  const context = await estimateFeeContext(client, chainId, items, priceTier);
+  return finalizeFeeEstimates(items, context);
 }

--- a/src/services/feeEstimation.ts
+++ b/src/services/feeEstimation.ts
@@ -1,4 +1,4 @@
-import { type PublicClient, serializeTransaction } from 'viem';
+import { type Hex, hexToBigInt, type PublicClient, serializeTransaction, toHex } from 'viem';
 import { SUPPORTED_CHAINS } from '../commons/constants';
 import { ARBITRUM_GAS_ORACLE_ABI } from '../sdk/ca-base/abi/gasOracle';
 import { type Eip1559FeeRecommendation, getGasPriceRecommendations } from './gasFeeHistory';
@@ -7,7 +7,8 @@ enum FeeModel {
   OP_STACK = 0,
   OP_STACK_SCROLL = 1,
   ARBITRUM = 2,
-  DEFAULT = 3,
+  CITREA = 3,
+  DEFAULT = 4,
 }
 
 const CHAIN_FEE_MODEL: Partial<Record<number, FeeModel>> = {
@@ -18,6 +19,8 @@ const CHAIN_FEE_MODEL: Partial<Record<number, FeeModel>> = {
   [SUPPORTED_CHAINS.SCROLL]: FeeModel.OP_STACK_SCROLL,
   [SUPPORTED_CHAINS.ARBITRUM]: FeeModel.ARBITRUM,
   [SUPPORTED_CHAINS.ARBITRUM_SEPOLIA]: FeeModel.ARBITRUM,
+  [SUPPORTED_CHAINS.CITREA]: FeeModel.CITREA,
+  [SUPPORTED_CHAINS.CITREA_TESTNET]: FeeModel.CITREA,
 };
 
 const L1_FEE_ORACLE = {
@@ -47,6 +50,7 @@ const BUFFER_CONFIGS: Record<FeeModel, BufferConfig> = {
   [FeeModel.OP_STACK]: { gasEstimate: 1.2, gasPrice: 1.1, l1Fee: 1.3 },
   [FeeModel.OP_STACK_SCROLL]: { gasEstimate: 1.2, gasPrice: 1.1, l1Fee: 1.3 },
   [FeeModel.ARBITRUM]: { gasEstimate: 1.2, gasPrice: 1.4, l1Fee: 1.0 },
+  [FeeModel.CITREA]: { gasEstimate: 1.2, gasPrice: 1.2, l1Fee: 1.2 },
   [FeeModel.DEFAULT]: { gasEstimate: 1.2, gasPrice: 1.2, l1Fee: 1.0 },
 };
 
@@ -86,13 +90,22 @@ type RawFeeResult = {
 };
 
 type GasEstimateL1ComponentResult = readonly [bigint, bigint, bigint];
+type CitreaEstimateDiffSizeResult = {
+  gas: Hex;
+  l1DiffSize: Hex;
+};
+type CitreaBlockResult = {
+  l1FeeRate?: Hex | null;
+};
 
 export type FeeOverhead = {
   l1Fee: bigint;
   extraGas: bigint;
 };
 
-export type FeeContextItem = Pick<TxWithGas, 'tx' | 'gasEstimateKind'>;
+export type FeeContextItem = Pick<TxWithGas, 'tx' | 'gasEstimateKind'> & {
+  l1DiffSizeHint?: bigint;
+};
 
 export type FeeContext = {
   chainId: number;
@@ -123,6 +136,36 @@ function serializeTxForOracle(chainId: number, tx: TxRequest): `0x${string}` {
     maxPriorityFeePerGas: 1n,
     gas: 1n,
   });
+}
+
+function toRpcTransactionRequest(tx: TxRequest) {
+  return {
+    to: tx.to,
+    data: tx.data,
+    value: toHex(tx.value ?? 0n),
+  };
+}
+
+async function requestCustomRpcMethod<T>(
+  client: PublicClient,
+  args: { method: string; params?: unknown[] }
+): Promise<T> {
+  return (
+    client.request as unknown as (request: { method: string; params?: unknown[] }) => Promise<T>
+  )(args);
+}
+
+async function getCitreaL1FeeRate(client: PublicClient): Promise<bigint> {
+  const block = await requestCustomRpcMethod<CitreaBlockResult | null>(client, {
+    method: 'eth_getBlockByNumber',
+    params: ['latest', false],
+  });
+
+  if (!block?.l1FeeRate) {
+    throw new Error('Citrea block response missing l1FeeRate');
+  }
+
+  return hexToBigInt(block.l1FeeRate);
 }
 
 function applyBuffer(value: bigint, multiplier: number): bigint {
@@ -203,6 +246,29 @@ const arbitrumStrategy: FeeStrategy = async (client, items) => {
   });
 };
 
+const citreaStrategy: FeeStrategy = async (client, items) => {
+  const [l1FeeRate, l1DiffSizes] = await Promise.all([
+    getCitreaL1FeeRate(client),
+    Promise.all(
+      items.map((item) => {
+        if (item.l1DiffSizeHint !== undefined) {
+          return Promise.resolve(item.l1DiffSizeHint);
+        }
+
+        return requestCustomRpcMethod<CitreaEstimateDiffSizeResult>(client, {
+          method: 'eth_estimateDiffSize',
+          params: [toRpcTransactionRequest(item.tx)],
+        }).then((result) => hexToBigInt(result.l1DiffSize));
+      })
+    ),
+  ]);
+
+  return l1DiffSizes.map((l1DiffSize) => ({
+    l1Fee: l1FeeRate * l1DiffSize,
+    extraGas: 0n,
+  }));
+};
+
 const defaultStrategy: FeeStrategy = async (_client, items) =>
   items.map(() => ({
     l1Fee: 0n,
@@ -224,6 +290,11 @@ const FEE_MODEL_CONFIGS: Record<FeeModel, FeeModelConfig> = {
     buffers: BUFFER_CONFIGS[FeeModel.ARBITRUM],
     useLegacyPricing: true,
     strategy: arbitrumStrategy,
+  },
+  [FeeModel.CITREA]: {
+    buffers: BUFFER_CONFIGS[FeeModel.CITREA],
+    useLegacyPricing: false,
+    strategy: citreaStrategy,
   },
   [FeeModel.DEFAULT]: {
     buffers: BUFFER_CONFIGS[FeeModel.DEFAULT],

--- a/src/services/feeEstimation.ts
+++ b/src/services/feeEstimation.ts
@@ -1,4 +1,5 @@
 import { type PublicClient, serializeTransaction } from 'viem';
+import { SUPPORTED_CHAINS } from '../commons/constants';
 import { ARBITRUM_GAS_ORACLE_ABI } from '../sdk/ca-base/abi/gasOracle';
 import { type Eip1559FeeRecommendation, getGasPriceRecommendations } from './gasFeeHistory';
 
@@ -9,22 +10,14 @@ enum FeeModel {
   DEFAULT = 3,
 }
 
-const CHAIN_FEE_MODEL: Record<number, FeeModel> = {
-  10: FeeModel.OP_STACK,
-  254: FeeModel.OP_STACK,
-  480: FeeModel.OP_STACK,
-  1135: FeeModel.OP_STACK,
-  7560: FeeModel.OP_STACK,
-  8453: FeeModel.OP_STACK,
-  84532: FeeModel.OP_STACK,
-  34443: FeeModel.OP_STACK,
-  7777777: FeeModel.OP_STACK,
-  11155420: FeeModel.OP_STACK,
-  534351: FeeModel.OP_STACK_SCROLL,
-  534352: FeeModel.OP_STACK_SCROLL,
-  42161: FeeModel.ARBITRUM,
-  42170: FeeModel.ARBITRUM,
-  421614: FeeModel.ARBITRUM,
+const CHAIN_FEE_MODEL: Partial<Record<number, FeeModel>> = {
+  [SUPPORTED_CHAINS.OPTIMISM]: FeeModel.OP_STACK,
+  [SUPPORTED_CHAINS.BASE]: FeeModel.OP_STACK,
+  [SUPPORTED_CHAINS.BASE_SEPOLIA]: FeeModel.OP_STACK,
+  [SUPPORTED_CHAINS.OPTIMISM_SEPOLIA]: FeeModel.OP_STACK,
+  [SUPPORTED_CHAINS.SCROLL]: FeeModel.OP_STACK_SCROLL,
+  [SUPPORTED_CHAINS.ARBITRUM]: FeeModel.ARBITRUM,
+  [SUPPORTED_CHAINS.ARBITRUM_SEPOLIA]: FeeModel.ARBITRUM,
 };
 
 const L1_FEE_ORACLE = {

--- a/src/services/feeEstimation.ts
+++ b/src/services/feeEstimation.ts
@@ -1,0 +1,247 @@
+import { type PublicClient, serializeTransaction } from 'viem';
+import { ARBITRUM_GAS_ORACLE_ABI } from '../sdk/ca-base/abi/gasOracle';
+import { type Eip1559FeeRecommendation, getGasPriceRecommendations } from './gasFeeHistory';
+
+enum FeeModel {
+  OP_STACK = 0,
+  OP_STACK_SCROLL = 1,
+  ARBITRUM = 2,
+  DEFAULT = 3,
+}
+
+const CHAIN_FEE_MODEL: Record<number, FeeModel> = {
+  10: FeeModel.OP_STACK,
+  254: FeeModel.OP_STACK,
+  480: FeeModel.OP_STACK,
+  1135: FeeModel.OP_STACK,
+  7560: FeeModel.OP_STACK,
+  8453: FeeModel.OP_STACK,
+  84532: FeeModel.OP_STACK,
+  34443: FeeModel.OP_STACK,
+  7777777: FeeModel.OP_STACK,
+  11155420: FeeModel.OP_STACK,
+  534351: FeeModel.OP_STACK_SCROLL,
+  534352: FeeModel.OP_STACK_SCROLL,
+  42161: FeeModel.ARBITRUM,
+  42170: FeeModel.ARBITRUM,
+  421614: FeeModel.ARBITRUM,
+};
+
+const L1_FEE_ORACLE = {
+  [FeeModel.OP_STACK]: '0x420000000000000000000000000000000000000F',
+  [FeeModel.OP_STACK_SCROLL]: '0x5300000000000000000000000000000000000002',
+} as const satisfies Partial<Record<FeeModel, `0x${string}`>>;
+
+const ARBITRUM_NODE_INTERFACE = '0x00000000000000000000000000000000000000C8';
+
+const GET_L1_FEE_ABI = [
+  {
+    name: 'getL1Fee',
+    type: 'function',
+    inputs: [{ name: 'data', type: 'bytes' }],
+    outputs: [{ name: 'fee', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+] as const;
+
+type BufferConfig = {
+  gasEstimate: number;
+  gasPrice: number;
+  l1Fee: number;
+};
+
+const BUFFER_CONFIGS: Record<FeeModel, BufferConfig> = {
+  [FeeModel.OP_STACK]: { gasEstimate: 1.2, gasPrice: 1.1, l1Fee: 1.3 },
+  [FeeModel.OP_STACK_SCROLL]: { gasEstimate: 1.2, gasPrice: 1.1, l1Fee: 1.3 },
+  [FeeModel.ARBITRUM]: { gasEstimate: 1.2, gasPrice: 1.4, l1Fee: 1.0 },
+  [FeeModel.DEFAULT]: { gasEstimate: 1.2, gasPrice: 1.2, l1Fee: 1.0 },
+};
+
+export type PriceTier = 'low' | 'medium' | 'high';
+export type GasEstimateKind = 'raw' | 'final';
+
+export type TxRequest = {
+  to: `0x${string}`;
+  data: `0x${string}`;
+  value?: bigint;
+};
+
+export type TxWithGas = {
+  tx: TxRequest;
+  gasEstimate: bigint;
+  gasEstimateKind?: GasEstimateKind;
+};
+
+export type FeeEstimate = {
+  l1Fee: bigint;
+  l2Fee: bigint;
+  total: bigint;
+  recommended: {
+    gasLimit: bigint;
+    maxFeePerGas: bigint;
+    maxPriorityFeePerGas: bigint;
+    totalMaxCost: bigint;
+    useLegacyPricing: boolean;
+  };
+};
+
+type RawFeeResult = {
+  l1Fee: bigint;
+  l2Fee: bigint;
+  gasPrice: bigint;
+  gasEstimate: bigint;
+};
+
+type GasEstimateL1ComponentResult = readonly [bigint, bigint, bigint];
+
+type FeeStrategy = (
+  client: PublicClient,
+  items: TxWithGas[],
+  gasPrice: bigint,
+  chainId: number
+) => Promise<RawFeeResult[]>;
+
+async function getClientChainId(client: PublicClient): Promise<number> {
+  if (client.chain?.id) {
+    return client.chain.id;
+  }
+
+  return client.getChainId();
+}
+
+function serializeTxForOracle(chainId: number, tx: TxRequest): `0x${string}` {
+  return serializeTransaction({
+    to: tx.to,
+    data: tx.data,
+    value: tx.value ?? 0n,
+    type: 'eip1559',
+    chainId,
+    maxFeePerGas: 1n,
+    maxPriorityFeePerGas: 1n,
+    gas: 1n,
+  });
+}
+
+function applyBuffer(value: bigint, multiplier: number): bigint {
+  const bps = BigInt(Math.round(multiplier * 10000));
+  return (value * bps) / 10000n;
+}
+
+function buildFeeEstimate(
+  raw: RawFeeResult,
+  buffers: BufferConfig,
+  useLegacyPricing: boolean,
+  priorityFee: bigint
+): FeeEstimate {
+  const bufferedGasLimit = applyBuffer(raw.gasEstimate, buffers.gasEstimate);
+  const bufferedGasPrice = applyBuffer(raw.gasPrice, buffers.gasPrice);
+  const bufferedL1Fee = applyBuffer(raw.l1Fee, buffers.l1Fee);
+
+  return {
+    l1Fee: raw.l1Fee,
+    l2Fee: raw.l2Fee,
+    total: raw.l1Fee + raw.l2Fee,
+    recommended: {
+      gasLimit: bufferedGasLimit,
+      maxFeePerGas: bufferedGasPrice,
+      maxPriorityFeePerGas: priorityFee,
+      totalMaxCost: bufferedGasLimit * bufferedGasPrice + bufferedL1Fee,
+      useLegacyPricing,
+    },
+  };
+}
+
+function buildOpStackStrategy(model: FeeModel.OP_STACK | FeeModel.OP_STACK_SCROLL): FeeStrategy {
+  const oracle = L1_FEE_ORACLE[model];
+
+  return async (client, items, gasPrice, chainId) => {
+    const l1Fees = await Promise.all(
+      items.map((item) => {
+        const serialized = serializeTxForOracle(chainId, item.tx);
+        return client.readContract({
+          address: oracle,
+          abi: GET_L1_FEE_ABI,
+          functionName: 'getL1Fee',
+          args: [serialized],
+        }) as Promise<bigint>;
+      })
+    );
+
+    return items.map((item, i) => ({
+      l1Fee: l1Fees[i],
+      l2Fee: item.gasEstimate * gasPrice,
+      gasPrice,
+      gasEstimate: item.gasEstimate,
+    }));
+  };
+}
+
+const arbitrumStrategy: FeeStrategy = async (client, items, gasPrice) => {
+  const l1Results = await Promise.all(
+    items.map((item) => {
+      if (item.gasEstimateKind === 'final') {
+        return Promise.resolve(null);
+      }
+
+      return client.readContract({
+        address: ARBITRUM_NODE_INTERFACE,
+        abi: ARBITRUM_GAS_ORACLE_ABI,
+        functionName: 'gasEstimateL1Component',
+        args: [item.tx.to, false, item.tx.data],
+      }) as Promise<GasEstimateL1ComponentResult>;
+    })
+  );
+
+  return items.map((item, i) => {
+    const l1GasUnits = l1Results[i]?.[0] ?? 0n;
+    const totalGas = item.gasEstimate + l1GasUnits;
+
+    return {
+      l1Fee: 0n,
+      l2Fee: totalGas * gasPrice,
+      gasPrice,
+      gasEstimate: totalGas,
+    };
+  });
+};
+
+const defaultStrategy: FeeStrategy = async (_client, items, gasPrice) =>
+  items.map((item) => ({
+    l1Fee: 0n,
+    l2Fee: item.gasEstimate * gasPrice,
+    gasPrice,
+    gasEstimate: item.gasEstimate,
+  }));
+
+const strategies: Record<FeeModel, FeeStrategy> = {
+  [FeeModel.OP_STACK]: buildOpStackStrategy(FeeModel.OP_STACK),
+  [FeeModel.OP_STACK_SCROLL]: buildOpStackStrategy(FeeModel.OP_STACK_SCROLL),
+  [FeeModel.ARBITRUM]: arbitrumStrategy,
+  [FeeModel.DEFAULT]: defaultStrategy,
+};
+
+const LEGACY_PRICING_MODELS = new Set<FeeModel>([FeeModel.ARBITRUM]);
+
+export async function estimateTotalFees(
+  client: PublicClient,
+  items: TxWithGas[],
+  priceTier: PriceTier = 'medium',
+  bufferOverrides?: Partial<BufferConfig>
+): Promise<FeeEstimate[]> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const chainId = await getClientChainId(client);
+  const model = CHAIN_FEE_MODEL[chainId] ?? FeeModel.DEFAULT;
+  const buffers = { ...BUFFER_CONFIGS[model], ...bufferOverrides };
+  const useLegacyPricing = LEGACY_PRICING_MODELS.has(model);
+
+  const recommendations = await getGasPriceRecommendations(client);
+  const selected: Eip1559FeeRecommendation = recommendations[priceTier];
+  const rawResults = await strategies[model](client, items, selected.maxFeePerGas, chainId);
+
+  return rawResults.map((raw) =>
+    buildFeeEstimate(raw, buffers, useLegacyPricing, selected.maxPriorityFeePerGas)
+  );
+}

--- a/src/services/gasFeeHistory.ts
+++ b/src/services/gasFeeHistory.ts
@@ -43,7 +43,8 @@ export function mean(nums: readonly bigint[]): bigint {
  * - High (90th percentile): Fastest confirmation, highest cost
  */
 export const getGasPriceRecommendations = async (
-  publicClient: PublicClient
+  publicClient: PublicClient,
+  chainId?: number
 ): Promise<GasPriceRecommendations> => {
   try {
     const feeHistory = await publicClient.getFeeHistory({
@@ -89,7 +90,7 @@ export const getGasPriceRecommendations = async (
     };
 
     logger.debug('Gas price recommendations', {
-      chainId: await publicClient.getChainId(),
+      chainId: chainId ?? publicClient.chain?.id,
       baseFee: nextBaseFee.toString(),
       baseFeeWithBuffer: baseFeeWithBuffer.toString(),
       'avglowPriority(50pctl)': avgLowPriority.toString(),

--- a/src/services/gasFeeHistory.ts
+++ b/src/services/gasFeeHistory.ts
@@ -1,16 +1,21 @@
 import type { PublicClient } from 'viem';
-import { getLogger } from '../../../commons';
-import { Errors } from '../errors';
+import { getLogger } from '../commons';
+import { Errors } from '../sdk/ca-base/errors';
 
 const logger = getLogger();
 
 /**
  * Gas price recommendations for different transaction speeds
  */
+export type Eip1559FeeRecommendation = {
+  maxFeePerGas: bigint;
+  maxPriorityFeePerGas: bigint;
+};
+
 export type GasPriceRecommendations = {
-  low: bigint;
-  medium: bigint;
-  high: bigint;
+  low: Eip1559FeeRecommendation;
+  medium: Eip1559FeeRecommendation;
+  high: Eip1559FeeRecommendation;
 };
 
 // from es-toolkit but with bigints
@@ -69,9 +74,18 @@ export const getGasPriceRecommendations = async (
 
     // Calculate maxFeePerGas for each tier: baseFee + buffer + priorityFee
     const recommendations: GasPriceRecommendations = {
-      low: baseFeeWithBuffer + avgLowPriority,
-      medium: baseFeeWithBuffer + avgMediumPriority,
-      high: baseFeeWithBuffer + avgHighPriority,
+      low: {
+        maxFeePerGas: baseFeeWithBuffer + avgLowPriority,
+        maxPriorityFeePerGas: avgLowPriority,
+      },
+      medium: {
+        maxFeePerGas: baseFeeWithBuffer + avgMediumPriority,
+        maxPriorityFeePerGas: avgMediumPriority,
+      },
+      high: {
+        maxFeePerGas: baseFeeWithBuffer + avgHighPriority,
+        maxPriorityFeePerGas: avgHighPriority,
+      },
     };
 
     logger.debug('Gas price recommendations', {

--- a/src/services/swapNativeReserveFee.ts
+++ b/src/services/swapNativeReserveFee.ts
@@ -1,0 +1,112 @@
+import { encodeAbiParameters, encodeFunctionData, type Hex } from 'viem';
+import type { Chain } from '../commons';
+import { SUPPORTED_CHAINS } from '../commons/constants';
+import CaliburABI from '../sdk/ca-base/swap/calibur.abi';
+import { createPublicClientWithFallback } from '../sdk/ca-base/utils/contract.utils';
+import {
+  estimateFeeContext,
+  finalizeFeeEstimates,
+  type PriceTier,
+  type TxRequest,
+} from './feeEstimation';
+
+export const DEFAULT_SWAP_NATIVE_RESERVE_GAS = 1_500_000n;
+
+const DEFAULT_PRICE_TIER: PriceTier = 'medium';
+const DEFAULT_SYNTHETIC_SWAP_BUFFER = 120n;
+const DEFAULT_CITREA_SWAP_L1_DIFF_SIZE = 120n;
+const REPRESENTATIVE_EPHEMERAL = '0x1111111111111111111111111111111111111111' as const;
+const REPRESENTATIVE_TARGET = '0x2222222222222222222222222222222222222222' as const;
+const REPRESENTATIVE_SIGNATURE = `0x${'11'.repeat(65)}` as Hex;
+const REPRESENTATIVE_SWAP_CALL_DATA = `0x${'11'.repeat(384)}` as Hex;
+const REPRESENTATIVE_SWEEP_CALL_DATA = `0x${'22'.repeat(68)}` as Hex;
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as const;
+const ZERO_BYTES_32 = `0x${'00'.repeat(32)}` as const;
+
+const applyMultiplier = (value: bigint, multiplier: bigint) => (value * multiplier) / 100n;
+
+const getRepresentativeL1DiffSizeHint = (chainId: number) => {
+  switch (chainId) {
+    case SUPPORTED_CHAINS.CITREA:
+    case SUPPORTED_CHAINS.CITREA_TESTNET:
+      return DEFAULT_CITREA_SWAP_L1_DIFF_SIZE;
+    default:
+      return undefined;
+  }
+};
+
+const buildRepresentativeCaliburExecuteTx = (): TxRequest => {
+  const wrappedSignature = encodeAbiParameters(
+    [
+      { name: 'signature', type: 'bytes' },
+      { name: 'hookData', type: 'bytes' },
+    ],
+    [REPRESENTATIVE_SIGNATURE, '0x']
+  );
+
+  return {
+    to: REPRESENTATIVE_EPHEMERAL,
+    data: encodeFunctionData({
+      abi: CaliburABI,
+      functionName: 'execute',
+      args: [
+        {
+          batchedCall: {
+            calls: [
+              {
+                to: REPRESENTATIVE_TARGET,
+                value: 1n,
+                data: REPRESENTATIVE_SWAP_CALL_DATA,
+              },
+              {
+                to: REPRESENTATIVE_TARGET,
+                value: 0n,
+                data: REPRESENTATIVE_SWEEP_CALL_DATA,
+              },
+            ],
+            revertOnFailure: true,
+          },
+          nonce: 1n,
+          keyHash: ZERO_BYTES_32,
+          executor: ZERO_ADDRESS,
+          deadline: 1n,
+        },
+        wrappedSignature,
+      ],
+    }),
+    value: 1n,
+  };
+};
+
+export const estimateRepresentativeSwapNativeReserveFee = async ({
+  chain,
+  gasEstimate = DEFAULT_SWAP_NATIVE_RESERVE_GAS,
+  priceTier = DEFAULT_PRICE_TIER,
+  syntheticBufferMultiplier = DEFAULT_SYNTHETIC_SWAP_BUFFER,
+}: {
+  chain: Chain;
+  gasEstimate?: bigint;
+  priceTier?: PriceTier;
+  syntheticBufferMultiplier?: bigint;
+}): Promise<bigint> => {
+  const client = createPublicClientWithFallback(chain);
+  const tx = buildRepresentativeCaliburExecuteTx();
+  const feeContext = await estimateFeeContext(
+    client,
+    chain.id,
+    [
+      {
+        tx,
+        gasEstimateKind: 'raw',
+        l1DiffSizeHint: getRepresentativeL1DiffSizeHint(chain.id),
+      },
+    ],
+    priceTier
+  );
+  const [feeEstimate] = finalizeFeeEstimates(
+    [{ tx, gasEstimate, gasEstimateKind: 'raw' }],
+    feeContext
+  );
+
+  return applyMultiplier(feeEstimate.total, syntheticBufferMultiplier);
+};

--- a/src/services/swapNativeReserveFee.ts
+++ b/src/services/swapNativeReserveFee.ts
@@ -14,14 +14,17 @@ export const DEFAULT_SWAP_NATIVE_RESERVE_GAS = 1_500_000n;
 
 const DEFAULT_PRICE_TIER: PriceTier = 'medium';
 const DEFAULT_SYNTHETIC_SWAP_BUFFER = 120n;
-const DEFAULT_CITREA_SWAP_L1_DIFF_SIZE = 120n;
+const DEFAULT_CITREA_SWAP_L1_DIFF_SIZE = 200n;
 const REPRESENTATIVE_EPHEMERAL = '0x1111111111111111111111111111111111111111' as const;
-const REPRESENTATIVE_TARGET = '0x2222222222222222222222222222222222222222' as const;
+const REPRESENTATIVE_ROUTER = '0xbeb0b0623f66be8ce162ebdfa2ec543a522f4ea6' as const;
+const REPRESENTATIVE_STABLE = '0x06efdbff2a14a7c8e15944d1f4a48f9f95f663a4' as const;
+const REPRESENTATIVE_WRAPPED_NATIVE = '0xac4c6e212a361c968f1725b4d055b47e63f80b75' as const;
+const REPRESENTATIVE_RECIPIENT = '0xc452cbf994d5a4f4b1d7c9a4dbb75e79c14e05b9' as const;
+const REPRESENTATIVE_EXECUTOR = '0xc10ee9031f2a0b84766a86b55a8d90f357910fb4' as const;
 const REPRESENTATIVE_SIGNATURE = `0x${'11'.repeat(65)}` as Hex;
-const REPRESENTATIVE_SWAP_CALL_DATA = `0x${'11'.repeat(384)}` as Hex;
-const REPRESENTATIVE_SWEEP_CALL_DATA = `0x${'22'.repeat(68)}` as Hex;
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as const;
 const ZERO_BYTES_32 = `0x${'00'.repeat(32)}` as const;
+const EADDRESS_BODY = 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 
 const applyMultiplier = (value: bigint, multiplier: bigint) => (value * multiplier) / 100n;
 
@@ -34,6 +37,28 @@ const getRepresentativeL1DiffSizeHint = (chainId: number) => {
       return undefined;
   }
 };
+
+const buildRepresentativeSwapCallData = (): Hex =>
+  `0x2143d82c${'0'.repeat(56)}a0${'0'.repeat(63)}32${'0'.repeat(63)}34${'0'.repeat(
+    63
+  )}76${'0'.repeat(24)}${REPRESENTATIVE_ROUTER.slice(2)}${'0'.repeat(
+    24
+  )}${REPRESENTATIVE_RECIPIENT.slice(2)}${'0'.repeat(24)}${REPRESENTATIVE_RECIPIENT.slice(
+    2
+  )}${'0'.repeat(64)}${'0'.repeat(56)}69b41d24${'0'.repeat(
+    56
+  )}69b41d24${'0'.repeat(24)}a210a4ebe64040b8a26cb798ef450f9c${'0'.repeat(
+    24
+  )}${REPRESENTATIVE_RECIPIENT.slice(2)}${'0'.repeat(1200)}` as Hex;
+
+const buildRepresentativeSweepCallData = (): Hex =>
+  `0x45f3bd1c8${'0'.repeat(23)}${EADDRESS_BODY}${'0'.repeat(48)}5b9bd4f21f19${'0'.repeat(
+    24
+  )}${REPRESENTATIVE_ROUTER.slice(2)}${'0'.repeat(24)}${REPRESENTATIVE_STABLE.slice(
+    2
+  )}${'0'.repeat(56)}35d17${'0'.repeat(24)}${REPRESENTATIVE_EXECUTOR.slice(
+    2
+  )}${'0'.repeat(224)}` as Hex;
 
 const buildRepresentativeCaliburExecuteTx = (): TxRequest => {
   const wrappedSignature = encodeAbiParameters(
@@ -54,14 +79,14 @@ const buildRepresentativeCaliburExecuteTx = (): TxRequest => {
           batchedCall: {
             calls: [
               {
-                to: REPRESENTATIVE_TARGET,
-                value: 1n,
-                data: REPRESENTATIVE_SWAP_CALL_DATA,
+                to: REPRESENTATIVE_ROUTER,
+                value: 100_000_000_000_000n,
+                data: buildRepresentativeSwapCallData(),
               },
               {
-                to: REPRESENTATIVE_TARGET,
+                to: REPRESENTATIVE_WRAPPED_NATIVE,
                 value: 0n,
-                data: REPRESENTATIVE_SWEEP_CALL_DATA,
+                data: buildRepresentativeSweepCallData(),
               },
             ],
             revertOnFailure: true,

--- a/src/services/walletCapabilities.ts
+++ b/src/services/walletCapabilities.ts
@@ -1,0 +1,33 @@
+import type { Hex, WalletClient } from 'viem';
+
+type AtomicCapabilities = Record<
+  number,
+  {
+    atomic?: {
+      status?: 'supported' | 'ready' | 'unsupported';
+    };
+  }
+>;
+
+export const getAtomicBatchSupport = async (
+  walletClient: WalletClient,
+  address: Hex,
+  chainIds: number[]
+): Promise<Map<number, boolean>> => {
+  const fallback = new Map<number, boolean>(chainIds.map((chainId) => [chainId, false]));
+
+  try {
+    const capabilities = (await walletClient.getCapabilities({
+      account: address,
+    })) as AtomicCapabilities;
+
+    return new Map(
+      chainIds.map((chainId) => {
+        const status = capabilities?.[chainId]?.atomic?.status;
+        return [chainId, status === 'supported' || status === 'ready'];
+      })
+    );
+  } catch {
+    return fallback;
+  }
+};

--- a/tests/sdk/ca-base/query/bridgeAndExecute.test.ts
+++ b/tests/sdk/ca-base/query/bridgeAndExecute.test.ts
@@ -4,7 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockPublicClient = vi.hoisted(() => ({ kind: 'publicClient' })) as unknown as PublicClient;
 const createPublicClientMock = vi.hoisted(() => vi.fn(() => mockPublicClient));
-const estimateTotalFeesMock = vi.hoisted(() => vi.fn());
+const estimateFeeContextMock = vi.hoisted(() => vi.fn());
+const finalizeFeeEstimatesMock = vi.hoisted(() => vi.fn());
 const erc20GetAllowanceMock = vi.hoisted(() => vi.fn());
 
 vi.mock('viem', async () => {
@@ -30,7 +31,8 @@ vi.mock('../../../../src/sdk/ca-base/utils', async () => {
 });
 
 vi.mock('../../../../src/services/feeEstimation', () => ({
-  estimateTotalFees: estimateTotalFeesMock,
+  estimateFeeContext: estimateFeeContextMock,
+  finalizeFeeEstimates: finalizeFeeEstimatesMock,
 }));
 
 import { BridgeAndExecuteQuery } from '../../../../src/sdk/ca-base/query/bridgeAndExecute';
@@ -82,7 +84,18 @@ describe('BridgeAndExecuteQuery fee estimation', () => {
     vi.clearAllMocks();
     createPublicClientMock.mockReturnValue(mockPublicClient);
     erc20GetAllowanceMock.mockResolvedValue(0n);
-    estimateTotalFeesMock.mockResolvedValue([
+    estimateFeeContextMock.mockResolvedValue({
+      chainId: 42161,
+      recommendation: {
+        maxFeePerGas: 17n,
+        maxPriorityFeePerGas: 2n,
+      },
+      overheads: [
+        { l1Fee: 0n, extraGas: 0n },
+        { l1Fee: 0n, extraGas: 0n },
+      ],
+    });
+    finalizeFeeEstimatesMock.mockReturnValue([
       {
         l1Fee: 0n,
         l2Fee: 0n,
@@ -150,22 +163,30 @@ describe('BridgeAndExecuteQuery fee estimation', () => {
       },
     });
 
-    expect(estimateTotalFeesMock).toHaveBeenCalledTimes(1);
-    expect(estimateTotalFeesMock).toHaveBeenCalledWith(
+    expect(estimateFeeContextMock).toHaveBeenCalledTimes(1);
+    expect(estimateFeeContextMock).toHaveBeenCalledWith(
       mockPublicClient,
+      42161,
       [
         expect.objectContaining({
-          gasEstimate: 70_000n,
+          tx: expect.objectContaining({
+            to: expect.any(String),
+          }),
         }),
         expect.objectContaining({
-          gasEstimate: 21_000n,
+          tx: expect.objectContaining({
+            to: expect.any(String),
+          }),
         }),
       ],
       'medium'
     );
 
-    const [, items] = estimateTotalFeesMock.mock.calls[0] ?? [];
+    expect(finalizeFeeEstimatesMock).toHaveBeenCalledTimes(1);
+    const [items] = finalizeFeeEstimatesMock.mock.calls[0] ?? [];
     expect(items).toHaveLength(2);
+    expect(items?.[0]?.gasEstimate).toBe(70_000n);
+    expect(items?.[1]?.gasEstimate).toBe(21_000n);
     expect(
       items?.every(
         (item: { gasEstimateKind?: 'raw' | 'final' }) => item.gasEstimateKind !== 'final'

--- a/tests/sdk/ca-base/query/bridgeAndExecute.test.ts
+++ b/tests/sdk/ca-base/query/bridgeAndExecute.test.ts
@@ -1,0 +1,187 @@
+import { Universe } from '@avail-project/ca-common';
+import type { PublicClient } from 'viem';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPublicClient = vi.hoisted(() => ({ kind: 'publicClient' })) as unknown as PublicClient;
+const createPublicClientMock = vi.hoisted(() => vi.fn(() => mockPublicClient));
+const estimateTotalFeesMock = vi.hoisted(() => vi.fn());
+const erc20GetAllowanceMock = vi.hoisted(() => vi.fn());
+
+vi.mock('viem', async () => {
+  const actual = await vi.importActual<typeof import('viem')>('viem');
+  return {
+    ...actual,
+    createPublicClient: createPublicClientMock,
+    http: vi.fn(() => ({})),
+  };
+});
+
+vi.mock('../../../../src/sdk/ca-base/utils', async () => {
+  const actual = await vi.importActual<typeof import('../../../../src/sdk/ca-base/utils')>(
+    '../../../../src/sdk/ca-base/utils'
+  );
+  return {
+    ...actual,
+    erc20GetAllowance: erc20GetAllowanceMock,
+    getL1Fee: vi.fn().mockResolvedValue(0n),
+    getPctGasBufferByChain: vi.fn().mockReturnValue(0.5),
+    pctAdditionWithSuggestion: vi.fn((base: bigint) => [base, base]),
+  };
+});
+
+vi.mock('../../../../src/services/feeEstimation', () => ({
+  estimateTotalFees: estimateTotalFeesMock,
+}));
+
+import { BridgeAndExecuteQuery } from '../../../../src/sdk/ca-base/query/bridgeAndExecute';
+
+const USER_ADDRESS = '0x1111111111111111111111111111111111111111' as const;
+const SPENDER = '0x2222222222222222222222222222222222222222' as const;
+const TARGET = '0x3333333333333333333333333333333333333333' as const;
+const TOKEN = '0x4444444444444444444444444444444444444444' as const;
+
+const dstChain = {
+  id: 42161,
+  name: 'Arbitrum',
+  ankrName: 'arbitrum',
+  blockExplorers: {
+    default: {
+      name: 'Arbiscan',
+      url: 'https://arbiscan.io',
+    },
+  },
+  custom: {
+    icon: '',
+    knownTokens: [],
+  },
+  nativeCurrency: {
+    decimals: 18,
+    name: 'Ether',
+    symbol: 'ETH',
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.example'],
+      webSocket: [],
+    },
+  },
+  swapSupported: true,
+  universe: Universe.ETHEREUM,
+} as const;
+
+const tokenInfo = {
+  contractAddress: TOKEN,
+  decimals: 6,
+  logo: '',
+  name: 'USD Coin',
+  symbol: 'USDC',
+};
+
+describe('BridgeAndExecuteQuery fee estimation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createPublicClientMock.mockReturnValue(mockPublicClient);
+    erc20GetAllowanceMock.mockResolvedValue(0n);
+    estimateTotalFeesMock.mockResolvedValue([
+      {
+        l1Fee: 0n,
+        l2Fee: 0n,
+        total: 0n,
+        recommended: {
+          gasLimit: 84_000n,
+          maxFeePerGas: 17n,
+          maxPriorityFeePerGas: 2n,
+          totalMaxCost: 1_428_000n,
+          useLegacyPricing: true,
+        },
+      },
+      {
+        l1Fee: 0n,
+        l2Fee: 0n,
+        total: 0n,
+        recommended: {
+          gasLimit: 25_000n,
+          maxFeePerGas: 17n,
+          maxPriorityFeePerGas: 2n,
+          totalMaxCost: 425_000n,
+          useLegacyPricing: true,
+        },
+      },
+    ]);
+  });
+
+  it('builds fee-estimate items for approval and execute txs and uses the helper result', async () => {
+    const chainList = {
+      getChainAndTokenFromSymbol: vi.fn(() => ({
+        chain: dstChain,
+        token: { ...tokenInfo, isNative: false },
+      })),
+      getChainByID: vi.fn(() => dstChain),
+      getTokenInfoBySymbol: vi.fn(() => tokenInfo),
+    } as never;
+
+    const query = new BridgeAndExecuteQuery(
+      chainList,
+      {
+        getAddresses: vi.fn().mockResolvedValue([USER_ADDRESS]),
+      } as never,
+      vi.fn() as never,
+      vi.fn().mockResolvedValue([]) as never,
+      {
+        simulateBundleV2: vi.fn(),
+      } as never
+    );
+
+    const result = await (query as any).estimateBridgeAndExecute({
+      token: 'USDC',
+      amount: 1_000_000n,
+      toChainId: dstChain.id,
+      execute: {
+        to: TARGET,
+        data: '0x1234',
+        value: 0n,
+        gas: 21_000n,
+        gasPrice: 'medium',
+        tokenApproval: {
+          token: 'USDC',
+          amount: 1_000_000n,
+          spender: SPENDER,
+        },
+      },
+    });
+
+    expect(estimateTotalFeesMock).toHaveBeenCalledTimes(1);
+    expect(estimateTotalFeesMock).toHaveBeenCalledWith(
+      mockPublicClient,
+      [
+        expect.objectContaining({
+          gasEstimate: 70_000n,
+        }),
+        expect.objectContaining({
+          gasEstimate: 21_000n,
+        }),
+      ],
+      'medium'
+    );
+
+    const [, items] = estimateTotalFeesMock.mock.calls[0] ?? [];
+    expect(items).toHaveLength(2);
+    expect(
+      items?.every(
+        (item: { gasEstimateKind?: 'raw' | 'final' }) => item.gasEstimateKind !== 'final'
+      )
+    ).toBe(true);
+    expect(result.approvalTx?.gas).toBe(84_000n);
+    expect(result.tx.gas).toBe(25_000n);
+    expect(result.gas).toEqual({
+      approval: 84_000n,
+      tx: 25_000n,
+    });
+    expect(result.feeParams).toEqual({
+      type: 'legacy',
+      gasPrice: 17n,
+    });
+    expect(result.gasPrice).toBe(17n);
+    expect(result.gasFee).toBe(1_853_000n);
+  });
+});

--- a/tests/sdk/ca-base/query/swapAndExecute.test.ts
+++ b/tests/sdk/ca-base/query/swapAndExecute.test.ts
@@ -4,7 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockPublicClient = vi.hoisted(() => ({ kind: 'publicClient' })) as unknown as PublicClient;
 const createPublicClientMock = vi.hoisted(() => vi.fn(() => mockPublicClient));
-const estimateTotalFeesMock = vi.hoisted(() => vi.fn());
+const estimateFeeContextMock = vi.hoisted(() => vi.fn());
+const finalizeFeeEstimatesMock = vi.hoisted(() => vi.fn());
 const erc20GetAllowanceMock = vi.hoisted(() => vi.fn());
 const getTokenInfoMock = vi.hoisted(() => vi.fn());
 const estimateGasMock = vi.hoisted(() => vi.fn());
@@ -42,7 +43,8 @@ vi.mock('../../../../src/sdk/ca-base/swap/utils', async () => {
 });
 
 vi.mock('../../../../src/services/feeEstimation', () => ({
-  estimateTotalFees: estimateTotalFeesMock,
+  estimateFeeContext: estimateFeeContextMock,
+  finalizeFeeEstimates: finalizeFeeEstimatesMock,
 }));
 
 import { SwapAndExecuteQuery } from '../../../../src/sdk/ca-base/query/swapAndExecute';
@@ -96,7 +98,18 @@ describe('SwapAndExecuteQuery fee estimation', () => {
       decimals: 6,
       symbol: 'USDC',
     });
-    estimateTotalFeesMock.mockResolvedValue([
+    estimateFeeContextMock.mockResolvedValue({
+      chainId: 42161,
+      recommendation: {
+        maxFeePerGas: 17n,
+        maxPriorityFeePerGas: 2n,
+      },
+      overheads: [
+        { l1Fee: 0n, extraGas: 0n },
+        { l1Fee: 0n, extraGas: 0n },
+      ],
+    });
+    finalizeFeeEstimatesMock.mockReturnValue([
       {
         l1Fee: 0n,
         l2Fee: 0n,
@@ -158,20 +171,29 @@ describe('SwapAndExecuteQuery fee estimation', () => {
       },
     });
 
-    expect(estimateTotalFeesMock).toHaveBeenCalledTimes(1);
-    expect(estimateTotalFeesMock).toHaveBeenCalledWith(
+    expect(estimateFeeContextMock).toHaveBeenCalledTimes(1);
+    expect(estimateFeeContextMock).toHaveBeenCalledWith(
       mockPublicClient,
+      42161,
       [
         expect.objectContaining({
-          gasEstimate: 50_000n,
           gasEstimateKind: 'final',
+          tx: expect.objectContaining({
+            to: expect.any(String),
+          }),
         }),
         expect.objectContaining({
-          gasEstimate: 100_000n,
+          tx: expect.objectContaining({
+            to: expect.any(String),
+          }),
         }),
       ],
       'medium'
     );
+    expect(finalizeFeeEstimatesMock).toHaveBeenCalledTimes(1);
+    const [items] = finalizeFeeEstimatesMock.mock.calls[0] ?? [];
+    expect(items?.[0]?.gasEstimate).toBe(50_000n);
+    expect(items?.[1]?.gasEstimate).toBe(100_000n);
 
     expect(result.approvalTx?.gas).toBe(60_000n);
     expect(result.tx.gas).toBe(130_000n);

--- a/tests/sdk/ca-base/query/swapAndExecute.test.ts
+++ b/tests/sdk/ca-base/query/swapAndExecute.test.ts
@@ -1,0 +1,189 @@
+import { Universe } from '@avail-project/ca-common';
+import type { PublicClient } from 'viem';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPublicClient = vi.hoisted(() => ({ kind: 'publicClient' })) as unknown as PublicClient;
+const createPublicClientMock = vi.hoisted(() => vi.fn(() => mockPublicClient));
+const estimateTotalFeesMock = vi.hoisted(() => vi.fn());
+const erc20GetAllowanceMock = vi.hoisted(() => vi.fn());
+const getTokenInfoMock = vi.hoisted(() => vi.fn());
+const estimateGasMock = vi.hoisted(() => vi.fn());
+
+vi.mock('viem', async () => {
+  const actual = await vi.importActual<typeof import('viem')>('viem');
+  return {
+    ...actual,
+    createPublicClient: createPublicClientMock,
+    http: vi.fn(() => ({})),
+  };
+});
+
+vi.mock('../../../../src/sdk/ca-base/utils', async () => {
+  const actual = await vi.importActual<typeof import('../../../../src/sdk/ca-base/utils')>(
+    '../../../../src/sdk/ca-base/utils'
+  );
+  return {
+    ...actual,
+    erc20GetAllowance: erc20GetAllowanceMock,
+    getL1Fee: vi.fn().mockResolvedValue(0n),
+    getPctGasBufferByChain: vi.fn().mockReturnValue(0.5),
+    pctAdditionWithSuggestion: vi.fn((base: bigint) => [base, base]),
+  };
+});
+
+vi.mock('../../../../src/sdk/ca-base/swap/utils', async () => {
+  const actual = await vi.importActual<typeof import('../../../../src/sdk/ca-base/swap/utils')>(
+    '../../../../src/sdk/ca-base/swap/utils'
+  );
+  return {
+    ...actual,
+    getTokenInfo: getTokenInfoMock,
+  };
+});
+
+vi.mock('../../../../src/services/feeEstimation', () => ({
+  estimateTotalFees: estimateTotalFeesMock,
+}));
+
+import { SwapAndExecuteQuery } from '../../../../src/sdk/ca-base/query/swapAndExecute';
+
+const USER_ADDRESS = '0x1111111111111111111111111111111111111111' as const;
+const TARGET = '0x2222222222222222222222222222222222222222' as const;
+const SPENDER = '0x3333333333333333333333333333333333333333' as const;
+const TO_TOKEN = '0x4444444444444444444444444444444444444444' as const;
+const APPROVAL_TOKEN = '0x5555555555555555555555555555555555555555' as const;
+
+const dstChain = {
+  id: 42161,
+  name: 'Arbitrum',
+  ankrName: 'arbitrum',
+  blockExplorers: {
+    default: {
+      name: 'Arbiscan',
+      url: 'https://arbiscan.io',
+    },
+  },
+  custom: {
+    icon: '',
+    knownTokens: [],
+  },
+  nativeCurrency: {
+    decimals: 18,
+    name: 'Ether',
+    symbol: 'ETH',
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.example'],
+      webSocket: [],
+    },
+  },
+  swapSupported: true,
+  universe: Universe.ETHEREUM,
+} as const;
+
+describe('SwapAndExecuteQuery fee estimation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(mockPublicClient as object, {
+      estimateGas: estimateGasMock,
+    });
+    createPublicClientMock.mockReturnValue(mockPublicClient);
+    erc20GetAllowanceMock.mockResolvedValue(0n);
+    estimateGasMock.mockResolvedValue(50_000n);
+    getTokenInfoMock.mockResolvedValue({
+      contractAddress: TO_TOKEN,
+      decimals: 6,
+      symbol: 'USDC',
+    });
+    estimateTotalFeesMock.mockResolvedValue([
+      {
+        l1Fee: 0n,
+        l2Fee: 0n,
+        total: 0n,
+        recommended: {
+          gasLimit: 60_000n,
+          maxFeePerGas: 17n,
+          maxPriorityFeePerGas: 2n,
+          totalMaxCost: 1_020_000n,
+          useLegacyPricing: true,
+        },
+      },
+      {
+        l1Fee: 0n,
+        l2Fee: 0n,
+        total: 0n,
+        recommended: {
+          gasLimit: 130_000n,
+          maxFeePerGas: 17n,
+          maxPriorityFeePerGas: 2n,
+          totalMaxCost: 2_210_000n,
+          useLegacyPricing: true,
+        },
+      },
+    ]);
+  });
+
+  it('marks approval gas as final and uses helper-based fee outputs', async () => {
+    const query = new SwapAndExecuteQuery(
+      {
+        getChainByID: vi.fn(() => dstChain),
+      } as never,
+      {
+        getAddresses: vi.fn().mockResolvedValue([USER_ADDRESS]),
+      } as never,
+      vi.fn().mockResolvedValue({
+        assets: [],
+        balances: [],
+      }) as never,
+      vi.fn() as never
+    );
+
+    const result = await (query as any).estimateSwapAndExecute({
+      toChainId: dstChain.id,
+      toTokenAddress: TO_TOKEN,
+      toAmount: 100_000_000n,
+      fromSources: [],
+      execute: {
+        to: TARGET,
+        data: '0x1234',
+        value: 0n,
+        gas: 100_000n,
+        gasPrice: 'medium',
+        tokenApproval: {
+          token: APPROVAL_TOKEN,
+          amount: 100_000_000n,
+          spender: SPENDER,
+        },
+      },
+    });
+
+    expect(estimateTotalFeesMock).toHaveBeenCalledTimes(1);
+    expect(estimateTotalFeesMock).toHaveBeenCalledWith(
+      mockPublicClient,
+      [
+        expect.objectContaining({
+          gasEstimate: 50_000n,
+          gasEstimateKind: 'final',
+        }),
+        expect.objectContaining({
+          gasEstimate: 100_000n,
+        }),
+      ],
+      'medium'
+    );
+
+    expect(result.approvalTx?.gas).toBe(60_000n);
+    expect(result.tx.gas).toBe(130_000n);
+    expect(result.gas).toEqual({
+      approval: 60_000n,
+      tx: 130_000n,
+    });
+    expect(result.feeParams).toEqual({
+      type: 'legacy',
+      gasPrice: 17n,
+    });
+    expect(result.gasPrice).toBe(17n);
+    expect(result.gasFee).toBe(3_230_000n);
+  });
+});

--- a/tests/sdk/ca-base/swap/sbc.test.ts
+++ b/tests/sdk/ca-base/swap/sbc.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const estimateFeeContextMock = vi.hoisted(() => vi.fn());
+const finalizeFeeEstimatesMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../../src/services/feeEstimation', () => ({
+  estimateFeeContext: estimateFeeContextMock,
+  finalizeFeeEstimates: finalizeFeeEstimatesMock,
+}));
+
+import { caliburExecute } from '../../../../src/sdk/ca-base/swap/sbc';
+
+describe('caliburExecute', () => {
+  const estimateGasMock = vi.fn();
+  const writeContractMock = vi.fn();
+  const signTypedDataMock = vi.fn();
+  const publicClient = {
+    estimateGas: estimateGasMock,
+  } as never;
+  const wallet = {
+    writeContract: writeContractMock,
+  } as never;
+  const ephemeralWallet = {
+    signTypedData: signTypedDataMock,
+  } as never;
+  const chain = {
+    id: 534352,
+  } as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    signTypedDataMock.mockResolvedValue(`0x${'11'.repeat(65)}`);
+    estimateGasMock.mockResolvedValue(1_100_000n);
+    estimateFeeContextMock.mockResolvedValue({
+      chainId: 534352,
+      recommendation: {
+        maxFeePerGas: 10n,
+        maxPriorityFeePerGas: 2n,
+      },
+      overheads: [{ l1Fee: 25n, extraGas: 0n }],
+    });
+    finalizeFeeEstimatesMock.mockReturnValue([
+      {
+        l1Fee: 25n,
+        l2Fee: 75n,
+        total: 100n,
+        recommended: {
+          gasLimit: 1_320_000n,
+          maxFeePerGas: 11n,
+          maxPriorityFeePerGas: 2n,
+          totalMaxCost: 14_520_025n,
+          useLegacyPricing: false,
+        },
+      },
+    ]);
+    writeContractMock.mockResolvedValue('0xhash');
+  });
+
+  it('estimates the exact execute request and passes explicit gas and fee params to the wallet', async () => {
+    const result = await caliburExecute({
+      actualAddress: '0x1111111111111111111111111111111111111111',
+      actualWallet: wallet,
+      calls: [
+        {
+          to: '0x2222222222222222222222222222222222222222',
+          value: 1n,
+          data: '0x1234',
+        },
+      ],
+      chain,
+      ephemeralAddress: '0x3333333333333333333333333333333333333333',
+      ephemeralWallet,
+      publicClient,
+      value: 1n,
+    });
+
+    expect(estimateGasMock).toHaveBeenCalledTimes(1);
+    expect(estimateFeeContextMock).toHaveBeenCalledTimes(1);
+    expect(finalizeFeeEstimatesMock).toHaveBeenCalledTimes(1);
+    expect(writeContractMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: '0x1111111111111111111111111111111111111111',
+        address: '0x3333333333333333333333333333333333333333',
+        chain,
+        functionName: 'execute',
+        gas: 1_320_000n,
+        maxFeePerGas: 11n,
+        maxPriorityFeePerGas: 2n,
+      })
+    );
+    expect(result).toBe('0xhash');
+  });
+});

--- a/tests/sdk/ca-base/utils/balance.utils.test.ts
+++ b/tests/sdk/ca-base/utils/balance.utils.test.ts
@@ -1,0 +1,102 @@
+import { Universe } from '@avail-project/ca-common';
+import Decimal from 'decimal.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ankrBalanceToAssetsMock = vi.hoisted(() => vi.fn());
+const fetchTransferFeesMock = vi.hoisted(() => vi.fn());
+const getAnkrBalancesMock = vi.hoisted(() => vi.fn());
+const toFlatBalanceMock = vi.hoisted(() => vi.fn());
+const vscBalancesToAssetsMock = vi.hoisted(() => vi.fn());
+const createPublicClientWithFallbackMock = vi.hoisted(() => vi.fn());
+const multicallMock = vi.hoisted(() => vi.fn());
+const estimateFeesPerGasMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../../src/sdk/ca-base/swap/utils', async () => {
+  const actual = await vi.importActual<typeof import('../../../../src/sdk/ca-base/swap/utils')>(
+    '../../../../src/sdk/ca-base/swap/utils'
+  );
+  return {
+    ...actual,
+    ankrBalanceToAssets: ankrBalanceToAssetsMock,
+    fetchTransferFees: fetchTransferFeesMock,
+    getAnkrBalances: getAnkrBalancesMock,
+    toFlatBalance: toFlatBalanceMock,
+    vscBalancesToAssets: vscBalancesToAssetsMock,
+  };
+});
+
+vi.mock('../../../../src/sdk/ca-base/utils/contract.utils', () => ({
+  createPublicClientWithFallback: createPublicClientWithFallbackMock,
+}));
+
+import { ZERO_ADDRESS } from '../../../../src/sdk/ca-base/constants';
+import { getBalancesForSwap } from '../../../../src/sdk/ca-base/utils/balance.utils';
+
+describe('getBalancesForSwap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createPublicClientWithFallbackMock.mockReturnValue({
+      multicall: multicallMock,
+      estimateFeesPerGas: estimateFeesPerGasMock,
+    });
+    multicallMock.mockResolvedValue([
+      {
+        status: 'success',
+        result: 3_000_000_000_000_000_000n,
+      },
+    ]);
+    estimateFeesPerGasMock.mockResolvedValue({
+      maxFeePerGas: 222_222_222_222n,
+    });
+    fetchTransferFeesMock.mockResolvedValue(new Map([[1, new Decimal(1)]]));
+    getAnkrBalancesMock.mockResolvedValue([]);
+    ankrBalanceToAssetsMock.mockReturnValue([]);
+    toFlatBalanceMock.mockReturnValue([]);
+    vscBalancesToAssetsMock.mockReturnValue([]);
+  });
+
+  it('deducts the swap native reserve once after merging balances', async () => {
+    const chain = {
+      ankrName: '',
+      custom: {
+        icon: '',
+        knownTokens: [],
+      },
+      id: 1,
+      name: 'Ethereum',
+      nativeCurrency: {
+        decimals: 18,
+        name: 'Ether',
+        symbol: 'ETH',
+      },
+      swapSupported: true,
+      universe: Universe.ETHEREUM,
+    } as never;
+
+    const chainList = {
+      chains: [chain],
+    } as never;
+
+    await getBalancesForSwap({
+      evmAddress: '0x1111111111111111111111111111111111111111',
+      chainList,
+      filterWithSupportedTokens: false,
+    });
+
+    expect(estimateFeesPerGasMock).not.toHaveBeenCalled();
+    expect(fetchTransferFeesMock).toHaveBeenCalledWith([chain]);
+    expect(ankrBalanceToAssetsMock).toHaveBeenCalledWith(
+      chainList,
+      [
+        expect.objectContaining({
+          chainID: 1,
+          tokenAddress: ZERO_ADDRESS,
+          balance: '2.000000000000000000',
+        }),
+      ],
+      false,
+      undefined,
+      undefined
+    );
+  });
+});

--- a/tests/sdk/ca-base/utils/common.utils.test.ts
+++ b/tests/sdk/ca-base/utils/common.utils.test.ts
@@ -1,0 +1,146 @@
+import { Universe } from '@avail-project/ca-common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const estimateRepresentativeDepositTxFeeMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../../src/services/depositFeeEstimation', () => ({
+  estimateRepresentativeDepositTxFee: estimateRepresentativeDepositTxFeeMock,
+}));
+
+vi.mock('../../../../src/sdk/ca-base/chains', () => ({
+  ChainList: class {},
+}));
+
+import { ZERO_ADDRESS } from '../../../../src/sdk/ca-base/constants';
+import { assetListWithDepositDeducted } from '../../../../src/sdk/ca-base/utils/common.utils';
+
+describe('assetListWithDepositDeducted', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    estimateRepresentativeDepositTxFeeMock.mockResolvedValue({
+      rawTotalFee: 1_000_000_000_000_000_000n,
+      bufferedTotalFee: 1_000_000_000_000_000_000n,
+    });
+  });
+
+  it('deducts native deposit cost only from non-destination source balances', async () => {
+    const chainList = {
+      getChainByID: vi.fn((chainId: number) => ({
+        id: chainId,
+        nativeCurrency: {
+          decimals: 18,
+          name: 'Ether',
+          symbol: 'ETH',
+        },
+      })),
+      getVaultContractAddress: vi.fn(
+        (chainId: number) => `0x${chainId.toString(16).padStart(40, '0')}` as `0x${string}`
+      ),
+    } as never;
+
+    const result = await assetListWithDepositDeducted(
+      [
+        {
+          balance: '5',
+          chainId: 10,
+          contractAddress: ZERO_ADDRESS,
+          universe: Universe.ETHEREUM,
+          decimals: 18,
+        },
+        {
+          balance: '4',
+          chainId: 8453,
+          contractAddress: ZERO_ADDRESS,
+          universe: Universe.ETHEREUM,
+          decimals: 18,
+        },
+        {
+          balance: '6',
+          chainId: 42161,
+          contractAddress: ZERO_ADDRESS,
+          universe: Universe.ETHEREUM,
+          decimals: 18,
+        },
+        {
+          balance: '7',
+          chainId: 10,
+          contractAddress: '0x2222222222222222222222222222222222222222',
+          universe: Universe.ETHEREUM,
+          decimals: 6,
+        },
+      ],
+      chainList,
+      {
+        feeMultiplier: 120n,
+        destinationChainId: 42161,
+      }
+    );
+
+    expect(
+      result
+        .find((item) => item.chainID === 10 && item.tokenContract === ZERO_ADDRESS)
+        ?.balance.toFixed()
+    ).toBe('4');
+    expect(
+      result
+        .find((item) => item.chainID === 8453 && item.tokenContract === ZERO_ADDRESS)
+        ?.balance.toFixed()
+    ).toBe('3');
+    expect(
+      result
+        .find((item) => item.chainID === 42161 && item.tokenContract === ZERO_ADDRESS)
+        ?.balance.toFixed()
+    ).toBe('6');
+    expect(
+      result
+        .find((item) => item.tokenContract === '0x2222222222222222222222222222222222222222')
+        ?.balance.toFixed()
+    ).toBe('7');
+    expect(estimateRepresentativeDepositTxFeeMock).toHaveBeenCalledTimes(2);
+    expect(estimateRepresentativeDepositTxFeeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        destinationChainId: 42161,
+        feeMultiplier: 120n,
+        sourceCount: 3,
+      })
+    );
+  });
+
+  it('clamps the native balance to zero when the representative fee exceeds it', async () => {
+    const chainList = {
+      getChainByID: vi.fn((chainId: number) => ({
+        id: chainId,
+        nativeCurrency: {
+          decimals: 18,
+          name: 'Ether',
+          symbol: 'ETH',
+        },
+      })),
+      getVaultContractAddress: vi.fn(() => '0x1111111111111111111111111111111111111111'),
+    } as never;
+
+    estimateRepresentativeDepositTxFeeMock.mockResolvedValueOnce({
+      rawTotalFee: 0n,
+      bufferedTotalFee: 2_000_000_000_000_000_000n,
+    });
+
+    const result = await assetListWithDepositDeducted(
+      [
+        {
+          balance: '1',
+          chainId: 10,
+          contractAddress: ZERO_ADDRESS,
+          universe: Universe.ETHEREUM,
+          decimals: 18,
+        },
+      ],
+      chainList,
+      {
+        feeMultiplier: 120n,
+        destinationChainId: 42161,
+      }
+    );
+
+    expect(result[0]?.balance.toFixed()).toBe('0');
+  });
+});

--- a/tests/services/depositFeeEstimation.test.ts
+++ b/tests/services/depositFeeEstimation.test.ts
@@ -1,0 +1,159 @@
+import type { PublicClient } from 'viem';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const estimateFeeContextMock = vi.hoisted(() => vi.fn());
+const finalizeFeeEstimatesMock = vi.hoisted(() => vi.fn());
+const createPublicClientWithFallbackMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/services/feeEstimation', () => ({
+  estimateFeeContext: estimateFeeContextMock,
+  finalizeFeeEstimates: finalizeFeeEstimatesMock,
+}));
+
+vi.mock('../../src/sdk/ca-base/utils/contract.utils', () => ({
+  createPublicClientWithFallback: createPublicClientWithFallbackMock,
+}));
+
+import {
+  DEFAULT_REPRESENTATIVE_DEPOSIT_GAS,
+  estimateRepresentativeDepositTxFee,
+} from '../../src/services/depositFeeEstimation';
+
+describe('estimateRepresentativeDepositTxFee', () => {
+  const estimateGas = vi.fn();
+  const client = {
+    chain: { id: 8453 },
+    estimateGas,
+  } as unknown as PublicClient;
+  const chain = {
+    id: 8453,
+    nativeCurrency: {
+      decimals: 18,
+      name: 'Ether',
+      symbol: 'ETH',
+    },
+  } as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createPublicClientWithFallbackMock.mockReturnValue(client);
+    estimateGas.mockResolvedValue(210_000n);
+    estimateFeeContextMock.mockResolvedValue({
+      chainId: 8453,
+      recommendation: {
+        maxFeePerGas: 13n,
+        maxPriorityFeePerGas: 3n,
+      },
+      overheads: [{ l1Fee: 25n, extraGas: 0n }],
+    });
+    finalizeFeeEstimatesMock.mockReturnValue([
+      {
+        l1Fee: 25n,
+        l2Fee: 75n,
+        total: 100n,
+        recommended: {
+          gasLimit: 240_000n,
+          maxFeePerGas: 15n,
+          maxPriorityFeePerGas: 2n,
+          totalMaxCost: 3_600_000n,
+          useLegacyPricing: false,
+        },
+      },
+    ]);
+  });
+
+  it('builds a representative deposit tx and applies both explicit and synthetic buffers', async () => {
+    const result = await estimateRepresentativeDepositTxFee({
+      chain,
+      vaultAddress: '0x1111111111111111111111111111111111111111',
+      destinationChainId: 42161,
+      sourceCount: 3,
+      feeMultiplier: 120n,
+    });
+
+    expect(estimateGas).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: '0x1111111111111111111111111111111111111111',
+        to: '0x1111111111111111111111111111111111111111',
+        value: 1n,
+        data: expect.stringMatching(/^0x/),
+      })
+    );
+    expect(estimateFeeContextMock).toHaveBeenCalledWith(
+      client,
+      8453,
+      [
+        expect.objectContaining({
+          tx: expect.objectContaining({
+            to: '0x1111111111111111111111111111111111111111',
+            value: 1n,
+          }),
+        }),
+      ],
+      'medium'
+    );
+    expect(finalizeFeeEstimatesMock).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          gasEstimate: 210_000n,
+          tx: expect.objectContaining({
+            to: '0x1111111111111111111111111111111111111111',
+          }),
+        }),
+      ],
+      expect.objectContaining({
+        chainId: 8453,
+      })
+    );
+    expect(result.rawTotalFee).toBe(100n);
+    expect(result.bufferedTotalFee).toBe(156n);
+  });
+
+  it('increases the synthetic calldata with the source count hint', async () => {
+    await estimateRepresentativeDepositTxFee({
+      chain,
+      vaultAddress: '0x1111111111111111111111111111111111111111',
+      sourceCount: 1,
+    });
+    const singleSourceData = estimateGas.mock.calls[0]?.[0]?.data as string;
+
+    await estimateRepresentativeDepositTxFee({
+      chain,
+      vaultAddress: '0x1111111111111111111111111111111111111111',
+      sourceCount: 4,
+    });
+    const multiSourceData = estimateGas.mock.calls[1]?.[0]?.data as string;
+
+    expect(multiSourceData.length).toBeGreaterThan(singleSourceData.length);
+  });
+
+  it('falls back to the default representative gas when chain estimation fails', async () => {
+    estimateGas.mockRejectedValueOnce(new Error('estimate failed'));
+
+    await estimateRepresentativeDepositTxFee({
+      chain,
+      vaultAddress: '0x1111111111111111111111111111111111111111',
+    });
+
+    expect(estimateFeeContextMock).toHaveBeenCalledWith(
+      client,
+      8453,
+      [
+        expect.objectContaining({
+          tx: expect.any(Object),
+        }),
+      ],
+      'medium'
+    );
+    expect(finalizeFeeEstimatesMock).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          gasEstimate: DEFAULT_REPRESENTATIVE_DEPOSIT_GAS,
+        }),
+      ],
+      expect.objectContaining({
+        chainId: 8453,
+      })
+    );
+  });
+});

--- a/tests/services/executeTransactions.test.ts
+++ b/tests/services/executeTransactions.test.ts
@@ -1,0 +1,228 @@
+import type { Hex } from 'viem';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/sdk/ca-base/utils', () => ({
+  switchChain: vi.fn().mockResolvedValue(undefined),
+  waitForTxReceipt: vi.fn().mockResolvedValue({
+    status: 'success',
+    transactionHash: '0x9999999999999999999999999999999999999999999999999999999999999999' as Hex,
+    blockNumber: 1n,
+    effectiveGasPrice: 1n,
+    gasUsed: 21_000n,
+    logs: [],
+  }),
+}));
+
+import { waitForTxReceipt } from '../../src/sdk/ca-base/utils';
+import {
+  type ExecuteFeeParams,
+  sendExecuteTransactions,
+} from '../../src/services/executeTransactions';
+
+const CHAIN_ID = 42161;
+const ADDRESS = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as Hex;
+const APPROVAL_HASH = '0x1111111111111111111111111111111111111111111111111111111111111111' as Hex;
+const EXECUTE_HASH = '0x2222222222222222222222222222222222222222222222222222222222222222' as Hex;
+
+const makeChain = () =>
+  ({
+    id: CHAIN_ID,
+    name: 'Arbitrum',
+    nativeCurrency: { decimals: 18, name: 'ETH', symbol: 'ETH' },
+    rpcUrls: { default: { http: ['https://arb.rpc'] } },
+    blockExplorers: { default: { url: 'https://arbiscan.io' } },
+    custom: { icon: '' },
+  }) as never;
+
+const makeTx = () => ({
+  to: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as Hex,
+  value: 0n,
+  data: '0xdeadbeef' as Hex,
+  gas: 123_456n,
+});
+
+const makeClient = (atomicBatchSupported: boolean) =>
+  ({
+    getCapabilities: vi.fn().mockResolvedValue({
+      [CHAIN_ID]: {
+        atomic: { status: atomicBatchSupported ? 'supported' : 'unsupported' },
+      },
+    }),
+    sendCalls: vi.fn().mockResolvedValue({ id: '0xcallid' }),
+    waitForCallsStatus: vi.fn().mockResolvedValue({
+      status: 'success',
+      receipts: [{ transactionHash: APPROVAL_HASH }, { transactionHash: EXECUTE_HASH }],
+    }),
+    sendTransaction: vi
+      .fn()
+      .mockResolvedValueOnce(APPROVAL_HASH)
+      .mockResolvedValueOnce(EXECUTE_HASH),
+  }) as never;
+
+describe('sendExecuteTransactions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('spreads EIP-1559 fee fields and gas onto sendTransaction', async () => {
+    const client = makeClient(false);
+    const feeParams: ExecuteFeeParams = {
+      type: 'eip1559',
+      maxFeePerGas: 2_000_000_000n,
+      maxPriorityFeePerGas: 100_000_000n,
+    };
+
+    await sendExecuteTransactions(
+      {
+        tx: makeTx(),
+        approvalTx: null,
+        feeParams,
+      },
+      {
+        chain: makeChain(),
+        dstPublicClient: {} as never,
+        address: ADDRESS,
+        client,
+        waitForReceipt: false,
+      }
+    );
+
+    expect(client.sendTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gas: 123_456n,
+        maxFeePerGas: 2_000_000_000n,
+        maxPriorityFeePerGas: 100_000_000n,
+      })
+    );
+    expect(client.sendTransaction).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        gasPrice: expect.anything(),
+      })
+    );
+  });
+
+  it('spreads legacy gasPrice and gas onto sendTransaction', async () => {
+    const client = makeClient(false);
+    const feeParams: ExecuteFeeParams = {
+      type: 'legacy',
+      gasPrice: 500_000_000n,
+    };
+
+    await sendExecuteTransactions(
+      {
+        tx: makeTx(),
+        approvalTx: null,
+        feeParams,
+      },
+      {
+        chain: makeChain(),
+        dstPublicClient: {} as never,
+        address: ADDRESS,
+        client,
+        waitForReceipt: false,
+      }
+    );
+
+    expect(client.sendTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gas: 123_456n,
+        gasPrice: 500_000_000n,
+      })
+    );
+    expect(client.sendTransaction).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxFeePerGas: expect.anything(),
+      })
+    );
+  });
+
+  it('uses wallet_sendCalls when approval batching is supported', async () => {
+    const client = makeClient(true);
+
+    const result = await sendExecuteTransactions(
+      {
+        tx: makeTx(),
+        approvalTx: {
+          to: '0xcccccccccccccccccccccccccccccccccccccccc' as Hex,
+          data: '0xapprove' as Hex,
+          value: 0n,
+          gas: 65_000n,
+        },
+      },
+      {
+        chain: makeChain(),
+        dstPublicClient: {} as never,
+        address: ADDRESS,
+        client,
+        waitForReceipt: true,
+      }
+    );
+
+    expect(client.sendCalls).toHaveBeenCalledWith({
+      account: ADDRESS,
+      chain: expect.objectContaining({ id: CHAIN_ID }),
+      forceAtomic: true,
+      calls: [
+        {
+          to: '0xcccccccccccccccccccccccccccccccccccccccc',
+          data: '0xapprove',
+          value: 0n,
+        },
+        {
+          to: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          data: '0xdeadbeef',
+          value: 0n,
+        },
+      ],
+    });
+    expect(client.sendTransaction).not.toHaveBeenCalled();
+    expect(waitForTxReceipt).toHaveBeenCalledTimes(1);
+    expect(result.approvalHash).toBe(APPROVAL_HASH);
+    expect(result.txHash).toBe(EXECUTE_HASH);
+  });
+
+  it('falls back to sequential sendTransaction when atomic batching is unsupported', async () => {
+    const client = makeClient(false);
+    const feeParams: ExecuteFeeParams = {
+      type: 'legacy',
+      gasPrice: 500_000_000n,
+    };
+
+    await sendExecuteTransactions(
+      {
+        tx: makeTx(),
+        approvalTx: {
+          to: '0xcccccccccccccccccccccccccccccccccccccccc' as Hex,
+          data: '0xapprove' as Hex,
+          value: 0n,
+          gas: 65_000n,
+        },
+        feeParams,
+      },
+      {
+        chain: makeChain(),
+        dstPublicClient: {} as never,
+        address: ADDRESS,
+        client,
+        waitForReceipt: false,
+      }
+    );
+
+    expect(client.sendCalls).not.toHaveBeenCalled();
+    expect(client.sendTransaction).toHaveBeenCalledTimes(2);
+    expect(client.sendTransaction).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        gas: 65_000n,
+        gasPrice: 500_000_000n,
+      })
+    );
+    expect(client.sendTransaction).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        gas: 123_456n,
+        gasPrice: 500_000_000n,
+      })
+    );
+  });
+});

--- a/tests/services/feeEstimation.test.ts
+++ b/tests/services/feeEstimation.test.ts
@@ -1,15 +1,17 @@
 import type { PublicClient } from 'viem';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const getGasPriceRecommendationsMock = vi.hoisted(() => vi.fn());
+
 vi.mock('../../src/services/gasFeeHistory', () => ({
-  getGasPriceRecommendations: vi.fn().mockResolvedValue({
-    low: { maxFeePerGas: 11n, maxPriorityFeePerGas: 2n },
-    medium: { maxFeePerGas: 13n, maxPriorityFeePerGas: 3n },
-    high: { maxFeePerGas: 17n, maxPriorityFeePerGas: 5n },
-  }),
+  getGasPriceRecommendations: getGasPriceRecommendationsMock,
 }));
 
-import { estimateTotalFees, type TxWithGas } from '../../src/services/feeEstimation';
+import {
+  estimateFeeContext,
+  estimateTotalFees,
+  type TxWithGas,
+} from '../../src/services/feeEstimation';
 
 const readContract = vi.fn();
 
@@ -17,28 +19,46 @@ const makeClient = (chainId: number) =>
   ({
     chain: { id: chainId },
     readContract,
-  }) as unknown as PublicClient;
+    getChainId: vi
+      .fn()
+      .mockRejectedValue(new Error('estimateTotalFees should not call getChainId')),
+  }) as unknown as PublicClient & {
+    getChainId: ReturnType<typeof vi.fn>;
+  };
 
 describe('estimateTotalFees', () => {
   beforeEach(() => {
     readContract.mockReset();
+    getGasPriceRecommendationsMock.mockReset();
+    getGasPriceRecommendationsMock.mockResolvedValue({
+      low: { maxFeePerGas: 11n, maxPriorityFeePerGas: 2n },
+      medium: { maxFeePerGas: 13n, maxPriorityFeePerGas: 3n },
+      high: { maxFeePerGas: 17n, maxPriorityFeePerGas: 5n },
+    });
   });
 
   it('adds Arbitrum L1 gas units for raw estimates before buffering the gas limit', async () => {
     readContract.mockResolvedValue([20n, 1n, 0n]);
+    const client = makeClient(42161);
 
-    const [fee] = await estimateTotalFees(makeClient(42161), [
-      {
-        tx: {
-          to: '0x1111111111111111111111111111111111111111',
-          data: '0x1234',
-          value: 0n,
-        },
-        gasEstimate: 100n,
-        gasEstimateKind: 'raw',
-      } as TxWithGas,
-    ]);
+    const [fee] = await estimateTotalFees(
+      client,
+      [
+        {
+          tx: {
+            to: '0x1111111111111111111111111111111111111111',
+            data: '0x1234',
+            value: 0n,
+          },
+          gasEstimate: 100n,
+          gasEstimateKind: 'raw',
+        } as TxWithGas,
+      ],
+      42161,
+      'medium'
+    );
 
+    expect(client.getChainId).not.toHaveBeenCalled();
     expect(readContract).toHaveBeenCalledTimes(1);
     expect(readContract).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -56,17 +76,25 @@ describe('estimateTotalFees', () => {
   });
 
   it('does not double count L1 gas units for final Arbitrum estimates', async () => {
-    const [fee] = await estimateTotalFees(makeClient(42161), [
-      {
-        tx: {
-          to: '0x1111111111111111111111111111111111111111',
-          data: '0x1234',
-        },
-        gasEstimate: 100n,
-        gasEstimateKind: 'final',
-      } as TxWithGas,
-    ]);
+    const client = makeClient(42161);
 
+    const [fee] = await estimateTotalFees(
+      client,
+      [
+        {
+          tx: {
+            to: '0x1111111111111111111111111111111111111111',
+            data: '0x1234',
+          },
+          gasEstimate: 100n,
+          gasEstimateKind: 'final',
+        } as TxWithGas,
+      ],
+      42161,
+      'medium'
+    );
+
+    expect(client.getChainId).not.toHaveBeenCalled();
     expect(readContract).not.toHaveBeenCalled();
     expect(fee.l1Fee).toBe(0n);
     expect(fee.recommended.gasLimit).toBe(120n);
@@ -75,43 +103,10 @@ describe('estimateTotalFees', () => {
 
   it('returns a separate L1 fee for OP Stack estimates', async () => {
     readContract.mockResolvedValue(25n);
+    const client = makeClient(8453);
 
-    const [fee] = await estimateTotalFees(makeClient(8453), [
-      {
-        tx: {
-          to: '0x1111111111111111111111111111111111111111',
-          data: '0x1234',
-        },
-        gasEstimate: 100n,
-      },
-    ]);
-
-    expect(fee.l1Fee).toBe(25n);
-    expect(fee.l2Fee).toBe(1300n);
-    expect(fee.recommended.gasLimit).toBe(120n);
-    expect(fee.recommended.totalMaxCost).toBe(1712n);
-  });
-
-  it('has no separate L1 fee on default fee models', async () => {
-    const [fee] = await estimateTotalFees(makeClient(1), [
-      {
-        tx: {
-          to: '0x1111111111111111111111111111111111111111',
-          data: '0x1234',
-        },
-        gasEstimate: 100n,
-      },
-    ]);
-
-    expect(readContract).not.toHaveBeenCalled();
-    expect(fee.l1Fee).toBe(0n);
-    expect(fee.recommended.gasLimit).toBe(120n);
-    expect(fee.recommended.totalMaxCost).toBe(1800n);
-  });
-
-  it('uses the requested price tier for max fee and priority fee recommendations', async () => {
     const [fee] = await estimateTotalFees(
-      makeClient(1),
+      client,
       [
         {
           tx: {
@@ -121,10 +116,117 @@ describe('estimateTotalFees', () => {
           gasEstimate: 100n,
         },
       ],
+      8453,
+      'medium'
+    );
+
+    expect(client.getChainId).not.toHaveBeenCalled();
+    expect(fee.l1Fee).toBe(25n);
+    expect(fee.l2Fee).toBe(1300n);
+    expect(fee.recommended.gasLimit).toBe(120n);
+    expect(fee.recommended.totalMaxCost).toBe(1712n);
+  });
+
+  it('has no separate L1 fee on default fee models', async () => {
+    const client = makeClient(1);
+
+    const [fee] = await estimateTotalFees(
+      client,
+      [
+        {
+          tx: {
+            to: '0x1111111111111111111111111111111111111111',
+            data: '0x1234',
+          },
+          gasEstimate: 100n,
+        },
+      ],
+      1,
+      'medium'
+    );
+
+    expect(client.getChainId).not.toHaveBeenCalled();
+    expect(readContract).not.toHaveBeenCalled();
+    expect(fee.l1Fee).toBe(0n);
+    expect(fee.recommended.gasLimit).toBe(120n);
+    expect(fee.recommended.totalMaxCost).toBe(1800n);
+  });
+
+  it('uses the requested price tier for max fee and priority fee recommendations', async () => {
+    const client = makeClient(1);
+
+    const [fee] = await estimateTotalFees(
+      client,
+      [
+        {
+          tx: {
+            to: '0x1111111111111111111111111111111111111111',
+            data: '0x1234',
+          },
+          gasEstimate: 100n,
+        },
+      ],
+      1,
       'high'
     );
 
     expect(fee.recommended.maxFeePerGas).toBe(20n);
     expect(fee.recommended.maxPriorityFeePerGas).toBe(5n);
+  });
+
+  it('starts chain-specific fee work before gas price recommendations resolve', async () => {
+    let resolveRecommendations:
+      | ((value: {
+          low: { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint };
+          medium: { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint };
+          high: { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint };
+        }) => void)
+      | null = null;
+
+    getGasPriceRecommendationsMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRecommendations = resolve;
+        })
+    );
+    readContract.mockResolvedValue(25n);
+    const client = makeClient(8453);
+
+    const contextPromise = estimateFeeContext(
+      client,
+      8453,
+      [
+        {
+          tx: {
+            to: '0x1111111111111111111111111111111111111111',
+            data: '0x1234',
+          },
+        },
+      ],
+      'medium'
+    );
+
+    await Promise.resolve();
+
+    expect(getGasPriceRecommendationsMock).toHaveBeenCalledWith(client, 8453);
+    expect(readContract).toHaveBeenCalledTimes(1);
+
+    resolveRecommendations?.({
+      low: { maxFeePerGas: 11n, maxPriorityFeePerGas: 2n },
+      medium: { maxFeePerGas: 13n, maxPriorityFeePerGas: 3n },
+      high: { maxFeePerGas: 17n, maxPriorityFeePerGas: 5n },
+    });
+
+    const context = await contextPromise;
+    expect(context.recommendation).toEqual({
+      maxFeePerGas: 13n,
+      maxPriorityFeePerGas: 3n,
+    });
+    expect(context.overheads).toEqual([
+      {
+        l1Fee: 25n,
+        extraGas: 0n,
+      },
+    ]);
   });
 });

--- a/tests/services/feeEstimation.test.ts
+++ b/tests/services/feeEstimation.test.ts
@@ -1,0 +1,130 @@
+import type { PublicClient } from 'viem';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/services/gasFeeHistory', () => ({
+  getGasPriceRecommendations: vi.fn().mockResolvedValue({
+    low: { maxFeePerGas: 11n, maxPriorityFeePerGas: 2n },
+    medium: { maxFeePerGas: 13n, maxPriorityFeePerGas: 3n },
+    high: { maxFeePerGas: 17n, maxPriorityFeePerGas: 5n },
+  }),
+}));
+
+import { estimateTotalFees, type TxWithGas } from '../../src/services/feeEstimation';
+
+const readContract = vi.fn();
+
+const makeClient = (chainId: number) =>
+  ({
+    chain: { id: chainId },
+    readContract,
+  }) as unknown as PublicClient;
+
+describe('estimateTotalFees', () => {
+  beforeEach(() => {
+    readContract.mockReset();
+  });
+
+  it('adds Arbitrum L1 gas units for raw estimates before buffering the gas limit', async () => {
+    readContract.mockResolvedValue([20n, 1n, 0n]);
+
+    const [fee] = await estimateTotalFees(makeClient(42161), [
+      {
+        tx: {
+          to: '0x1111111111111111111111111111111111111111',
+          data: '0x1234',
+          value: 0n,
+        },
+        gasEstimate: 100n,
+        gasEstimateKind: 'raw',
+      } as TxWithGas,
+    ]);
+
+    expect(readContract).toHaveBeenCalledTimes(1);
+    expect(readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: '0x00000000000000000000000000000000000000C8',
+        functionName: 'gasEstimateL1Component',
+      })
+    );
+    const call = readContract.mock.calls[0]?.[0] as {
+      abi: readonly [{ outputs: readonly unknown[] }];
+    };
+    expect(call.abi[0]?.outputs).toHaveLength(3);
+    expect(fee.l1Fee).toBe(0n);
+    expect(fee.recommended.gasLimit).toBe(144n);
+    expect(fee.recommended.totalMaxCost).toBe(2592n);
+  });
+
+  it('does not double count L1 gas units for final Arbitrum estimates', async () => {
+    const [fee] = await estimateTotalFees(makeClient(42161), [
+      {
+        tx: {
+          to: '0x1111111111111111111111111111111111111111',
+          data: '0x1234',
+        },
+        gasEstimate: 100n,
+        gasEstimateKind: 'final',
+      } as TxWithGas,
+    ]);
+
+    expect(readContract).not.toHaveBeenCalled();
+    expect(fee.l1Fee).toBe(0n);
+    expect(fee.recommended.gasLimit).toBe(120n);
+    expect(fee.recommended.totalMaxCost).toBe(2160n);
+  });
+
+  it('returns a separate L1 fee for OP Stack estimates', async () => {
+    readContract.mockResolvedValue(25n);
+
+    const [fee] = await estimateTotalFees(makeClient(8453), [
+      {
+        tx: {
+          to: '0x1111111111111111111111111111111111111111',
+          data: '0x1234',
+        },
+        gasEstimate: 100n,
+      },
+    ]);
+
+    expect(fee.l1Fee).toBe(25n);
+    expect(fee.l2Fee).toBe(1300n);
+    expect(fee.recommended.gasLimit).toBe(120n);
+    expect(fee.recommended.totalMaxCost).toBe(1712n);
+  });
+
+  it('has no separate L1 fee on default fee models', async () => {
+    const [fee] = await estimateTotalFees(makeClient(1), [
+      {
+        tx: {
+          to: '0x1111111111111111111111111111111111111111',
+          data: '0x1234',
+        },
+        gasEstimate: 100n,
+      },
+    ]);
+
+    expect(readContract).not.toHaveBeenCalled();
+    expect(fee.l1Fee).toBe(0n);
+    expect(fee.recommended.gasLimit).toBe(120n);
+    expect(fee.recommended.totalMaxCost).toBe(1800n);
+  });
+
+  it('uses the requested price tier for max fee and priority fee recommendations', async () => {
+    const [fee] = await estimateTotalFees(
+      makeClient(1),
+      [
+        {
+          tx: {
+            to: '0x1111111111111111111111111111111111111111',
+            data: '0x1234',
+          },
+          gasEstimate: 100n,
+        },
+      ],
+      'high'
+    );
+
+    expect(fee.recommended.maxFeePerGas).toBe(20n);
+    expect(fee.recommended.maxPriorityFeePerGas).toBe(5n);
+  });
+});

--- a/tests/services/feeEstimation.test.ts
+++ b/tests/services/feeEstimation.test.ts
@@ -14,11 +14,13 @@ import {
 } from '../../src/services/feeEstimation';
 
 const readContract = vi.fn();
+const request = vi.fn();
 
 const makeClient = (chainId: number) =>
   ({
     chain: { id: chainId },
     readContract,
+    request,
     getChainId: vi
       .fn()
       .mockRejectedValue(new Error('estimateTotalFees should not call getChainId')),
@@ -29,6 +31,7 @@ const makeClient = (chainId: number) =>
 describe('estimateTotalFees', () => {
   beforeEach(() => {
     readContract.mockReset();
+    request.mockReset();
     getGasPriceRecommendationsMock.mockReset();
     getGasPriceRecommendationsMock.mockResolvedValue({
       low: { maxFeePerGas: 11n, maxPriorityFeePerGas: 2n },
@@ -125,6 +128,45 @@ describe('estimateTotalFees', () => {
     expect(fee.l2Fee).toBe(1300n);
     expect(fee.recommended.gasLimit).toBe(120n);
     expect(fee.recommended.totalMaxCost).toBe(1712n);
+  });
+
+  it('returns a separate L1 fee for Citrea estimates using l1FeeRate and l1DiffSize', async () => {
+    request
+      .mockResolvedValueOnce({ l1FeeRate: '0x2' })
+      .mockResolvedValueOnce({ gas: '0x186a0', l1DiffSize: '0x11' });
+    const client = makeClient(4114);
+
+    const [fee] = await estimateTotalFees(
+      client,
+      [
+        {
+          tx: {
+            to: '0x1111111111111111111111111111111111111111',
+            data: '0x1234',
+          },
+          gasEstimate: 100n,
+        },
+      ],
+      4114,
+      'medium'
+    );
+
+    expect(request).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: 'eth_getBlockByNumber',
+        params: ['latest', false],
+      })
+    );
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: 'eth_estimateDiffSize',
+      })
+    );
+    expect(fee.l1Fee).toBe(34n);
+    expect(fee.l2Fee).toBe(1300n);
+    expect(fee.recommended.totalMaxCost).toBe(1840n);
   });
 
   it('has no separate L1 fee on default fee models', async () => {
@@ -225,6 +267,34 @@ describe('estimateTotalFees', () => {
     expect(context.overheads).toEqual([
       {
         l1Fee: 25n,
+        extraGas: 0n,
+      },
+    ]);
+  });
+
+  it('uses a Citrea diff-size hint without calling eth_estimateDiffSize', async () => {
+    request.mockResolvedValueOnce({ l1FeeRate: '0x2' });
+    const client = makeClient(4114);
+
+    const context = await estimateFeeContext(
+      client,
+      4114,
+      [
+        {
+          tx: {
+            to: '0x1111111111111111111111111111111111111111',
+            data: '0x1234',
+          },
+          l1DiffSizeHint: 120n,
+        },
+      ],
+      'medium'
+    );
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(context.overheads).toEqual([
+      {
+        l1Fee: 240n,
         extraGas: 0n,
       },
     ]);

--- a/tests/services/swapNativeReserveFee.test.ts
+++ b/tests/services/swapNativeReserveFee.test.ts
@@ -70,7 +70,7 @@ describe('estimateRepresentativeSwapNativeReserveFee', () => {
       [
         expect.objectContaining({
           gasEstimateKind: 'raw',
-          l1DiffSizeHint: 120n,
+          l1DiffSizeHint: 200n,
           tx: expect.objectContaining({
             to: '0x1111111111111111111111111111111111111111',
             value: 1n,
@@ -91,6 +91,8 @@ describe('estimateRepresentativeSwapNativeReserveFee', () => {
         chainId: 4114,
       })
     );
+    const [{ tx }] = estimateFeeContextMock.mock.calls[0]?.[2] ?? [];
+    expect((tx.data as string).length).toBeGreaterThan(4000);
     expect(result).toBe(120n);
   });
 });

--- a/tests/services/swapNativeReserveFee.test.ts
+++ b/tests/services/swapNativeReserveFee.test.ts
@@ -1,0 +1,96 @@
+import type { PublicClient } from 'viem';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const estimateFeeContextMock = vi.hoisted(() => vi.fn());
+const finalizeFeeEstimatesMock = vi.hoisted(() => vi.fn());
+const createPublicClientWithFallbackMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/services/feeEstimation', () => ({
+  estimateFeeContext: estimateFeeContextMock,
+  finalizeFeeEstimates: finalizeFeeEstimatesMock,
+}));
+
+vi.mock('../../src/sdk/ca-base/utils/contract.utils', () => ({
+  createPublicClientWithFallback: createPublicClientWithFallbackMock,
+}));
+
+import {
+  DEFAULT_SWAP_NATIVE_RESERVE_GAS,
+  estimateRepresentativeSwapNativeReserveFee,
+} from '../../src/services/swapNativeReserveFee';
+
+describe('estimateRepresentativeSwapNativeReserveFee', () => {
+  const client = {
+    chain: { id: 4114 },
+  } as unknown as PublicClient;
+  const chain = {
+    id: 4114,
+    nativeCurrency: {
+      decimals: 18,
+      name: 'cBTC',
+      symbol: 'cBTC',
+    },
+  } as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createPublicClientWithFallbackMock.mockReturnValue(client);
+    estimateFeeContextMock.mockResolvedValue({
+      chainId: 4114,
+      recommendation: {
+        maxFeePerGas: 10n,
+        maxPriorityFeePerGas: 2n,
+      },
+      overheads: [{ l1Fee: 0n, extraGas: 123n }],
+    });
+    finalizeFeeEstimatesMock.mockReturnValue([
+      {
+        l1Fee: 25n,
+        l2Fee: 75n,
+        total: 100n,
+        recommended: {
+          gasLimit: 1_800_000n,
+          maxFeePerGas: 11n,
+          maxPriorityFeePerGas: 2n,
+          totalMaxCost: 19_800_000n,
+          useLegacyPricing: true,
+        },
+      },
+    ]);
+  });
+
+  it('prices a representative raw calibur execute tx with fixed gas and synthetic buffering', async () => {
+    const result = await estimateRepresentativeSwapNativeReserveFee({
+      chain,
+    });
+
+    expect(estimateFeeContextMock).toHaveBeenCalledWith(
+      client,
+      4114,
+      [
+        expect.objectContaining({
+          gasEstimateKind: 'raw',
+          l1DiffSizeHint: 120n,
+          tx: expect.objectContaining({
+            to: '0x1111111111111111111111111111111111111111',
+            value: 1n,
+            data: expect.stringMatching(/^0x/),
+          }),
+        }),
+      ],
+      'medium'
+    );
+    expect(finalizeFeeEstimatesMock).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          gasEstimate: DEFAULT_SWAP_NATIVE_RESERVE_GAS,
+          gasEstimateKind: 'raw',
+        }),
+      ],
+      expect.objectContaining({
+        chainId: 4114,
+      })
+    );
+    expect(result).toBe(120n);
+  });
+});


### PR DESCRIPTION
- Add better estimation of l1 and l2 fees across different stacks
- Batch approval + execute if wallet supports it
- Synthetic estimation of deposit + native swap for deduction from usable balance
- Pass estimated gas and prices to wallets