### PR TITLE
fix native balance state override for bundle simulation on non-ethereum chains

### DIFF
--- a/src/core/utils/balance.utils.ts
+++ b/src/core/utils/balance.utils.ts
@@ -317,8 +317,8 @@ export const generateStateOverride = (params: {
   amount: bigint;
 }) => {
   const amountInHex = toHex(params.amount * 2n);
-  // FIXME: it should estimate for any other native token also
-  if (equalFold(params.tokenSymbol, 'ETH')) {
+  // Native currency on any EVM chain uses account balance override (not only ETH).
+  if (equalFold(params.tokenAddress, ZERO_ADDRESS)) {
     return {
       [params.userAddress]: {
         balance: amountInHex,

--- a/tests/sdk/ca-base/utils/balance.utils.test.ts
+++ b/tests/sdk/ca-base/utils/balance.utils.test.ts
@@ -30,7 +30,10 @@ vi.mock('../../../../src/core/utils/contract.utils', () => ({
 }));
 
 import { ZERO_ADDRESS } from '../../../../src/core/constants';
-import { getBalancesForSwap } from '../../../../src/core/utils/balance.utils';
+import {
+  generateStateOverride,
+  getBalancesForSwap,
+} from '../../../../src/core/utils/balance.utils';
 
 describe('getBalancesForSwap', () => {
   beforeEach(() => {
@@ -98,5 +101,41 @@ describe('getBalancesForSwap', () => {
       undefined,
       undefined
     );
+  });
+});
+
+describe('generateStateOverride', () => {
+  const user = '0x742d35Cc6634C0532925a3b8D4C9db96c4b4Db45' as const;
+  const usdcPolygon = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359' as const;
+
+  it('uses account balance for any native token (zero address), not only ETH', () => {
+    const amount = 1_000_000_000_000_000_000n;
+    const o = generateStateOverride({
+      tokenSymbol: 'POL',
+      tokenAddress: ZERO_ADDRESS,
+      chainId: 137,
+      userAddress: user,
+      amount,
+    });
+    expect(o).toEqual({
+      [user]: {
+        balance: '0x1bc16d674ec80000',
+      },
+    });
+  });
+
+  it('uses ERC-20 storage override for non-native tokens', () => {
+    const amount = 1_000_000n;
+    const o = generateStateOverride({
+      tokenSymbol: 'USDC',
+      tokenAddress: usdcPolygon,
+      chainId: 137,
+      userAddress: user,
+      amount,
+    });
+    expect(o).toMatchObject({
+      [usdcPolygon]: { storage: expect.any(Object) },
+      [user]: { balance: '0x186a0' },
+    });
   });
 });


### PR DESCRIPTION
## what was wrong
\generateStateOverride\ only applied the EVM **account balance** override when \	okenSymbol\ was \ETH\. For bridge-and-execute, gas estimation calls \simulateBundle\ with the destination token: native assets on Polygon (POL/MATIC), BNB, Avalanche, etc. use the zero address and are not named ETH. Those runs incorrectly went through the ERC-20 storage path, so backend bundle simulation did not model native balance the same way as on Ethereum.

## what changed
- treat **any** native token (zero / native contract address) like ETH for the state override, so native gas + execution simulation is consistent on every EVM chain.

## tests
- added unit coverage for \generateStateOverride\ (native POL on polygon + USDC ERC-20 case).

made by mooncitydev
