### PR TITLE
fix: swap reliability fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@avail-project/ca-common": "github:availproject/ca-common#fbfde6d04c2bf63bcb1753ea0f0a4e2047244b20",
+        "@avail-project/ca-common": "github:availproject/ca-common#44a75d132d742e0c38f1da9be6fdb100d9d4e9a5",
         "@cosmjs/proto-signing": "^0.34.1",
         "@cosmjs/stargate": "^0.34.1",
         "@metamask/safe-event-emitter": "3.1.2",
@@ -61,8 +61,8 @@
     },
     "node_modules/@avail-project/ca-common": {
       "version": "2.2.1",
-      "resolved": "git+ssh://git@github.com/availproject/ca-common.git#fbfde6d04c2bf63bcb1753ea0f0a4e2047244b20",
-      "integrity": "sha512-eBKmYN9X8qqPQjJ8tO+ipkgjAva2yFjbeMZwnFrB9DOa4YGrHDz6pdmVHh5YRG+i5T/w4bdPUsvvEaTCAgJXoA==",
+      "resolved": "git+ssh://git@github.com/availproject/ca-common.git#44a75d132d742e0c38f1da9be6fdb100d9d4e9a5",
+      "integrity": "sha512-4V0pW717qMFbQksmX71zKozOHtjuuyMRD1nfHsGmYJTHaRu/VvLBe1U0qTsRDPxK++Cb2fFk6B3UoAqzNNu6cQ==",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@avail-project/ca-common": "github:availproject/ca-common#44a75d132d742e0c38f1da9be6fdb100d9d4e9a5",
+        "@avail-project/ca-common": "github:availproject/ca-common#672c8bdddd44158f5bb4a297abc34dea079054f8",
         "@cosmjs/proto-signing": "^0.34.1",
         "@cosmjs/stargate": "^0.34.1",
         "@metamask/safe-event-emitter": "3.1.2",
@@ -61,8 +61,8 @@
     },
     "node_modules/@avail-project/ca-common": {
       "version": "2.2.1",
-      "resolved": "git+ssh://git@github.com/availproject/ca-common.git#44a75d132d742e0c38f1da9be6fdb100d9d4e9a5",
-      "integrity": "sha512-4V0pW717qMFbQksmX71zKozOHtjuuyMRD1nfHsGmYJTHaRu/VvLBe1U0qTsRDPxK++Cb2fFk6B3UoAqzNNu6cQ==",
+      "resolved": "git+ssh://git@github.com/availproject/ca-common.git#672c8bdddd44158f5bb4a297abc34dea079054f8",
+      "integrity": "sha512-h3Fx41D8MxFDIxgetduHi2117+YnTxD+u/Sj2YS4IOdobgXYHgTZiKp0pvScGv51VLjMAl2wrxSPAVpocEIpBQ==",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@avail-project/ca-common": "2.2.1",
+        "@avail-project/ca-common": "github:availproject/ca-common#fbfde6d04c2bf63bcb1753ea0f0a4e2047244b20",
         "@cosmjs/proto-signing": "^0.34.1",
         "@cosmjs/stargate": "^0.34.1",
         "@metamask/safe-event-emitter": "3.1.2",
@@ -61,8 +61,8 @@
     },
     "node_modules/@avail-project/ca-common": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@avail-project/ca-common/-/ca-common-2.2.1.tgz",
-      "integrity": "sha512-L8cI96UR+lMPW3EjAhw03NslV3gswDF71XALdrTrDyLp28YM1aBAXqGmB3aEJ8UatnXO5fZfv7mbj8rIe+ahgw==",
+      "resolved": "git+ssh://git@github.com/availproject/ca-common.git#fbfde6d04c2bf63bcb1753ea0f0a4e2047244b20",
+      "integrity": "sha512-eBKmYN9X8qqPQjJ8tO+ipkgjAva2yFjbeMZwnFrB9DOa4YGrHDz6pdmVHh5YRG+i5T/w4bdPUsvvEaTCAgJXoA==",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@avail-project/ca-common": "github:availproject/ca-common#672c8bdddd44158f5bb4a297abc34dea079054f8",
+        "@avail-project/ca-common": "2.3.0",
         "@cosmjs/proto-signing": "^0.34.1",
         "@cosmjs/stargate": "^0.34.1",
         "@metamask/safe-event-emitter": "3.1.2",
@@ -60,9 +60,9 @@
       "license": "MIT"
     },
     "node_modules/@avail-project/ca-common": {
-      "version": "2.2.1",
-      "resolved": "git+ssh://git@github.com/availproject/ca-common.git#672c8bdddd44158f5bb4a297abc34dea079054f8",
-      "integrity": "sha512-h3Fx41D8MxFDIxgetduHi2117+YnTxD+u/Sj2YS4IOdobgXYHgTZiKp0pvScGv51VLjMAl2wrxSPAVpocEIpBQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@avail-project/ca-common/-/ca-common-2.3.0.tgz",
+      "integrity": "sha512-BiO1vbhEBd/QBgaAuhoNUZHIvLk9ZdCerNyPugU2XbHNiAXPGXu9FVbAq2RXYd+NQwinLUJEwcCSYxUGrmZL3A==",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "npm": ">=9.0.0"
   },
   "dependencies": {
-    "@avail-project/ca-common": "github:availproject/ca-common#44a75d132d742e0c38f1da9be6fdb100d9d4e9a5",
+    "@avail-project/ca-common": "github:availproject/ca-common#672c8bdddd44158f5bb4a297abc34dea079054f8",
     "@cosmjs/proto-signing": "^0.34.1",
     "@cosmjs/stargate": "^0.34.1",
     "@metamask/safe-event-emitter": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "npm": ">=9.0.0"
   },
   "dependencies": {
-    "@avail-project/ca-common": "github:availproject/ca-common#fbfde6d04c2bf63bcb1753ea0f0a4e2047244b20",
+    "@avail-project/ca-common": "github:availproject/ca-common#44a75d132d742e0c38f1da9be6fdb100d9d4e9a5",
     "@cosmjs/proto-signing": "^0.34.1",
     "@cosmjs/stargate": "^0.34.1",
     "@metamask/safe-event-emitter": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "npm": ">=9.0.0"
   },
   "dependencies": {
-    "@avail-project/ca-common": "2.2.1",
+    "@avail-project/ca-common": "github:availproject/ca-common#fbfde6d04c2bf63bcb1753ea0f0a4e2047244b20",
     "@cosmjs/proto-signing": "^0.34.1",
     "@cosmjs/stargate": "^0.34.1",
     "@metamask/safe-event-emitter": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "npm": ">=9.0.0"
   },
   "dependencies": {
-    "@avail-project/ca-common": "github:availproject/ca-common#672c8bdddd44158f5bb4a297abc34dea079054f8",
+    "@avail-project/ca-common": "2.3.0",
     "@cosmjs/proto-signing": "^0.34.1",
     "@cosmjs/stargate": "^0.34.1",
     "@metamask/safe-event-emitter": "3.1.2",

--- a/src/core/ca.ts
+++ b/src/core/ca.ts
@@ -263,7 +263,7 @@ export class CA {
             mode: SwapMode.EXACT_IN,
             data: input,
           },
-          await this._getSwapOptions(options)
+          this._getSwapOptions(options)
         );
       } catch (e) {
         swapFailed = true;
@@ -290,7 +290,7 @@ export class CA {
             mode: SwapMode.EXACT_OUT,
             data: input,
           },
-          { ...(await this._getSwapOptions(options)), preloadedBalances }
+          { ...this._getSwapOptions(options), preloadedBalances }
         );
       } catch (e) {
         swapFailed = true;
@@ -304,29 +304,36 @@ export class CA {
 
   protected _calculateMaxForSwap = async (input: MaxSwapInput) => {
     return this.withReinit(async () => {
-      return calculateMaxForSwap(input, await this._getSwapOptions());
+      return calculateMaxForSwap(input, this._getSwapOptions());
     });
   };
 
   protected _swapAndExecute = async (input: SwapAndExecuteParams, options?: OnEventParam) => {
     return this.withReinit(async () => {
+      // `withReinit` has already synced `_evm.address` from the wallet; pass it through
+      // so SwapAndExecuteQuery doesn't re-issue `getAddresses()`.
       return new SwapAndExecuteQuery(
         this.chainList,
         this._evm!.client,
+        this._evm!.address,
         this._getBalancesForSwap,
         this._swapWithExactOut
       ).swapAndExecute(input, options);
     });
   };
 
-  private readonly _getSwapOptions = async (options?: OnEventParam): Promise<SwapParams> => {
+  // Only `withReinit`'s `reinitOnAccountChange` is allowed to call `wallet.getAddresses()`
+  // — it syncs the result into `_evm.address`. Every caller below `withReinit` reads the
+  // cached field instead; otherwise the same EOA is asked of the wallet 4–5 times per
+  // swap flow, each round-trip 50–200ms in some wallets.
+  private readonly _getSwapOptions = (options?: OnEventParam): SwapParams => {
     return {
       onSwapIntent: this._hooks.onSwapIntent,
       onEvent: options?.onEvent,
       chainList: this.chainList,
       address: {
         cosmos: this.#cosmos!.address,
-        eoa: (await this._evm!.client.getAddresses())[0],
+        eoa: this._evm!.address,
         ephemeral: this.#ephemeralWallet!.address,
       },
       wallet: {
@@ -769,9 +776,24 @@ export class CA {
     await this._init();
   };
 
+  // Re-entrancy guard: nested `withReinit` calls (e.g. swap-and-execute calls
+  // `_getBalancesForSwap` which also calls `withReinit`) used to re-issue
+  // `wallet.getAddresses()` each time. Within a single in-flight outer call the EOA
+  // can't have changed under us, so subsequent reentrant calls skip the wallet RPC.
+  // Counter increments/decrements bracket each call, including parallel arms, so a
+  // `Promise.all` of nested withReinit'd ops all see depth > 0 and short-circuit.
+  private _withReinitDepth = 0;
+
   private async withReinit<T>(fn: () => Promise<T>): Promise<T> {
-    await this.reinitOnAccountChange();
-    return fn();
+    if (this._withReinitDepth === 0) {
+      await this.reinitOnAccountChange();
+    }
+    this._withReinitDepth++;
+    try {
+      return await fn();
+    } finally {
+      this._withReinitDepth--;
+    }
   }
 
   protected _convertTokenReadableAmountToBigInt = (

--- a/src/core/ca.ts
+++ b/src/core/ca.ts
@@ -776,24 +776,9 @@ export class CA {
     await this._init();
   };
 
-  // Re-entrancy guard: nested `withReinit` calls (e.g. swap-and-execute calls
-  // `_getBalancesForSwap` which also calls `withReinit`) used to re-issue
-  // `wallet.getAddresses()` each time. Within a single in-flight outer call the EOA
-  // can't have changed under us, so subsequent reentrant calls skip the wallet RPC.
-  // Counter increments/decrements bracket each call, including parallel arms, so a
-  // `Promise.all` of nested withReinit'd ops all see depth > 0 and short-circuit.
-  private _withReinitDepth = 0;
-
   private async withReinit<T>(fn: () => Promise<T>): Promise<T> {
-    if (this._withReinitDepth === 0) {
-      await this.reinitOnAccountChange();
-    }
-    this._withReinitDepth++;
-    try {
-      return await fn();
-    } finally {
-      this._withReinitDepth--;
-    }
+    await this.reinitOnAccountChange();
+    return fn();
   }
 
   protected _convertTokenReadableAmountToBigInt = (

--- a/src/core/decimal-precision.ts
+++ b/src/core/decimal-precision.ts
@@ -1,0 +1,13 @@
+import Decimal from 'decimal.js';
+
+// Decimal.js defaults to 20 significant figures with ROUND_HALF_UP, which truncates
+// 21+ digit raw token amounts (≥100 tokens at 18 decimals — PEPE, SHIB, BONK, etc.)
+// on the first arithmetic op. The divDecimals → mulDecimals round-trip in
+// common.utils.ts then encodes a transferFrom amount up to ~5 wei above the user's
+// actual balance, causing the inner transfer to revert. Bumped to 50 sig figs,
+// which covers every realistic uint256 (max 78 digits; tokens cap ~30).
+//
+// IMPORTANT: do not remove. The Decimal.js global config is shared with
+// @avail-project/ca-common, which relies on this precision for selectSources /
+// liquidateSourceHoldings amount math.
+Decimal.set({ precision: 50 });

--- a/src/core/utils/api.utils.ts
+++ b/src/core/utils/api.utils.ts
@@ -11,7 +11,17 @@ import { remove, retry } from 'es-toolkit';
 import { connect } from 'it-ws/client';
 import type Long from 'long';
 import { pack, unpack } from 'msgpackr';
-import { bytesToBigInt, bytesToNumber, type Hex, toBytes, toHex } from 'viem';
+import {
+  bytesToBigInt,
+  bytesToHex,
+  bytesToNumber,
+  encodeFunctionData,
+  type Hex,
+  toBytes,
+  toHex,
+  zeroAddress,
+} from 'viem';
+import caliburAbi from '../../abi/calibur.abi';
 import {
   type AnkrAsset,
   type Chain,
@@ -731,23 +741,32 @@ const createVSCClient = ({ vscWsUrl, vscUrl }: { vscWsUrl: string; vscUrl: strin
       };
     },
     vscCreateSafeExecuteTx: async (input: SafeExecuteTx) => {
-      const response = await instance.post<TransactionHashResponse>('/create-safe-execute-tx', {
-        base_gas: convertTo32Bytes(input.baseGas),
-        chain_id: convertTo32Bytes(input.chainId),
-        data: toBytes(input.data),
-        gas_price: convertTo32Bytes(input.gasPrice),
-        gas_token: toBytes(input.gasToken),
-        nonce: convertTo32Bytes(input.nonce),
-        operation: input.operation,
-        refund_receiver: toBytes(input.refundReceiver),
-        safe_address: convertTo32Bytes(input.safeAddress),
-        safe_tx_gas: convertTo32Bytes(input.safeTxGas),
-        signature: toBytes(input.signature),
-        to: toBytes(input.to),
-        universe: Universe.ETHEREUM,
-        value: convertTo32Bytes(input.value),
-      });
-      return [BigInt(input.chainId), toHex(response.data.tx_hash)];
+      try {
+        const response = await instance.post<TransactionHashResponse>('/create-safe-execute-tx', {
+          base_gas: convertTo32Bytes(input.baseGas),
+          chain_id: convertTo32Bytes(input.chainId),
+          data: toBytes(input.data),
+          gas_price: convertTo32Bytes(input.gasPrice),
+          gas_token: toBytes(input.gasToken),
+          nonce: convertTo32Bytes(input.nonce),
+          operation: input.operation,
+          refund_receiver: toBytes(input.refundReceiver),
+          safe_address: convertTo32Bytes(input.safeAddress),
+          safe_tx_gas: convertTo32Bytes(input.safeTxGas),
+          signature: toBytes(input.signature),
+          to: toBytes(input.to),
+          universe: Universe.ETHEREUM,
+          value: convertTo32Bytes(input.value),
+        });
+        return [BigInt(input.chainId), toHex(response.data.tx_hash)];
+      } catch (error) {
+        logger.error('[TX_FAIL] safe_execute_relay_error', error, {
+          chainId: input.chainId,
+          safeAddress: input.safeAddress,
+        });
+        logger.debug('[TX_FAIL] safe_execute_relay_error:detail', safeExecuteTxToLogValue(input));
+        throw error;
+      }
     },
     vscSBCTx: async (input: SBCTx[]) => {
       const ops: [bigint, Hex][] = [];
@@ -764,9 +783,16 @@ const createVSCClient = ({ vscWsUrl, vscUrl }: { vscWsUrl: string; vscUrl: strin
             tx_hash: Uint8Array;
           } = unpack(response);
 
-          logger.debug('vscSBCTx', { data });
-
           if (data.errored) {
+            logger.error(
+              '[TX_FAIL] calibur_execute_relay_error',
+              new Error('Error in VSC SBC Tx'),
+              { chainIds: input.map((i) => bytesToNumber(i.chain_id)) }
+            );
+            // Detail at debug level: calldata contains the user's signature, must not leave the console.
+            logger.debug('[TX_FAIL] calibur_execute_relay_error:detail', {
+              txs: input.map(sbcTxToLogValue),
+            });
             throw Errors.internal('Error in VSC SBC Tx');
           }
 
@@ -782,6 +808,93 @@ const createVSCClient = ({ vscWsUrl, vscUrl }: { vscWsUrl: string; vscUrl: strin
         await connection.close();
       }
       return ops;
+    },
+  };
+};
+
+// Inlined to avoid a cross-layer import of SAFE_ABI from src/swap/.
+const SAFE_EXEC_TRANSACTION_ABI = [
+  {
+    inputs: [
+      { internalType: 'address', name: 'to', type: 'address' },
+      { internalType: 'uint256', name: 'value', type: 'uint256' },
+      { internalType: 'bytes', name: 'data', type: 'bytes' },
+      { internalType: 'uint8', name: 'operation', type: 'uint8' },
+      { internalType: 'uint256', name: 'safeTxGas', type: 'uint256' },
+      { internalType: 'uint256', name: 'baseGas', type: 'uint256' },
+      { internalType: 'uint256', name: 'gasPrice', type: 'uint256' },
+      { internalType: 'address', name: 'gasToken', type: 'address' },
+      { internalType: 'address', name: 'refundReceiver', type: 'address' },
+      { internalType: 'bytes', name: 'signatures', type: 'bytes' },
+    ],
+    name: 'execTransaction',
+    outputs: [{ internalType: 'bool', name: 'success', type: 'bool' }],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+] as const;
+
+const safeExecuteTxToLogValue = (input: SafeExecuteTx) => ({
+  chainId: input.chainId,
+  executeData: {
+    to: input.safeAddress,
+    // Relay submits with value=0; inner SafeTx value is in the encoded execTransaction args.
+    value: 0n,
+    data: encodeFunctionData({
+      abi: SAFE_EXEC_TRANSACTION_ABI,
+      functionName: 'execTransaction',
+      args: [
+        input.to,
+        input.value,
+        input.data,
+        input.operation,
+        input.safeTxGas,
+        input.baseGas,
+        input.gasPrice,
+        input.gasToken,
+        input.refundReceiver,
+        input.signature,
+      ],
+    }),
+  },
+});
+
+const sbcTxToLogValue = (input: SBCTx) => {
+  const calls = input.calls.map((c) => ({
+    to: bytesToHex(c.to_addr),
+    value: bytesToBigInt(c.value),
+    data: bytesToHex(c.data),
+  }));
+  const value = calls.reduce((acc, c) => acc + c.value, 0n);
+  return {
+    chainId: bytesToNumber(input.chain_id),
+    calls,
+    // For 7702 cold-start: apply these authorizations before simulating execute.
+    authorizationList: input.authorization_list.map((a) => ({
+      address: bytesToHex(a.address),
+      chainId: bytesToNumber(a.chain_id),
+      nonce: a.nonce,
+      r: bytesToHex(a.sig_r),
+      s: bytesToHex(a.sig_s),
+      v: a.sig_v,
+    })),
+    executeData: {
+      to: convertToHexAddressByUniverse(input.address, input.universe),
+      value,
+      data: encodeFunctionData({
+        abi: caliburAbi,
+        functionName: 'execute',
+        args: [
+          {
+            batchedCall: { calls, revertOnFailure: input.revert_on_failure },
+            nonce: bytesToBigInt(input.nonce),
+            keyHash: bytesToHex(input.key_hash),
+            executor: zeroAddress,
+            deadline: bytesToBigInt(input.deadline),
+          },
+          bytesToHex(input.signature),
+        ],
+      }),
     },
   };
 };

--- a/src/core/utils/balance.utils.ts
+++ b/src/core/utils/balance.utils.ts
@@ -38,6 +38,14 @@ const deductTransferFees = (
     return { ...balance, balance: adjusted };
   });
 
+// vservice /swap-balances returns `""` for balanceUsd (and tokenPrice) on unpriced long-tail
+// tokens — `new Decimal("")` throws downstream and rejects the whole route fetch. Coerce
+// empty/missing numeric strings to "0" at this boundary so the rest of the pipeline can
+// trust the values it sees. We don't want to *drop* unpriced assets: the user still holds
+// the balance, and surfacing it at $0 is more useful than hiding it.
+const normalizeDecimalString = (value: string | undefined | null): string =>
+  typeof value === 'string' && value.length > 0 ? value : '0';
+
 // vservice /swap-balances returns Ankr-shaped assets already merged across ankr + multicall
 // chains. Map them into the existing AnkrBalance shape so the downstream pipeline
 // (ankrBalanceToAssets, toFlatBalance) is unchanged.
@@ -47,8 +55,8 @@ const swapAssetsToAnkrBalances = (assets: AnkrAsset[]): AnkrBalance[] => {
     const chainID = Number.parseInt(asset.blockchain, 10);
     if (!Number.isFinite(chainID)) continue;
     out.push({
-      balance: asset.balance,
-      balanceUSD: asset.balanceUsd,
+      balance: normalizeDecimalString(asset.balance),
+      balanceUSD: normalizeDecimalString(asset.balanceUsd),
       chainID,
       tokenAddress: (asset.tokenType === 'ERC20' ? asset.contractAddress : ZERO_ADDRESS) as Hex,
       tokenData: {

--- a/src/core/utils/balance.utils.ts
+++ b/src/core/utils/balance.utils.ts
@@ -15,6 +15,7 @@ import {
   ankrBalanceToAssets,
   fetchTransferFees,
   getTokenSymbol,
+  type PublicClientList,
   toFlatBalance,
   vscBalancesToAssets,
 } from '../../swap/utils';
@@ -80,21 +81,31 @@ export const getBalancesForSwap = async (input: {
   oraclePrices?: OraclePriceResponse | Promise<OraclePriceResponse>;
   allowedSources?: Source[];
   removeSources?: Source[];
+  /** When supplied, fetchTransferFees reuses the cached batched clients (no fresh client per chain). */
+  publicClientList?: PublicClientList;
 }) => {
   const swapSupportedChains = input.chainList.chains.filter(
     (chain) =>
       chain.universe === Universe.ETHEREUM && (chain.ankrName !== '' || chain.swapSupported)
   );
 
-  const [swapAssets, transferFeesByChain] = await Promise.all([
-    input.vscClient.getSwapBalances(input.evmAddress),
-    fetchTransferFees(swapSupportedChains),
-  ]);
-
-  const mergedBalances = deductTransferFees(
-    swapAssetsToAnkrBalances(swapAssets),
-    transferFeesByChain
+  // Sequencing: balances first, transfer fees second. `fetchTransferFees` was previously
+  // fanned out across every swap-supported chain on every route calc — typically 11+ RPC
+  // batches just to estimate a fee that's only ever deducted from *native* balances
+  // (deductTransferFees skips non-native). Scoping the fanout to chains the user actually
+  // holds native on drops typical 11-chain fanout to 0–2. Wall clock difference is small;
+  // RPC-cost / throttling reduction is the win.
+  const swapAssets = await input.vscClient.getSwapBalances(input.evmAddress);
+  const ankrBalances = swapAssetsToAnkrBalances(swapAssets);
+  const nativeChainIds = new Set(
+    ankrBalances
+      .filter((b) => equalFold(b.tokenAddress, ZERO_ADDRESS) && new Decimal(b.balance).gt(0))
+      .map((b) => b.chainID)
   );
+  const chainsNeedingFees = swapSupportedChains.filter((c) => nativeChainIds.has(c.id));
+  const transferFeesByChain = await fetchTransferFees(chainsNeedingFees, input.publicClientList);
+
+  const mergedBalances = deductTransferFees(ankrBalances, transferFeesByChain);
 
   const assets = ankrBalanceToAssets(
     input.chainList,

--- a/src/core/utils/balance.utils.ts
+++ b/src/core/utils/balance.utils.ts
@@ -7,7 +7,6 @@ import {
   type ChainListType,
   logger,
   type OraclePriceResponse,
-  type Source,
   SUPPORTED_CHAINS,
   type VSCClient,
 } from '../../commons';
@@ -79,8 +78,6 @@ export const getBalancesForSwap = async (input: {
   filterWithSupportedTokens: boolean;
   /** Unused since vservice provides USD pricing; kept for API stability. */
   oraclePrices?: OraclePriceResponse | Promise<OraclePriceResponse>;
-  allowedSources?: Source[];
-  removeSources?: Source[];
   /** When supplied, fetchTransferFees reuses the cached batched clients (no fresh client per chain). */
   publicClientList?: PublicClientList;
 }) => {
@@ -95,6 +92,10 @@ export const getBalancesForSwap = async (input: {
   // (deductTransferFees skips non-native). Scoping the fanout to chains the user actually
   // holds native on drops typical 11-chain fanout to 0–2. Wall clock difference is small;
   // RPC-cost / throttling reduction is the win.
+  //
+  // Note: `allowedSources` / `removeSources` filtering used to live here — it now lives
+  // in `_exactOutRoute`'s refresh body so a refresh with a different fromSources doesn't
+  // have to refetch balances. This function always returns the unfiltered set.
   const swapAssets = await input.vscClient.getSwapBalances(input.evmAddress);
   const ankrBalances = swapAssetsToAnkrBalances(swapAssets);
   const nativeChainIds = new Set(
@@ -110,9 +111,7 @@ export const getBalancesForSwap = async (input: {
   const assets = ankrBalanceToAssets(
     input.chainList,
     mergedBalances,
-    input.filterWithSupportedTokens,
-    input.allowedSources,
-    input.removeSources
+    input.filterWithSupportedTokens
   );
   const balances = toFlatBalance(assets);
 

--- a/src/core/utils/common.utils.ts
+++ b/src/core/utils/common.utils.ts
@@ -1,3 +1,4 @@
+import '../decimal-precision'; // side-effect: sets Decimal.precision before any arithmetic
 import {
   type Bytes,
   DepositVEPacket,

--- a/src/flows/calculateMaxForSwap.ts
+++ b/src/flows/calculateMaxForSwap.ts
@@ -10,7 +10,11 @@ import { type MaxSwapInput, type MaxSwapResult, SwapMode, type SwapParams } from
 import { mulDecimals } from '../core/utils';
 import { BEBOP_API_KEY, LIFI_API_KEY } from '../swap/constants';
 import { determineSwapRoute } from '../swap/route';
-import { PublicClientList, validateDestinationChainForSwap } from '../swap/utils';
+import {
+  PublicClientList,
+  validateDestinationChainForSwap,
+  withAggregatorTiming,
+} from '../swap/utils';
 
 export const calculateMaxForSwap = async (
   input: MaxSwapInput,
@@ -21,9 +25,9 @@ export const calculateMaxForSwap = async (
   const publicClientList = new PublicClientList(options.chainList);
 
   const aggregators: Aggregator[] = [
-    new LiFiAggregator(LIFI_API_KEY),
-    new BebopAggregator(BEBOP_API_KEY),
-    new FibrousAggregator(),
+    withAggregatorTiming(new LiFiAggregator(LIFI_API_KEY), 'lifi'),
+    withAggregatorTiming(new BebopAggregator(BEBOP_API_KEY), 'bebop'),
+    withAggregatorTiming(new FibrousAggregator(), 'fibrous'),
   ];
   const swapRouteParams = { ...options, publicClientList, aggregators, cotCurrencyID: COT };
 

--- a/src/flows/calculateMaxForSwap.ts
+++ b/src/flows/calculateMaxForSwap.ts
@@ -10,11 +10,7 @@ import { type MaxSwapInput, type MaxSwapResult, SwapMode, type SwapParams } from
 import { mulDecimals } from '../core/utils';
 import { BEBOP_API_KEY, LIFI_API_KEY } from '../swap/constants';
 import { determineSwapRoute } from '../swap/route';
-import {
-  PublicClientList,
-  validateDestinationChainForSwap,
-  withAggregatorTiming,
-} from '../swap/utils';
+import { PublicClientList, validateDestinationChainForSwap } from '../swap/utils';
 
 export const calculateMaxForSwap = async (
   input: MaxSwapInput,
@@ -25,9 +21,9 @@ export const calculateMaxForSwap = async (
   const publicClientList = new PublicClientList(options.chainList);
 
   const aggregators: Aggregator[] = [
-    withAggregatorTiming(new LiFiAggregator(LIFI_API_KEY), 'lifi'),
-    withAggregatorTiming(new BebopAggregator(BEBOP_API_KEY), 'bebop'),
-    withAggregatorTiming(new FibrousAggregator(), 'fibrous'),
+    new LiFiAggregator(LIFI_API_KEY),
+    new BebopAggregator(BEBOP_API_KEY),
+    new FibrousAggregator(),
   ];
   const swapRouteParams = { ...options, publicClientList, aggregators, cotCurrencyID: COT };
 

--- a/src/flows/calculateMaxForSwap.ts
+++ b/src/flows/calculateMaxForSwap.ts
@@ -27,7 +27,9 @@ export const calculateMaxForSwap = async (
   ];
   const swapRouteParams = { ...options, publicClientList, aggregators, cotCurrencyID: COT };
 
-  const swapRoute = await determineSwapRoute(
+  // One-shot consumer: ignore the `refresh` half of the result — `calculateMaxForSwap`
+  // has no intent-approval loop to feed.
+  const { route: swapRoute } = await determineSwapRoute(
     {
       mode: SwapMode.EXACT_IN,
       data: {

--- a/src/flows/swap.ts
+++ b/src/flows/swap.ts
@@ -87,7 +87,16 @@ export const swap = async (
 
   const swapRouteParams = { ...options, publicClientList, aggregators, cotCurrencyID: COT };
 
-  let swapRoute = await determineSwapRoute(input, swapRouteParams);
+  // `determineSwapRoute` now returns `{ route, refresh }` where `refresh` re-runs the
+  // per-call work (aggregator quotes, intent build) against the closure-cached fee
+  // store / oracle prices / balances / chain executions. Hand `refresh` to
+  // `waitForIntentApproval` so user-driven refreshes skip the balance + slow-state
+  // refetches.
+  const { route: initialRoute, refresh: routeRefresh } = await determineSwapRoute(
+    input,
+    swapRouteParams
+  );
+  let swapRoute = initialRoute;
   let { source, destination, bridge, extras } = swapRoute;
 
   logger.debug('initial-swap-route', {
@@ -107,7 +116,7 @@ export const swap = async (
 
   swapRoute = await waitForIntentApproval(swapRoute, {
     input,
-    swapRouteParams,
+    routeRefresh,
     onSwapIntent: options.onSwapIntent,
     chainList: options.chainList,
     emitList: emitter.emitList,
@@ -359,7 +368,7 @@ const ensureSafeAccountsBeforeExecution = async ({
 
 type IntentApprovalContext = {
   input: SwapData;
-  swapRouteParams: Parameters<typeof determineSwapRoute>[1];
+  routeRefresh: (input: SwapData) => Promise<SwapRoute>;
   emitList: (steps: SwapStepType[]) => void;
 } & Pick<SwapParams, 'onSwapIntent' | 'chainList'>;
 
@@ -382,7 +391,9 @@ const waitForIntentApproval = async (
       updatedInput.data.fromSources = fromSources;
     }
 
-    currentRoute = await determineSwapRoute(updatedInput, ctx.swapRouteParams);
+    // Reuses the closure-cached fee store / oracle prices / balances / chain executions
+    // and only re-runs the per-call work (aggregator quotes, intent build).
+    currentRoute = await ctx.routeRefresh(updatedInput);
     logger.debug('refresh-swap-route', { swapRoute: currentRoute });
 
     ctx.emitList(createSwapSteps(currentRoute, ctx.chainList));

--- a/src/flows/swap.ts
+++ b/src/flows/swap.ts
@@ -294,7 +294,6 @@ const createSwapHandlerOptions = ({
   destinationChainID: input.data.toChainId,
   emitter,
   publicClientList,
-  slippage: 0.005,
   wallet: options.wallet,
   cosmosQueryClient: options.cosmosQueryClient,
   vscClient: options.vscClient,

--- a/src/flows/swap.ts
+++ b/src/flows/swap.ts
@@ -38,6 +38,7 @@ import {
   PublicClientList,
   type SwapMetadata,
   validateDestinationChainForSwap,
+  withAggregatorTiming,
 } from '../swap/utils';
 
 const logger = getLogger();
@@ -79,10 +80,14 @@ export const swap = async (
 
   emitter.emit(SWAP_STEPS.DETERMINING_SWAP());
 
+  // Each aggregator is wrapped so every getQuotes call logs `agg:<name> chains=[...]
+  // requests=N ms=...`. That attribution shows which aggregator × which chain combo is
+  // dominating wall clock inside autoSelectSources / getDstSwap (quote latency varies
+  // significantly by chain).
   const aggregators: Aggregator[] = [
-    new LiFiAggregator(LIFI_API_KEY),
-    new BebopAggregator(BEBOP_API_KEY),
-    new FibrousAggregator(),
+    withAggregatorTiming(new LiFiAggregator(LIFI_API_KEY), 'lifi'),
+    withAggregatorTiming(new BebopAggregator(BEBOP_API_KEY), 'bebop'),
+    withAggregatorTiming(new FibrousAggregator(), 'fibrous'),
   ];
 
   const swapRouteParams = { ...options, publicClientList, aggregators, cotCurrencyID: COT };
@@ -205,6 +210,11 @@ const calculatePerformance = () => {
     );
 
     const entries = performance.getEntries();
+
+    // Route-phase measures (route-fetch, route-dst-quote, route-source-quote,
+    // route-max-bridge-fee, route-verify) are printed inline by `printRouteTimings`
+    // in src/swap/route.ts — once per route call (initial + each refresh) — so they
+    // surface without having to complete the full swap flow.
 
     if (entries.some((entry) => entry.name === 'source-swap-tx-start')) {
       measures.push(

--- a/src/flows/swap.ts
+++ b/src/flows/swap.ts
@@ -38,7 +38,6 @@ import {
   PublicClientList,
   type SwapMetadata,
   validateDestinationChainForSwap,
-  withAggregatorTiming,
 } from '../swap/utils';
 
 const logger = getLogger();
@@ -80,14 +79,10 @@ export const swap = async (
 
   emitter.emit(SWAP_STEPS.DETERMINING_SWAP());
 
-  // Each aggregator is wrapped so every getQuotes call logs `agg:<name> chains=[...]
-  // requests=N ms=...`. That attribution shows which aggregator × which chain combo is
-  // dominating wall clock inside autoSelectSources / getDstSwap (quote latency varies
-  // significantly by chain).
   const aggregators: Aggregator[] = [
-    withAggregatorTiming(new LiFiAggregator(LIFI_API_KEY), 'lifi'),
-    withAggregatorTiming(new BebopAggregator(BEBOP_API_KEY), 'bebop'),
-    withAggregatorTiming(new FibrousAggregator(), 'fibrous'),
+    new LiFiAggregator(LIFI_API_KEY),
+    new BebopAggregator(BEBOP_API_KEY),
+    new FibrousAggregator(),
   ];
 
   const swapRouteParams = { ...options, publicClientList, aggregators, cotCurrencyID: COT };

--- a/src/flows/swapAndExecute.ts
+++ b/src/flows/swapAndExecute.ts
@@ -29,6 +29,11 @@ class SwapAndExecuteQuery {
   constructor(
     private chainList: ChainListType,
     private evmClient: WalletClient,
+    // EOA address resolved up-front by the caller (via `withReinit`, which already syncs
+    // `_evm.address` from the wallet). Avoids re-issuing `getAddresses()` on every entry
+    // point — wallet RPCs can add 50–200ms each and the value can't have changed in this
+    // window (`withReinit` already aborted/reinit'd on account change).
+    private address: Hex,
     private getBalancesForSwap: () => Promise<{
       assets: UserAssetDatum[];
       balances: FlatBalance[];
@@ -45,71 +50,106 @@ class SwapAndExecuteQuery {
 
     validateDestinationChainForSwap(this.chainList, toChainId);
 
-    const address = (await this.evmClient.getAddresses())[0];
-    const txs: Tx[] = [];
+    const address = this.address;
 
-    const { tx, approvalTx, dstChain, dstPublicClient } = await this.createTxsForExecute(
-      execute,
-      toChainId,
-      address
-    );
+    // `createTxsForExecute` is now sync — it builds a *speculative* approvalTx
+    // unconditionally (when params.tokenApproval is set) and surfaces the allowance-check
+    // params separately. The actual allowance read is run in parallel with everything else
+    // below, so it no longer blocks the parallel batch.
+    const { tx, speculativeApprovalTx, dstChain, dstPublicClient, allowanceCheck } =
+      this.createTxsForExecute(execute, toChainId);
 
     logger.debug('SwapAndExecute:2', {
       tx,
       dstPublicClient,
-      approvalTx,
+      speculativeApprovalTx,
     });
 
-    if (approvalTx) {
-      txs.push(approvalTx);
-    }
+    // Speculative: every parallel arm assumes the approval *might* be needed.
+    // - approvalGasPromise: estimateGas for the speculative approvalTx. Wasted if allowance
+    //   turns out to be sufficient, but the call runs in parallel either way.
+    // - feeContextPromise: includes the speculative approval in its items list. If approval
+    //   isn't actually needed, we trim `feeContext.overheads[0]` after Promise.all.
+    // - allowancePromise: the deciding read.
+    const allowancePromise = allowanceCheck
+      ? erc20GetAllowance(
+          {
+            contractAddress: allowanceCheck.token,
+            spender: allowanceCheck.spender,
+            owner: address,
+          },
+          dstPublicClient
+        )
+      : Promise.resolve(null);
 
-    txs.push(tx);
-
-    const approvalGasPromise = approvalTx
+    const approvalGasPromise = speculativeApprovalTx
       ? dstPublicClient
           .estimateGas({
-            to: approvalTx.to,
-            data: approvalTx.data,
-            value: approvalTx.value,
+            to: speculativeApprovalTx.to,
+            data: speculativeApprovalTx.data,
+            value: speculativeApprovalTx.value,
             account: address,
           })
           .catch(() => 70_000n)
       : Promise.resolve(0n);
 
+    const feeContextItems = [
+      ...(speculativeApprovalTx
+        ? [
+            {
+              tx: {
+                to: speculativeApprovalTx.to,
+                data: speculativeApprovalTx.data,
+                value: speculativeApprovalTx.value,
+              },
+              gasEstimateKind: 'final' as const,
+            },
+          ]
+        : []),
+      {
+        tx: {
+          to: tx.to,
+          data: tx.data,
+          value: tx.value,
+        },
+      },
+    ];
     const feeContextPromise = estimateFeeContext(
       dstPublicClient,
       toChainId,
-      [
-        ...(approvalTx
-          ? [
-              {
-                tx: {
-                  to: approvalTx.to,
-                  data: approvalTx.data,
-                  value: approvalTx.value,
-                },
-                gasEstimateKind: 'final' as const,
-              },
-            ]
-          : []),
-        {
-          tx: {
-            to: tx.to,
-            data: tx.data,
-            value: tx.value,
-          },
-        },
-      ],
+      feeContextItems,
       params.execute.gasPrice ?? 'medium'
     );
 
-    const [approvalGas, balances, dstTokenInfo, feeContext] = await Promise.all([
+    const [currentAllowance, approvalGas, balances, dstTokenInfo, feeContext] = await Promise.all([
+      allowancePromise,
       approvalGasPromise,
       this.getBalancesForSwap(),
       getTokenInfo(params.toTokenAddress, dstPublicClient, dstChain),
       feeContextPromise,
     ]);
+
+    // Decide whether approval is actually required now that we have the on-chain allowance.
+    const approvalTx: Tx | null =
+      allowanceCheck &&
+      currentAllowance !== null &&
+      currentAllowance < allowanceCheck.requiredAllowance
+        ? speculativeApprovalTx
+        : null;
+
+    // If we built feeContext with a speculative approval but the real allowance covers it,
+    // drop the leading overhead so `overheads` aligns with the real items list (one entry).
+    const effectiveFeeContext =
+      speculativeApprovalTx && !approvalTx
+        ? { ...feeContext, overheads: feeContext.overheads.slice(1) }
+        : feeContext;
+
+    const txs: Tx[] = [];
+    if (approvalTx) {
+      txs.push(approvalTx);
+    }
+    txs.push(tx);
+
     const fees = finalizeFeeEstimates(
       [
         ...(approvalTx
@@ -134,7 +174,7 @@ class SwapAndExecuteQuery {
           gasEstimate: params.execute.gas,
         },
       ],
-      feeContext
+      effectiveFeeContext
     );
     const approvalFee = approvalTx ? fees[0] : null;
     const txFee = fees[approvalTx ? 1 : 0];
@@ -164,7 +204,7 @@ class SwapAndExecuteQuery {
     });
 
     // 6. Determine gas or token needed via bridge
-    const { skipSwap, tokenAmount, gasAmount } = await this.calculateOptimalSwapAmount(
+    const { skipSwap, tokenAmount, gasAmount } = this.calculateOptimalSwapAmount(
       toChainId,
       dstTokenInfo.contractAddress,
       dstTokenInfo.decimals,
@@ -205,8 +245,21 @@ class SwapAndExecuteQuery {
     };
   }
 
-  private async createTxsForExecute(params: SwapExecuteParams, chainId: number, address: Hex) {
-    // 1. Check if dst chain data is available
+  // Sync — does no I/O. The allowance read used to live here, gating every parallel
+  // step downstream; the caller now runs it in parallel with balances / tokenInfo /
+  // feeContext via `allowanceCheck`. We always build the speculative approvalTx when
+  // `params.tokenApproval` is set so callers can both speculate (estimate gas, fold into
+  // feeContext) in parallel with the allowance check itself.
+  private createTxsForExecute(
+    params: SwapExecuteParams,
+    chainId: number
+  ): {
+    tx: Tx;
+    speculativeApprovalTx: Tx | null;
+    dstChain: Chain;
+    dstPublicClient: PublicClient;
+    allowanceCheck: { token: Hex; spender: Hex; requiredAllowance: bigint } | null;
+  } {
     const dstChain = this.chainList.getChainByID(chainId);
     if (!dstChain) {
       throw Errors.chainNotFound(chainId);
@@ -216,43 +269,29 @@ class SwapAndExecuteQuery {
       transport: http(dstChain.rpcUrls.default.http[0]),
     });
 
-    // 2. Check if token is supported
-    let approvalTx: Tx | null = null;
+    let speculativeApprovalTx: Tx | null = null;
+    let allowanceCheck: { token: Hex; spender: Hex; requiredAllowance: bigint } | null = null;
     if (params.tokenApproval) {
-      const spender = params.tokenApproval.spender;
-      const currentAllowance = await erc20GetAllowance(
-        {
-          contractAddress: params.tokenApproval.token,
-          spender: params.tokenApproval.spender,
-          owner: address,
-        },
-        dstPublicClient
-      );
-
       const requiredAllowance = BigInt(params.tokenApproval.amount);
-
-      logger.debug('SwapAndExecute:createTxsForExecute', {
+      speculativeApprovalTx = {
+        to: params.tokenApproval.token,
+        data: packERC20Approve(params.tokenApproval.spender, requiredAllowance),
+        value: 0n,
+      };
+      allowanceCheck = {
+        token: params.tokenApproval.token,
+        spender: params.tokenApproval.spender,
         requiredAllowance,
-        currentAllowance,
-        skipApproval: currentAllowance > requiredAllowance,
-      });
-      if (currentAllowance < requiredAllowance) {
-        approvalTx = {
-          to: params.tokenApproval.token,
-          data: packERC20Approve(spender, requiredAllowance),
-          value: 0n,
-        };
-      }
+      };
     }
 
-    // 4. Encode execute tx
     const tx: Tx = {
       to: params.to,
       value: params.value ?? 0n,
       data: params.data ?? '0x',
     };
 
-    return { tx, approvalTx, dstChain, dstPublicClient };
+    return { tx, speculativeApprovalTx, dstChain, dstPublicClient, allowanceCheck };
   }
 
   public async swapAndExecute(
@@ -380,14 +419,14 @@ class SwapAndExecuteQuery {
    * Calculate optimal bridge amount based on destination chain balance
    * Returns the exact amount needed to bridge, or indicates if bridge can be skipped entirely
    */
-  private async calculateOptimalSwapAmount(
+  private calculateOptimalSwapAmount(
     toChainId: number,
     tokenAddress: Hex,
     tokenDecimals: number,
     requiredTokenAmount: bigint,
     requiredGasAmount: bigint,
     balances: FlatBalance[]
-  ): Promise<{ skipSwap: boolean; tokenAmount: bigint; gasAmount: bigint }> {
+  ): { skipSwap: boolean; tokenAmount: bigint; gasAmount: bigint } {
     let skipSwap = true;
     let tokenAmount = requiredTokenAmount;
     let gasAmount = requiredGasAmount;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import './_polyfill';
+import './core/decimal-precision'; // must run before any Decimal arithmetic
 
 export { Environment } from '@avail-project/ca-common';
 // Analytics exports

--- a/src/services/swapNativeReserveFee.ts
+++ b/src/services/swapNativeReserveFee.ts
@@ -1,4 +1,4 @@
-import { encodeAbiParameters, encodeFunctionData, type Hex } from 'viem';
+import { encodeAbiParameters, encodeFunctionData, type Hex, type PublicClient } from 'viem';
 import CaliburABI from '../abi/calibur.abi';
 import type { Chain } from '../commons';
 import { SUPPORTED_CHAINS } from '../commons/constants';
@@ -108,13 +108,17 @@ export const estimateRepresentativeSwapNativeReserveFee = async ({
   gasEstimate = DEFAULT_SWAP_NATIVE_RESERVE_GAS,
   priceTier = DEFAULT_PRICE_TIER,
   syntheticBufferMultiplier = DEFAULT_SYNTHETIC_SWAP_BUFFER,
+  publicClient,
 }: {
   chain: Chain;
   gasEstimate?: bigint;
   priceTier?: PriceTier;
   syntheticBufferMultiplier?: bigint;
+  // Optional: reuse a cached PublicClient (typically from `PublicClientList`) to avoid
+  // re-handshaking on every route calc. Falls back to a fresh fallback-RPC client.
+  publicClient?: PublicClient;
 }): Promise<bigint> => {
-  const client = createPublicClientWithFallback(chain);
+  const client = publicClient ?? createPublicClientWithFallback(chain);
   const tx = buildRepresentativeSourceExecutionTx();
   const feeContext = await estimateFeeContext(
     client,

--- a/src/services/swapNativeReserveFee.ts
+++ b/src/services/swapNativeReserveFee.ts
@@ -11,6 +11,18 @@ import {
 } from './feeEstimation';
 
 export const DEFAULT_SWAP_NATIVE_RESERVE_GAS = 1_500_000n;
+// Safe-mode chains (non-pectra, e.g. HyperEVM) execute via `Safe.execTransaction`, which adds
+// signature verification + `multiSend` DELEGATECALL fan-out on top of the inner aggregator
+// calls. Empirically the live submission on HyperEVM consumes ~6× the Calibur representative
+// gas — and HyperEVM's small-block limit is 3M, so anything above that wouldn't even fit a
+// small block. Reserve against the 3M ceiling so the EOA always retains enough native for the
+// worst small-block-sized Safe execution. Production failure that motivated this: chainId 999,
+// `value+gas` 849,636,684,432,245 vs EOA balance 529,093,107,360,245.
+export const SAFE_ACCOUNT_SWAP_NATIVE_RESERVE_GAS = 3_000_000n;
+
+// Inlined to avoid pulling `swap/route` (and its transitive ca-common surface) into the
+// services layer. Mirrors `requiresSafeAccount` in src/swap/route.ts:123.
+const usesSafeExecution = (chain: Chain) => chain.swapSupported && !chain.pectraUpgradeSupport;
 
 const DEFAULT_PRICE_TIER: PriceTier = 'medium';
 const DEFAULT_SYNTHETIC_SWAP_BUFFER = 120n;
@@ -105,7 +117,7 @@ const buildRepresentativeSourceExecutionTx = (): TxRequest => {
 
 export const estimateRepresentativeSwapNativeReserveFee = async ({
   chain,
-  gasEstimate = DEFAULT_SWAP_NATIVE_RESERVE_GAS,
+  gasEstimate,
   priceTier = DEFAULT_PRICE_TIER,
   syntheticBufferMultiplier = DEFAULT_SYNTHETIC_SWAP_BUFFER,
   publicClient,
@@ -119,6 +131,11 @@ export const estimateRepresentativeSwapNativeReserveFee = async ({
   publicClient?: PublicClient;
 }): Promise<bigint> => {
   const client = publicClient ?? createPublicClientWithFallback(chain);
+  const effectiveGasEstimate =
+    gasEstimate ??
+    (usesSafeExecution(chain)
+      ? SAFE_ACCOUNT_SWAP_NATIVE_RESERVE_GAS
+      : DEFAULT_SWAP_NATIVE_RESERVE_GAS);
   const tx = buildRepresentativeSourceExecutionTx();
   const feeContext = await estimateFeeContext(
     client,
@@ -133,7 +150,7 @@ export const estimateRepresentativeSwapNativeReserveFee = async ({
     priceTier
   );
   const [feeEstimate] = finalizeFeeEstimates(
-    [{ tx, gasEstimate, gasEstimateKind: 'raw' }],
+    [{ tx, gasEstimate: effectiveGasEstimate, gasEstimateKind: 'raw' }],
     feeContext
   );
 

--- a/src/swap/intent.ts
+++ b/src/swap/intent.ts
@@ -38,7 +38,7 @@ export const createSwapIntent = (
     : dstAmount;
 
   const gasAmount = destination.swap.gasSwap?.quote?.output.amount ?? '0';
-  const gasValue = destination.swap.gasSwap?.quote?.output.value.toString() ?? '0';
+  const gasValue = destination.swap.gasSwap?.quote?.output.value?.toString() ?? '0';
 
   // Bridge fees
   let totalBridgeFee = new Decimal(0);

--- a/src/swap/intent.ts
+++ b/src/swap/intent.ts
@@ -15,25 +15,30 @@ export const createSwapIntent = (
   const dstChain = chainList.getChainByID(input.data.toChainId);
   if (!dstChain) throw Errors.chainNotFound(input.data.toChainId);
 
-  // Destination token amount. For EXACT_OUT, input.data.toAmount can be a sentinel
-  // (-1n exact, <-1n surplus) meaning "no bridging for toToken" — clamp to 0n for display,
-  // matching the gas side (which shows '0' when no gas swap is needed).
+  // Destination token amount. Prefer the aggregator's quoted output — it's the guaranteed
+  // floor (on-chain actual ≥ quote), so for EXACT_OUT it's ≥ the user-requested toAmount
+  // and reflects what the user will actually receive. Fallback applies when there's no
+  // tokenSwap: EXACT_OUT direct COT transfer or sentinel toAmount (-1n exact, <-1n surplus)
+  // shows the user-requested amount (clamped to 0n for sentinels, matching gas side);
+  // EXACT_IN with no swap means dst token IS COT, so the COT input amount is the output.
   const dstAmount =
-    input.mode === SwapMode.EXACT_OUT
+    destination.swap.tokenSwap?.quote.output.amount ??
+    (input.mode === SwapMode.EXACT_OUT
       ? divDecimals(
           input.data.toAmount > 0n ? input.data.toAmount : 0n,
           dstTokenInfo.decimals
         ).toFixed()
-      : (destination.swap.tokenSwap?.quote.output.amount ?? destination.inputAmount.min.toFixed());
+      : destination.inputAmount.min.toFixed());
 
-  // Destination USD value — COT input to the token swap is the USDC cost.
-  // If there's no token swap the destination token is already COT (USDC), so amount ≈ USD.
+  // Destination USD value — the aggregator's quote carries an explicit USD `value` for both
+  // sides; use the output's value since it pairs with the output amount shown above. Fallback
+  // when there's no tokenSwap: the destination token is already COT (USDC), so amount ≈ USD.
   const dstValue = destination.swap.tokenSwap
-    ? destination.swap.tokenSwap.quote.input.amount
+    ? destination.swap.tokenSwap.quote.output.value.toString()
     : dstAmount;
 
   const gasAmount = destination.swap.gasSwap?.quote?.output.amount ?? '0';
-  const gasValue = destination.swap.gasSwap?.quote?.input.amount ?? '0';
+  const gasValue = destination.swap.gasSwap?.quote?.output.value.toString() ?? '0';
 
   // Bridge fees
   let totalBridgeFee = new Decimal(0);

--- a/src/swap/ob.ts
+++ b/src/swap/ob.ts
@@ -1,15 +1,11 @@
 import {
   type Aggregator,
-  autoSelectSources,
   type Bytes,
   ChaindataMap,
   type CurrencyID,
-  getDestinationExactInSwap,
-  liquidateInputHoldings,
   liquidateSourceHoldings,
   OmniversalChainID,
   type Quote,
-  type QuoteResponse,
   Universe,
 } from '@avail-project/ca-common';
 import type { SigningStargateClient } from '@cosmjs/stargate';
@@ -34,7 +30,7 @@ import { Errors } from '../core/errors';
 import { divDecimals, equalFold, minutesToMs, switchChain, waitForTxReceipt } from '../core/utils';
 import { EADDRESS, SWEEPER_ADDRESS } from './constants';
 import { createBridgeRFF } from './rff';
-import { COMBINED_SAME_CHAIN_BUFFER_PCT, type SwapRoute } from './route';
+import type { SwapRoute } from './route';
 import { createSafeExecuteEOASubmittedTx, createSafeExecuteTxFromCalls } from './safetx';
 import { caliburExecute, checkAuthCodeSet, createSBCTxFromCalls, waitForSBCTxReceipt } from './sbc';
 import {
@@ -73,7 +69,6 @@ type Options = {
     emit: (step: SwapStepType) => void;
   };
   publicClientList: PublicClientList;
-  slippage: number;
   wallet: {
     cosmos: SigningStargateClient;
     eoa: WalletClient;
@@ -82,6 +77,63 @@ type Options = {
 } & QueryClients;
 
 const logger = getLogger();
+
+/**
+ * Re-quote the given source-leg holdings with their original input amounts (so no
+ * re-approval/permit is needed) and verify the combined new COT output stays within
+ * `srcBuffer` of the old total. Shared by SourceSwapsHandler.retryWithSlippageCheck
+ * (partial retry — failed-chain subset) and CombinedSwapHandler.requoteBothLegs
+ * (full retry — atomic batch). Wraps the aggregator call in `retry` to absorb
+ * transient quote failures. Throws on no quotes or buffer breach.
+ */
+const liquidateAndCheckSrcBuffer = async ({
+  oldSwaps,
+  holdings,
+  srcBuffer,
+  aggregators,
+  commonCurrencyID,
+  errorPrefix,
+}: {
+  oldSwaps: SwapRoute['source']['swaps'];
+  holdings: Parameters<typeof liquidateSourceHoldings>[0]['holdings'];
+  srcBuffer: Decimal;
+  aggregators: Aggregator[];
+  commonCurrencyID: CurrencyID;
+  errorPrefix: string;
+}): Promise<SwapRoute['source']['swaps']> => {
+  const newSwaps = await retry(
+    () => liquidateSourceHoldings({ holdings, aggregators, commonCurrencyID }),
+    { retries: 2 }
+  );
+  if (newSwaps.length === 0) {
+    throw Errors.quoteFailed(`${errorPrefix}: source re-quote returned no quotes`);
+  }
+
+  const oldTotal = oldSwaps.reduce(
+    (acc, q) => acc.add(divDecimals(q.quote.output.amountRaw, q.quote.output.decimals)),
+    new Decimal(0)
+  );
+  const newTotal = newSwaps.reduce(
+    (acc, q) => acc.add(divDecimals(q.quote.output.amountRaw, q.quote.output.decimals)),
+    new Decimal(0)
+  );
+
+  if (oldTotal.gt(0)) {
+    const minAcceptable = Decimal.max(oldTotal.sub(srcBuffer), 0);
+    logger.debug(`${errorPrefix}: source buffer check`, {
+      oldTotal: oldTotal.toFixed(),
+      newTotal: newTotal.toFixed(),
+      srcBuffer: srcBuffer.toFixed(),
+    });
+    if (newTotal.lt(minAcceptable)) {
+      throw Errors.slippageError(
+        `${errorPrefix}: source COT output dropped from ${oldTotal.toFixed()} to ${newTotal.toFixed()} (>${srcBuffer.toFixed()} buffer)`
+      );
+    }
+  }
+
+  return newSwaps;
+};
 
 class BridgeHandler {
   private depositCalls: RFFDepositCallMap = {};
@@ -1023,90 +1075,41 @@ class SourceSwapsHandler {
     }
   }
 
-  // Re-quote source legs that reverted, then enforce that the combined output drop fits
-  // inside the route's pre-allocated source buffer. The buffer (srcBuffer in COT units,
-  // sized as `min(2%, $1)` of bridgeOutputWithFees for EXACT_OUT, 0 for EXACT_IN) is the
-  // only headroom the bridge step has — re-quote drops larger than that would underflow
-  // the bridge's input requirement. A static slippage % is unrelated to that requirement
-  // and was previously over- or under-strict depending on the failed-leg output size.
+  // Re-quote source legs on the failed chains via the shared `liquidateAndCheckSrcBuffer`
+  // helper, then re-enter `process`. The buffer (sized as `min(2%, $1)` of
+  // bridgeOutputWithFees for EXACT_OUT, `min(0.5%, $1)` of swapCombinedBalance for
+  // EXACT_IN) is the headroom the bridge step has — re-quote drops larger than that
+  // would underflow the bridge's input requirement.
   async retryWithSlippageCheck(metadata: SwapMetadata, failedChains: number[]) {
-    let oldTotalOutput = new Decimal(0);
-
-    logger.debug('sourceSwapsHandler:retryWithSlippageCheck:0', {
-      failedChains,
-      srcBuffer: this.srcBuffer.toFixed(),
-    });
-
-    const quoteResponses = await retry(
-      () => {
-        const quoteRequests = [];
-        // if it comes to retry it should be set to 0
-        oldTotalOutput = new Decimal(0);
-        for (const fChain of failedChains) {
-          const oldSwaps = this.swapsData.get(fChain);
-          if (!oldSwaps) {
-            logger.debug('how can old quote not be there???? we are iterating on it');
-            continue;
-          }
-          for (const oldSwap of oldSwaps) {
-            oldTotalOutput = oldTotalOutput.add(
-              divDecimals(oldSwap.quote.output.amountRaw, oldSwap.quote.output.decimals)
-            );
-            logger.debug('retryWithSlippage:quoteRequests:1', {
-              holding: {
-                amount: oldSwap.quote.input.amountRaw,
-                tokenAddress: oldSwap.quote.input.contractAddress,
-              },
-            });
-            quoteRequests.push(
-              liquidateInputHoldings(
-                convertTo32Bytes(this.getSourceExecution(fChain).address),
-                [
-                  {
-                    ...oldSwap.holding,
-                    amountRaw: oldSwap.quote.input.amountRaw,
-                    tokenAddress: convertTo32Bytes(oldSwap.quote.input.contractAddress),
-                  },
-                ],
-                this.options.aggregators,
-                this.options.cot.currencyID
-              ).then((nq) => {
-                logger.debug('retryWithSlippage:quoteRequests:2', {
-                  newQuote: nq[0],
-                });
-
-                const q = nq[0];
-                return q;
-              })
-            );
-          }
-        }
-
-        return Promise.all(quoteRequests);
-      },
-      { retries: 2 }
-    );
-
-    let newTotalOutput = new Decimal(0);
-    for (const q of quoteResponses) {
-      newTotalOutput = newTotalOutput.add(
-        divDecimals(q.quote.output.amountRaw, q.quote.output.decimals)
-      );
+    const oldSwaps: SwapRoute['source']['swaps'] = [];
+    const holdings: Parameters<typeof liquidateSourceHoldings>[0]['holdings'] = [];
+    for (const fChain of failedChains) {
+      const chainSwaps = this.swapsData.get(fChain);
+      if (!chainSwaps) {
+        logger.debug('how can old quote not be there???? we are iterating on it');
+        continue;
+      }
+      const swapAddress = convertTo32Bytes(this.getSourceExecution(fChain).address);
+      for (const oldSwap of chainSwaps) {
+        oldSwaps.push(oldSwap);
+        holdings.push({
+          ...oldSwap.holding,
+          amountRaw: oldSwap.quote.input.amountRaw,
+          tokenAddress: convertTo32Bytes(oldSwap.quote.input.contractAddress),
+          takerAddress: swapAddress,
+          receiverAddress: swapAddress,
+        });
+      }
     }
 
-    const minAcceptable = oldTotalOutput.sub(this.srcBuffer);
-    logger.debug('sourceSwapsHandler:retryWithSlippageCheck:1', {
-      minAcceptable: minAcceptable.toFixed(),
-      newTotalOutput: newTotalOutput.toFixed(),
-      oldTotalOutput: oldTotalOutput.toFixed(),
-      quoteResponses,
-      srcBuffer: this.srcBuffer.toFixed(),
+    const quoteResponses = await liquidateAndCheckSrcBuffer({
+      oldSwaps,
+      holdings,
+      srcBuffer: this.srcBuffer,
+      aggregators: this.options.aggregators,
+      commonCurrencyID: this.options.cot.currencyID,
+      errorPrefix: 'source swap retry',
     });
-    if (newTotalOutput.lt(minAcceptable)) {
-      throw Errors.slippageError(
-        `source swap retry exceeded srcBuffer: dropped from ${oldTotalOutput.toFixed()} to ${newTotalOutput.toFixed()} (>${this.srcBuffer.toFixed()} buffer)`
-      );
-    }
 
     return this.process(metadata, this.groupAndOrder(quoteResponses), false);
   }
@@ -1165,12 +1168,12 @@ const COMBINED_MAX_RETRIES = 2;
  * batch is atomic: a partial failure reverts everything and the user's input stays at the EOA.
  */
 class CombinedSwapHandler {
-  private readonly initialDstOutputAmountRaw: bigint;
+  private readonly srcBuffer: Decimal;
   constructor(
     private route: SwapRoute,
     private readonly options: Options
   ) {
-    this.initialDstOutputAmountRaw = route.destination.swap.tokenSwap?.quote.output.amountRaw ?? 0n;
+    this.srcBuffer = route.source.srcBuffer ?? new Decimal(0);
   }
 
   async process(metadata: SwapMetadata): Promise<void> {
@@ -1388,9 +1391,6 @@ class CombinedSwapHandler {
   }
 
   private async requoteBothLegs(): Promise<void> {
-    const execAddr = this.route.destination.execution.address;
-    const dstChainId = this.route.destination.chainId;
-
     const holdings = this.route.source.swaps.map((swap) => {
       const execution = this.route.source.executions[Number(swap.chainID)];
       if (!execution) {
@@ -1406,164 +1406,42 @@ class CombinedSwapHandler {
       };
     });
 
-    const dstOmni = new OmniversalChainID(Universe.ETHEREUM, dstChainId);
-    const dstSwapTakerInBytes = convertTo32Bytes(execAddr);
-    const dstSwapReceiverInBytes = convertTo32Bytes(this.options.address.eoa);
-
-    if (this.route.type === 'EXACT_IN') {
-      // EXACT_IN: source produces COT, dst consumes (source output * (1 - buffer)).
-      // Order: re-quote source → guard source-output slippage → re-quote dst with fresh
-      // buffered input → guard dst-output slippage.
-
-      const oldSrcOutputRaw = this.route.source.swaps.reduce(
-        (acc, q) => acc + q.quote.output.amountRaw,
-        0n
-      );
-
-      const newSrcSwaps = await liquidateSourceHoldings({
+    // Source-leg re-quote + buffer check is the same for both directions (mirrors
+    // SourceSwapsHandler.retryWithSlippageCheck via the shared helper). The dst re-quote
+    // delegates to the route closure's `getDstSwap` (which carries its own rate guard,
+    // mirroring DestinationSwapHandler.requoteIfRequired). For EXACT_OUT we re-quote dst
+    // first so its `ratesChangedBeyondTolerance` against `originalMax` fails fast before
+    // we spend a source quote; EXACT_IN's closure uses a fixed dst input from initial
+    // routing so order doesn't matter and we use the same shape.
+    const requoteSource = () =>
+      liquidateAndCheckSrcBuffer({
+        oldSwaps: this.route.source.swaps,
         holdings,
+        srcBuffer: this.srcBuffer,
         aggregators: this.route.extras.aggregators,
         commonCurrencyID: this.options.cot.currencyID,
+        errorPrefix: 'combined retry',
       });
-      if (newSrcSwaps.length === 0) {
-        throw Errors.quoteFailed('combined retry: source re-quote returned no quotes');
+
+    let newDstSwap: SwapRoute['destination']['swap'];
+    let newSrcSwaps: SwapRoute['source']['swaps'];
+    if (this.route.type === 'EXACT_OUT') {
+      const dstSwap = await this.route.destination.getDstSwap();
+      if (!dstSwap) {
+        throw Errors.quoteFailed('combined retry: getDstSwap returned null');
       }
-
-      const newSrcOutputRaw = newSrcSwaps.reduce((acc, q) => acc + q.quote.output.amountRaw, 0n);
-
-      // Source slippage guard. Runs unconditionally, including the toToken == COT case
-      // where there is no dst tokenSwap to absorb a worse source quote downstream.
-      if (oldSrcOutputRaw > 0n) {
-        const minAcceptableSrc =
-          (oldSrcOutputRaw * BigInt(Math.round((1 - this.options.slippage) * 1_000_000))) /
-          1_000_000n;
-        if (newSrcOutputRaw < minAcceptableSrc) {
-          throw Errors.slippageError(
-            `combined retry: source COT output dropped from ${oldSrcOutputRaw} to ${newSrcOutputRaw} (>${this.options.slippage} slippage)`
-          );
-        }
-      }
-
-      let newDst: QuoteResponse | null = null;
-      if (this.route.destination.swap.tokenSwap) {
-        // The batch transfers any pre-existing dst-chain COT from the EOA into the wrapper
-        // alongside the source-swap output. The dst aggregator can spend all of it, so
-        // include both in availableCotRaw before applying the slippage buffer. The source
-        // slippage guard above intentionally ignores this fixed credit — it's not source
-        // quote performance.
-        const directCotRaw = this.route.destination.eoaToDestinationAccount?.amount ?? 0n;
-        const availableCotRaw = newSrcOutputRaw + directCotRaw;
-        const bufferedInput =
-          (availableCotRaw * BigInt(Math.round((100 - COMBINED_SAME_CHAIN_BUFFER_PCT) * 1000))) /
-          100_000n;
-        const outputTokenBytes = convertTo32Bytes(
-          this.route.destination.swap.tokenSwap.quote.output.contractAddress
-        );
-        newDst = await getDestinationExactInSwap({
-          takerAddress: dstSwapTakerInBytes,
-          receiverAddress: dstSwapReceiverInBytes,
-          chain: dstOmni,
-          inputAmount: bufferedInput,
-          outputToken: outputTokenBytes,
-          aggregators: this.route.extras.aggregators,
-          inputCurrency: this.options.cot.currencyID,
-        });
-
-        if (this.initialDstOutputAmountRaw > 0n) {
-          const minAcceptableDst =
-            (this.initialDstOutputAmountRaw *
-              BigInt(Math.round((1 - this.options.slippage) * 1_000_000))) /
-            1_000_000n;
-          if (newDst.quote.output.amountRaw < minAcceptableDst) {
-            throw Errors.slippageError(
-              `combined retry: dst output dropped from ${this.initialDstOutputAmountRaw} to ${newDst.quote.output.amountRaw} (>${this.options.slippage} slippage)`
-            );
-          }
-        }
-      }
-
-      this.route.source.swaps = newSrcSwaps;
-      if (newDst) {
-        this.route.destination.swap = {
-          creationTime: Date.now(),
-          gasSwap: this.route.destination.swap.gasSwap,
-          tokenSwap: newDst,
-        };
-      }
-      return;
-    }
-
-    // EXACT_OUT: dst legs (tokenSwap + gasSwap + direct COT transfer) define the COT
-    // requirement that source must satisfy. Re-quote dst first via the route closure so
-    // its rate/max-input guard runs (throws ratesChangedBeyondTolerance when the new dst
-    // input exceeds the originally approved max). Only then size the source re-selection
-    // off the refreshed dst requirement so we never carry forward a stale gasSwap or a
-    // mismatched outputRequired.
-    const newDstSwap = await this.route.destination.getDstSwap();
-    if (!newDstSwap) {
-      throw Errors.quoteFailed('combined retry: getDstSwap returned null');
-    }
-
-    // Fresh COT requirement at the wrapper. When tokenSwap is null (toToken == COT and
-    // the user wants exact-COT delivered), the closure encodes the direct-transfer amount
-    // into inputAmount.max already, so we fall back to that.
-    let outputRequired: Decimal;
-    if (newDstSwap.tokenSwap) {
-      outputRequired = new Decimal(newDstSwap.tokenSwap.quote.input.amount);
-      if (newDstSwap.gasSwap) {
-        outputRequired = outputRequired.add(newDstSwap.gasSwap.quote.input.amount);
-      }
+      newDstSwap = dstSwap;
+      newSrcSwaps = await requoteSource();
     } else {
-      outputRequired = this.route.destination.inputAmount.max;
-    }
-
-    // Credit any dst-chain COT the batch pulls in from the user's EOA. autoSelectSources
-    // only sees the prior source holdings — without this credit it would size the source
-    // legs to produce the full requirement again, over-spending the user's source input.
-    if (this.route.destination.eoaToDestinationAccount) {
-      const cotDecimals =
-        newDstSwap.tokenSwap?.quote.input.decimals ??
-        newDstSwap.gasSwap?.quote.input.decimals ??
-        ChaindataMap.get(new OmniversalChainID(Universe.ETHEREUM, dstChainId))?.Currencies.find(
-          (c) => c.currencyID === this.options.cot.currencyID
-        )?.decimals;
-      if (cotDecimals === undefined) {
-        throw Errors.internal(
-          `combined retry: COT decimals not resolvable for chain ${dstChainId}`
-        );
+      newSrcSwaps = await requoteSource();
+      const dstSwap = await this.route.destination.getDstSwap();
+      if (!dstSwap) {
+        throw Errors.quoteFailed('combined retry: getDstSwap returned null');
       }
-      const directCotAmount = divDecimals(
-        this.route.destination.eoaToDestinationAccount.amount,
-        cotDecimals
-      );
-      outputRequired = Decimal.max(outputRequired.minus(directCotAmount), new Decimal(0));
+      newDstSwap = dstSwap;
     }
 
-    const { quoteResponses } = await autoSelectSources({
-      holdings,
-      outputRequired,
-      aggregators: this.route.extras.aggregators,
-      commonCurrencyID: this.options.cot.currencyID,
-    });
-    if (quoteResponses.length === 0) {
-      throw Errors.quoteFailed('combined retry: source re-quote returned no quotes');
-    }
-
-    // Dst output slippage guard against the user-visible toAmount. Cheap belt-and-braces
-    // on top of the closure's own rate guard.
-    if (newDstSwap.tokenSwap && this.initialDstOutputAmountRaw > 0n) {
-      const minAcceptableDst =
-        (this.initialDstOutputAmountRaw *
-          BigInt(Math.round((1 - this.options.slippage) * 1_000_000))) /
-        1_000_000n;
-      if (newDstSwap.tokenSwap.quote.output.amountRaw < minAcceptableDst) {
-        throw Errors.slippageError(
-          `combined retry: dst output dropped from ${this.initialDstOutputAmountRaw} to ${newDstSwap.tokenSwap.quote.output.amountRaw} (>${this.options.slippage} slippage)`
-        );
-      }
-    }
-
-    this.route.source.swaps = quoteResponses;
+    this.route.source.swaps = newSrcSwaps;
     this.route.destination.swap = newDstSwap;
   }
 

--- a/src/swap/ob.ts
+++ b/src/swap/ob.ts
@@ -650,6 +650,7 @@ class SourceSwapsHandler {
   private disposableCache: { [k: string]: Tx } = {};
   private readonly sourceExecutionsByChain: Map<number, SourceExecution>;
   private readonly swapsData: Map<number, SwapRoute['source']['swaps']>;
+  private readonly srcBuffer: Decimal;
   constructor(
     route: SwapRoute,
     private readonly options: Options
@@ -660,6 +661,7 @@ class SourceSwapsHandler {
         execution,
       ])
     );
+    this.srcBuffer = route.source.srcBuffer ?? new Decimal(0);
     this.swapsData = this.groupAndOrder(route.source.swaps);
     for (const [chainID, swapQuotes] of this.swapsData) {
       const execution = this.getSourceExecution(chainID);
@@ -1021,18 +1023,25 @@ class SourceSwapsHandler {
     }
   }
 
+  // Re-quote source legs that reverted, then enforce that the combined output drop fits
+  // inside the route's pre-allocated source buffer. The buffer (srcBuffer in COT units,
+  // sized as `min(2%, $1)` of bridgeOutputWithFees for EXACT_OUT, 0 for EXACT_IN) is the
+  // only headroom the bridge step has — re-quote drops larger than that would underflow
+  // the bridge's input requirement. A static slippage % is unrelated to that requirement
+  // and was previously over- or under-strict depending on the failed-leg output size.
   async retryWithSlippageCheck(metadata: SwapMetadata, failedChains: number[]) {
-    let oldTotalOutputAmount = 0n;
+    let oldTotalOutput = new Decimal(0);
 
     logger.debug('sourceSwapsHandler:retryWithSlippageCheck:0', {
       failedChains,
+      srcBuffer: this.srcBuffer.toFixed(),
     });
 
     const quoteResponses = await retry(
       () => {
         const quoteRequests = [];
         // if it comes to retry it should be set to 0
-        oldTotalOutputAmount = 0n;
+        oldTotalOutput = new Decimal(0);
         for (const fChain of failedChains) {
           const oldSwaps = this.swapsData.get(fChain);
           if (!oldSwaps) {
@@ -1040,7 +1049,9 @@ class SourceSwapsHandler {
             continue;
           }
           for (const oldSwap of oldSwaps) {
-            oldTotalOutputAmount += oldSwap.quote.output.amountRaw;
+            oldTotalOutput = oldTotalOutput.add(
+              divDecimals(oldSwap.quote.output.amountRaw, oldSwap.quote.output.decimals)
+            );
             logger.debug('retryWithSlippage:quoteRequests:1', {
               holding: {
                 amount: oldSwap.quote.input.amountRaw,
@@ -1076,33 +1087,26 @@ class SourceSwapsHandler {
       { retries: 2 }
     );
 
-    logger.debug('sourceSwapsHandler:retryWithSlippageCheck:1', {
-      oldTotalOutputAmount,
-      quoteResponses,
-    });
-    let newTotalOutputAmount = 0n;
+    let newTotalOutput = new Decimal(0);
     for (const q of quoteResponses) {
-      newTotalOutputAmount += q.quote.output.amountRaw;
+      newTotalOutput = newTotalOutput.add(
+        divDecimals(q.quote.output.amountRaw, q.quote.output.decimals)
+      );
     }
 
-    const diff = oldTotalOutputAmount - newTotalOutputAmount;
-    if (diff > 0) {
-      if (
-        !this.isSwapQuoteValid({
-          newAmount: newTotalOutputAmount,
-          oldAmount: oldTotalOutputAmount,
-          slippage: this.options.slippage,
-        })
-      ) {
-        throw Errors.slippageError('source swap retry slippage exceeded max');
-      }
-    }
-
-    logger.debug('sourceSwapsHandler:retryWithSlippageCheck:2', {
-      diff,
-      newTotalOutputAmount,
-      oldTotalOutputAmount,
+    const minAcceptable = oldTotalOutput.sub(this.srcBuffer);
+    logger.debug('sourceSwapsHandler:retryWithSlippageCheck:1', {
+      minAcceptable: minAcceptable.toFixed(),
+      newTotalOutput: newTotalOutput.toFixed(),
+      oldTotalOutput: oldTotalOutput.toFixed(),
+      quoteResponses,
+      srcBuffer: this.srcBuffer.toFixed(),
     });
+    if (newTotalOutput.lt(minAcceptable)) {
+      throw Errors.slippageError(
+        `source swap retry exceeded srcBuffer: dropped from ${oldTotalOutput.toFixed()} to ${newTotalOutput.toFixed()} (>${this.srcBuffer.toFixed()} buffer)`
+      );
+    }
 
     return this.process(metadata, this.groupAndOrder(quoteResponses), false);
   }
@@ -1136,24 +1140,6 @@ class SourceSwapsHandler {
       ),
       (s) => s.chainID
     );
-  }
-
-  private isSwapQuoteValid({
-    newAmount,
-    oldAmount,
-    slippage,
-  }: {
-    newAmount: bigint;
-    oldAmount: bigint;
-    slippage: number;
-  }) {
-    const minAcceptable = Decimal.mul(oldAmount, Decimal.sub(1, slippage));
-    logger.debug('isSwapQuoteValid', {
-      minAcceptable: minAcceptable.toFixed(),
-      newAmount,
-      oldAmount,
-    });
-    return new Decimal(newAmount).gte(minAcceptable);
   }
 }
 

--- a/src/swap/ob.ts
+++ b/src/swap/ob.ts
@@ -81,10 +81,15 @@ const logger = getLogger();
 /**
  * Re-quote the given source-leg holdings with their original input amounts (so no
  * re-approval/permit is needed) and verify the combined new COT output stays within
- * `srcBuffer` of the old total. Shared by SourceSwapsHandler.retryWithSlippageCheck
- * (partial retry — failed-chain subset) and CombinedSwapHandler.requoteBothLegs
- * (full retry — atomic batch). Wraps the aggregator call in `retry` to absorb
- * transient quote failures. Throws on no quotes or buffer breach.
+ * `srcBuffer` of the old total. Used by SourceSwapsHandler.retryWithSlippageCheck
+ * on partial source-leg retries where the bridge step has already been sized against
+ * the old total — `srcBuffer` is the headroom the bridge can absorb. Wraps the
+ * aggregator call in `retry` to absorb transient quote failures. Throws on no quotes
+ * or buffer breach.
+ *
+ * NOTE: Not used by CombinedSwapHandler.requoteBothLegs. Combined batches are atomic
+ * (no pre-committed bridge), so they re-quote directly and enforce a different
+ * invariant (`availableCOT ≥ dst.input`) inline.
  */
 const liquidateAndCheckSrcBuffer = async ({
   oldSwaps,
@@ -1168,13 +1173,10 @@ const COMBINED_MAX_RETRIES = 2;
  * batch is atomic: a partial failure reverts everything and the user's input stays at the EOA.
  */
 class CombinedSwapHandler {
-  private readonly srcBuffer: Decimal;
   constructor(
     private route: SwapRoute,
     private readonly options: Options
-  ) {
-    this.srcBuffer = route.source.srcBuffer ?? new Decimal(0);
-  }
+  ) {}
 
   async process(metadata: SwapMetadata): Promise<void> {
     const chain = this.options.chainList.getChainByID(this.route.destination.chainId);
@@ -1406,27 +1408,38 @@ class CombinedSwapHandler {
       };
     });
 
-    // Source-leg re-quote + buffer check is the same for both directions (mirrors
-    // SourceSwapsHandler.retryWithSlippageCheck via the shared helper). The dst re-quote
-    // delegates to the route closure's `getDstSwap` (which carries its own rate guard,
-    // mirroring DestinationSwapHandler.requoteIfRequired). For EXACT_OUT we re-quote dst
-    // first so its `ratesChangedBeyondTolerance` against `originalMax` fails fast before
-    // we spend a source quote; EXACT_IN's closure uses a fixed dst input from initial
-    // routing so order doesn't matter and we use the same shape.
-    const requoteSource = () =>
-      liquidateAndCheckSrcBuffer({
-        oldSwaps: this.route.source.swaps,
-        holdings,
-        srcBuffer: this.srcBuffer,
-        aggregators: this.route.extras.aggregators,
-        commonCurrencyID: this.options.cot.currencyID,
-        errorPrefix: 'combined retry',
-      });
+    // Combined batches are atomic on a single wrapper: src outputs land at the wrapper that
+    // dst pulls from, all in one tx. The bridge-style buffer check (newTotal < oldTotal -
+    // srcBuffer) doesn't apply — nothing was pre-committed for old totals to anchor against.
+    // Likewise the dst rate guard (`ratesChangedBeyondTolerance` against `originalMax`)
+    // protects bridge flows whose budget was fixed when the bridge was sent; here both legs
+    // re-quote together inside the retry, so we pass `skipRateGuard: true`.
+    //
+    // The only invariant that matters is `availableCOT ≥ sum(dst.input)`, where
+    // `availableCOT = sum(src.output) + eoaToDestinationAccount.amount` (the EOA-held dst-COT
+    // term contributes when `buildBatch` permits/transfers it to the wrapper before the dst
+    // swap pulls; see the check below). If that holds, the atomic batch funds itself; any
+    // surplus sweeps back to the EOA via the existing sweeper appended in `buildBatch`.
+    const requoteSource = async (): Promise<SwapRoute['source']['swaps']> => {
+      const newSwaps = await retry(
+        () =>
+          liquidateSourceHoldings({
+            holdings,
+            aggregators: this.route.extras.aggregators,
+            commonCurrencyID: this.options.cot.currencyID,
+          }),
+        { retries: 2 }
+      );
+      if (newSwaps.length === 0) {
+        throw Errors.quoteFailed('combined retry: source re-quote returned no quotes');
+      }
+      return newSwaps;
+    };
 
     let newDstSwap: SwapRoute['destination']['swap'];
     let newSrcSwaps: SwapRoute['source']['swaps'];
     if (this.route.type === 'EXACT_OUT') {
-      const dstSwap = await this.route.destination.getDstSwap();
+      const dstSwap = await this.route.destination.getDstSwap({ skipRateGuard: true });
       if (!dstSwap) {
         throw Errors.quoteFailed('combined retry: getDstSwap returned null');
       }
@@ -1434,11 +1447,48 @@ class CombinedSwapHandler {
       newSrcSwaps = await requoteSource();
     } else {
       newSrcSwaps = await requoteSource();
-      const dstSwap = await this.route.destination.getDstSwap();
+      const dstSwap = await this.route.destination.getDstSwap({ skipRateGuard: true });
       if (!dstSwap) {
         throw Errors.quoteFailed('combined retry: getDstSwap returned null');
       }
       newDstSwap = dstSwap;
+    }
+
+    // Sole invariant: COT available at the wrapper covers dst COT input within the same
+    // atomic batch. Both contributions land/pull at the same wrapper, so decimals match —
+    // raw bigint compare is safe.
+    //
+    // Available COT at the wrapper:
+    //   1. sum of src swap outputs (each swap deposits its COT output at the wrapper)
+    //   2. plus `eoaToDestinationAccount.amount` when set (pre-existing dst-chain COT that
+    //      `buildBatch` permits/transfers from the EOA to the wrapper before the dst swap).
+    //      Only counted when its token matches the dst swap's input token (the COT).
+    const srcOutputTotal = newSrcSwaps.reduce((acc, q) => acc + q.quote.output.amountRaw, 0n);
+    const dstInputContract =
+      newDstSwap.tokenSwap?.quote.input.contractAddress ??
+      newDstSwap.gasSwap?.quote.input.contractAddress;
+    const eoaContribution =
+      this.route.destination.eoaToDestinationAccount &&
+      dstInputContract &&
+      equalFold(this.route.destination.eoaToDestinationAccount.contractAddress, dstInputContract)
+        ? this.route.destination.eoaToDestinationAccount.amount
+        : 0n;
+    const availableCOT = srcOutputTotal + eoaContribution;
+    const dstInputTotal =
+      (newDstSwap.tokenSwap?.quote.input.amountRaw ?? 0n) +
+      (newDstSwap.gasSwap?.quote.input.amountRaw ?? 0n);
+
+    logger.debug('combined retry: available COT vs dst input', {
+      srcOutputTotal: srcOutputTotal.toString(),
+      eoaContribution: eoaContribution.toString(),
+      availableCOT: availableCOT.toString(),
+      dstInputTotal: dstInputTotal.toString(),
+    });
+
+    if (availableCOT < dstInputTotal) {
+      throw Errors.slippageError(
+        `combined retry: source output ${srcOutputTotal} (+ EOA→dst ${eoaContribution}) cannot fund destination input ${dstInputTotal}`
+      );
     }
 
     this.route.source.swaps = newSrcSwaps;

--- a/src/swap/route.ts
+++ b/src/swap/route.ts
@@ -111,9 +111,9 @@ const printRouteTimings = () => {
       );
     }
 
-    console.log('Timings for route:');
+    logger.debug('Timings for route:');
     for (const measure of measures) {
-      console.log(`${measure.name}: ${measure.duration}`);
+      logger.debug(`${measure.name}: ${measure.duration}`);
     }
   } catch (e) {
     logger.error('printRouteTimings', e);

--- a/src/swap/route.ts
+++ b/src/swap/route.ts
@@ -911,7 +911,15 @@ const _exactOutRoute = async (
     );
 
     let originalMax: Decimal | null = null;
-    const getDstSwap = async (): Promise<DestinationSwap> => {
+    // `skipRateGuard` is set by combined retries (CombinedSwapHandler.requoteBothLegs).
+    // The originalMax rate-tolerance check exists to protect bridge flows where the bridge
+    // was already sized against the first dst quote — a requote whose input requirement
+    // outgrows that fixed budget cannot be funded. Combined batches are atomic on a single
+    // wrapper: src outputs and dst inputs balance in the same tx, with no pre-committed
+    // bridge to underfund. The combined handler enforces its own funding invariant
+    // (`availableCOT ≥ dst.input`, where `availableCOT = src.output + eoaToDestinationAccount`)
+    // instead, so this guard must not fire there.
+    const getDstSwap = async (opts: { skipRateGuard?: boolean } = {}): Promise<DestinationSwap> => {
       if (!needsTokenSwap && !needsGasSwap) {
         return { creationTime: Date.now(), tokenSwap: null, gasSwap: null };
       }
@@ -958,7 +966,7 @@ const _exactOutRoute = async (
         originalMax = rounded;
         destination.inputAmount.max = rounded;
         buffer = buffer.add(dstBuffer);
-      } else if (destination.inputAmount.min.gt(originalMax)) {
+      } else if (destination.inputAmount.min.gt(originalMax) && !opts.skipRateGuard) {
         // Requote: the bridge has already been sized for `originalMax`. A requote whose
         // input requirement still fits inside that budget is fine — leftover gets swept.
         // Only reject when the requote genuinely outgrows what the bridge funded; do NOT
@@ -1240,8 +1248,12 @@ export type SwapRoute = {
     // (see BUFFER_EXACT_OUT). EXACT_IN carries `min(0.5%, $1)` of swapCombinedBalance
     // (see BUFFER_EXACT_IN). Non-combined EXACT_IN also subtracts this from the dst-swap
     // input so the dst swap stays funded if a source leg re-quotes lower; combined routes
-    // under-size the dst-swap input by `COMBINED_SAME_CHAIN_BUFFER_PCT` instead, but still
-    // carry `srcBuffer` as the retry tolerance consumed by CombinedSwapHandler.
+    // under-size the dst-swap input by `COMBINED_SAME_CHAIN_BUFFER_PCT` instead.
+    //
+    // Consumed by SourceSwapsHandler.retryWithSlippageCheck (via `liquidateAndCheckSrcBuffer`)
+    // on bridge-flow retries. NOT consumed by CombinedSwapHandler — combined retries enforce
+    // `availableCOT ≥ dst.input` inline instead, where `availableCOT = src.output +
+    // eoaToDestinationAccount`.
     srcBuffer: Decimal;
   };
   bridge: BridgeInput;
@@ -1254,7 +1266,7 @@ export type SwapRoute = {
     execution: DestinationExecution;
     inputAmount: { min: Decimal; max: Decimal }; // This is input of tokenSwap + gasSwap + buffer
     swap: DestinationSwap;
-    getDstSwap: () => Promise<DestinationSwap | null>;
+    getDstSwap: (opts?: { skipRateGuard?: boolean }) => Promise<DestinationSwap | null>;
   };
   // True when the route's source legs and destination leg can be executed as a single batched
   // transaction on one same-chain wrapper (no bridge, every source swap lands on the dst chain,
@@ -1575,7 +1587,12 @@ const _exactInRoute = async (
       };
     }
 
-    const getDstSwap = async () => {
+    // `skipRateGuard` is set by combined retries (CombinedSwapHandler.requoteBothLegs).
+    // The 0.5% output-drop rate guard exists to protect bridge flows that committed an
+    // input budget at quote time. Combined batches re-quote both legs together and enforce
+    // their own funding invariant (`availableCOT ≥ dst.input`, where `availableCOT =
+    // src.output + eoaToDestinationAccount`), so the guard must not fire there.
+    const getDstSwap = async (opts: { skipRateGuard?: boolean } = {}) => {
       let tokenSwap = null;
       if (needsDstSwap) {
         tokenSwap = await getDestinationExactInSwap({
@@ -1589,7 +1606,7 @@ const _exactInRoute = async (
         });
 
         // Rate guard on requote: check output didn't drop beyond 0.5% tolerance
-        if (destination.swap.tokenSwap) {
+        if (destination.swap.tokenSwap && !opts.skipRateGuard) {
           const prevAmountRaw = destination.swap.tokenSwap.quote.output.amountRaw;
           const newAmountRaw = tokenSwap.quote.output.amountRaw;
           if (newAmountRaw < (prevAmountRaw * 995n) / 1000n) {

--- a/src/swap/route.ts
+++ b/src/swap/route.ts
@@ -17,6 +17,7 @@ import { type Hex, toBytes } from 'viem';
 import {
   type BridgeAsset,
   type Chain,
+  type ChainListType,
   type DestinationExecution,
   type ExactInSwapInput,
   type ExactOutSwapInput,
@@ -43,6 +44,8 @@ import {
 import { EADDRESS, EADDRESS_32_BYTES } from './constants';
 import type { FlatBalance } from './data';
 import { createIntent, estimateCollectionFee } from './rff';
+import { SAFE_PROXY_FACTORY } from './safe.constants';
+import { predictSafeAccountAddress } from './safetx';
 import {
   calculateValue,
   convertTo32Bytes,
@@ -57,69 +60,84 @@ const logger = getLogger();
 export const requiresSafeAccount = (chain: Chain | undefined): boolean =>
   !!chain && chain.swapSupported && !chain.pectraUpgradeSupport;
 
-export const resolveSourceExecution = async ({
-  chain,
-  eoaAddress: _eoaAddress,
-  ephemeralAddress,
-  vscClient,
-}: {
-  chain: Chain;
-  eoaAddress: Hex;
-  ephemeralAddress: Hex;
-  vscClient: SwapParams['vscClient'];
-}): Promise<SourceExecution> => {
-  if (!requiresSafeAccount(chain)) {
-    return {
-      address: ephemeralAddress,
-      entryPoint: null,
-      mode: '7702',
-    };
-  }
-
-  const account = await vscClient.vscGetSafeAccountAddress(chain.id, ephemeralAddress);
-  return {
-    address: account.address,
-    entryPoint: null,
-    factoryAddress: account.factoryAddress,
-    mode: 'safe_account',
-  };
+// Source and destination wrappers on the same chain resolve to the same on-chain executor —
+// it's purely chain-dependent, not src/dst-dependent. The only divergence is the optional
+// `direct_eoa` dst mode applied at the call site via {@link buildDirectEoaDestinationExecution}.
+//
+// The Safe address is computed locally via CREATE2 (see `predictSafeAccountAddress`). We DO
+// still fire `vscGetSafeAccountAddress` per non-pectra chain — but only as a background
+// sanity check that catches SDK ↔ server config drift (different salt/init code). The
+// returned promise is awaited via `verification` just before the SwapRoute is returned;
+// it does NOT block aggregator quotes or any other route step.
+type ChainExecution = {
+  address: Hex;
+  entryPoint: Hex | null;
+  factoryAddress?: Hex;
+  mode: '7702' | 'safe_account';
 };
 
-export const resolveDestinationExecution = async ({
-  chain,
-  eoaAddress,
+const buildDirectEoaDestinationExecution = (eoaAddress: Hex): DestinationExecution => ({
+  address: eoaAddress,
+  entryPoint: null,
+  mode: 'direct_eoa',
+});
+
+export const resolveChainExecutions = ({
+  chainIds,
   ephemeralAddress,
-  needsDestinationExecution,
+  chainList,
   vscClient,
 }: {
-  chain: Chain;
-  eoaAddress: Hex;
+  chainIds: Iterable<number>;
   ephemeralAddress: Hex;
-  needsDestinationExecution: boolean;
+  chainList: ChainListType;
   vscClient: SwapParams['vscClient'];
-}): Promise<DestinationExecution> => {
-  if (!needsDestinationExecution) {
-    return {
-      address: eoaAddress,
+}): {
+  executions: Record<number, ChainExecution>;
+  verification: Promise<void>;
+} => {
+  const executions: Record<number, ChainExecution> = {};
+  const verificationPromises: Promise<void>[] = [];
+
+  for (const chainId of new Set(chainIds)) {
+    const chain = chainList.getChainByID(chainId);
+    if (!chain) {
+      throw Errors.chainNotFound(chainId);
+    }
+
+    if (!requiresSafeAccount(chain)) {
+      executions[chainId] = {
+        address: ephemeralAddress,
+        entryPoint: null,
+        mode: '7702',
+      };
+      continue;
+    }
+
+    const safeAddress = predictSafeAccountAddress(ephemeralAddress);
+    executions[chainId] = {
+      address: safeAddress,
       entryPoint: null,
-      mode: 'direct_eoa',
+      factoryAddress: SAFE_PROXY_FACTORY,
+      mode: 'safe_account',
     };
+
+    verificationPromises.push(
+      vscClient.vscGetSafeAccountAddress(chainId, ephemeralAddress).then((account) => {
+        if (account.address.toLowerCase() !== safeAddress.toLowerCase()) {
+          throw Errors.internal(
+            `Safe address mismatch on chain ${chainId}: local=${safeAddress} server=${account.address}`
+          );
+        }
+      })
+    );
   }
 
-  if (!requiresSafeAccount(chain)) {
-    return {
-      address: ephemeralAddress,
-      entryPoint: null,
-      mode: '7702',
-    };
-  }
-
-  const account = await vscClient.vscGetSafeAccountAddress(chain.id, ephemeralAddress);
   return {
-    address: account.address,
-    entryPoint: null,
-    factoryAddress: account.factoryAddress,
-    mode: 'safe_account',
+    executions,
+    verification: Promise.all(verificationPromises).then(() => {
+      // Promise<void[]> → Promise<void>
+    }),
   };
 };
 
@@ -136,36 +154,22 @@ type AggregatorInputWithSwapAddresses = AggregatorInput & {
 };
 type SourceExecutionRecord = Record<number, SourceExecution>;
 
-const resolveSourceExecutions = async ({
-  eoaAddress,
-  ephemeralAddress,
-  sourceBalances,
-  params,
-}: {
-  eoaAddress: Hex;
-  ephemeralAddress: Hex;
-  sourceBalances: FlatBalance[];
-  params: SwapParams & { publicClientList: PublicClientList };
-}): Promise<SourceExecutionRecord> => {
-  const uniqueSourceChains = uniqBy(sourceBalances, (balance) => balance.chainID);
-  const entries = await Promise.all(
-    uniqueSourceChains.map(async (balance) => {
-      const chain = params.chainList.getChainByID(balance.chainID);
-      if (!chain) {
-        throw Errors.chainNotFound(balance.chainID);
-      }
-
-      const execution = await resolveSourceExecution({
-        chain,
-        eoaAddress,
-        ephemeralAddress,
-        vscClient: params.vscClient,
-      });
-      return [balance.chainID, execution] as const;
-    })
-  );
-
-  return Object.fromEntries(entries) as SourceExecutionRecord;
+// Source executions are just the per-source-chain slice of the combined chain-execution map.
+// Kept as a tiny helper so the call sites stay symmetric with the legacy shape, but no
+// async work happens here — everything sources from {@link resolveChainExecutions}.
+const pickSourceExecutions = (
+  chainExecutions: Record<number, ChainExecution>,
+  sourceBalances: FlatBalance[]
+): SourceExecutionRecord => {
+  const out: SourceExecutionRecord = {};
+  for (const chainId of new Set(sourceBalances.map((b) => b.chainID))) {
+    const execution = chainExecutions[chainId];
+    if (!execution) {
+      throw Errors.internal(`source execution not resolved for chain ${chainId}`);
+    }
+    out[chainId] = execution;
+  }
+  return out;
 };
 
 export const toAggregatorInputsWithSwapAddresses = (
@@ -359,6 +363,7 @@ const fetchRouteData = async (
           filterWithSupportedTokens: false,
           allowedSources: opts.allowedSources,
           removeSources: opts.removeSources,
+          publicClientList: params.publicClientList,
         }).then((r) => r.balances),
     oraclePricesPromise,
     getTokenInfo(opts.toTokenAddress, params.publicClientList.get(opts.toChainId), opts.dstChain),
@@ -729,13 +734,26 @@ const _exactOutRoute = async (
   const needsTokenSwap =
     input.toAmount > 0n && !equalFold(input.toTokenAddress, dstChainCOTAddress);
   const needsGasSwap = !gasInCOT.isZero();
-  const destinationExecution = await resolveDestinationExecution({
-    chain: dstChain,
-    eoaAddress: params.address.eoa,
-    ephemeralAddress: params.address.ephemeral,
-    needsDestinationExecution: needsTokenSwap || needsGasSwap,
-    vscClient: params.vscClient,
+
+  // Resolve every chain we'll need a wrapper on in a single sync pass:
+  //   dst + every source chain (deduped). Safe addresses are computed locally; the only
+  //   async piece (`verification`) is awaited at the very end before the route returns.
+  const sortedBalances = sortSourcesByPriority(balances, {
+    tokenAddress: input.toTokenAddress,
+    symbol: dstTokenInfo.symbol,
+    chainID: dstChain.id,
   });
+  const { executions: chainExecutions, verification: executionsVerification } =
+    resolveChainExecutions({
+      chainIds: [input.toChainId, ...sortedBalances.map((b) => b.chainID)],
+      ephemeralAddress: params.address.ephemeral,
+      chainList: params.chainList,
+      vscClient: params.vscClient,
+    });
+  const destinationExecution: DestinationExecution =
+    needsTokenSwap || needsGasSwap
+      ? chainExecutions[input.toChainId]
+      : buildDirectEoaDestinationExecution(params.address.eoa);
   // Aggregator simulation context (taker_address / fromAddress) must be the wrapper — that's
   // the on-chain executor at runtime, so the aggregator's permit/approval routing has to match.
   // Output recipient is the user's EOA so we never need to sweep token or native dust out of
@@ -878,17 +896,7 @@ const _exactOutRoute = async (
     sourceSwapOutputRequired: sourceSwapOutputRequired.toFixed(),
   });
 
-  const sortedBalances = sortSourcesByPriority(balances, {
-    tokenAddress: input.toTokenAddress,
-    symbol: dstTokenInfo.symbol,
-    chainID: dstChain.id,
-  });
-  const sourceExecutions = await resolveSourceExecutions({
-    eoaAddress: params.address.eoa,
-    ephemeralAddress: params.address.ephemeral,
-    sourceBalances: sortedBalances,
-    params,
-  });
+  const sourceExecutions = pickSourceExecutions(chainExecutions, sortedBalances);
 
   const { quoteResponses: rawSourceSwapQuotes, usedCOTs: rawUsedCOTs } = await autoSelectSources({
     holdings: toAggregatorInputsWithSwapAddresses(sortedBalances, sourceExecutions),
@@ -967,13 +975,10 @@ const _exactOutRoute = async (
       params.address.eoa
     )
   ) {
-    destination.execution = await resolveDestinationExecution({
-      chain: dstChain,
-      eoaAddress: params.address.eoa,
-      ephemeralAddress: params.address.ephemeral,
-      needsDestinationExecution: true,
-      vscClient: params.vscClient,
-    });
+    // Source swaps land COT on the dst chain at a non-EOA wrapper, so the dst leg can't
+    // stay as `direct_eoa` after all. The wrapper was already resolved up-front (same
+    // chain, same ephemeral) — flip is a sync lookup, no extra VSC roundtrip.
+    destination.execution = chainExecutions[input.toChainId];
   }
 
   const isBridgeRequired = !(
@@ -1017,6 +1022,10 @@ const _exactOutRoute = async (
   }
 
   logger.debug('exact-out: bridge', { bridgeAssets, bridgeInput, assetsUsed, dstEOAToEphTx });
+
+  // VSC verification is fire-and-forget during the rest of route calc; resolve it now
+  // before returning so any SDK ↔ server config drift surfaces here instead of mid-execution.
+  await executionsVerification;
 
   return buildSwapRouteResult({
     type: 'EXACT_OUT',
@@ -1156,12 +1165,18 @@ const _exactInRoute = async (
   );
 
   const dstOmniversalChainID = new OmniversalChainID(Universe.ETHEREUM, input.toChainId);
-  const sourceExecutions = await resolveSourceExecutions({
-    eoaAddress: params.address.eoa,
-    ephemeralAddress: params.address.ephemeral,
-    sourceBalances: srcBalances,
-    params,
-  });
+
+  // Resolve every chain we'll need a wrapper on (dst + every source chain) in a single
+  // sync pass. VSC verification fires in the background via `executionsVerification` and
+  // is awaited right before the route returns.
+  const { executions: chainExecutions, verification: executionsVerification } =
+    resolveChainExecutions({
+      chainIds: [input.toChainId, ...srcBalances.map((b) => b.chainID)],
+      ephemeralAddress: params.address.ephemeral,
+      chainList: params.chainList,
+      vscClient: params.vscClient,
+    });
+  const sourceExecutions = pickSourceExecutions(chainExecutions, srcBalances);
 
   const bridgeAssets: BridgeAsset[] = [];
 
@@ -1285,13 +1300,11 @@ const _exactInRoute = async (
     input.toChainId,
     params.address.eoa
   );
-  const destinationExecution = await resolveDestinationExecution({
-    chain: dstChain,
-    eoaAddress: params.address.eoa,
-    ephemeralAddress: params.address.ephemeral,
-    needsDestinationExecution: needsDstSwap || hasDestinationChainSourceOutput,
-    vscClient: params.vscClient,
-  });
+  // Same chain executions resolved up-front; just pick (or downgrade to direct_eoa).
+  const destinationExecution: DestinationExecution =
+    needsDstSwap || hasDestinationChainSourceOutput
+      ? chainExecutions[input.toChainId]
+      : buildDirectEoaDestinationExecution(params.address.eoa);
 
   // If the source swap(s) and the destination swap collapse to one same-wrapper batch (no
   // bridge in between), the dst aggregator will pull COT from the same wrapper the source
@@ -1370,6 +1383,9 @@ const _exactInRoute = async (
 
   destination.swap = await getDstSwap();
   destination.getDstSwap = getDstSwap;
+
+  // VSC verification fired in the background while quotes ran; resolve it before returning.
+  await executionsVerification;
 
   return buildSwapRouteResult({
     type: 'EXACT_IN',

--- a/src/swap/route.ts
+++ b/src/swap/route.ts
@@ -1,7 +1,5 @@
 import {
   type Aggregator,
-  autoSelectSources,
-  type Bytes,
   ChaindataMap,
   CurrencyID,
   getDestinationExactInSwap,
@@ -9,6 +7,8 @@ import {
   liquidateSourceHoldings,
   OmniversalChainID,
   type QuoteResponse,
+  type SourceWithValue,
+  selectSources,
   Universe,
 } from '@avail-project/ca-common';
 import Decimal from 'decimal.js';
@@ -56,6 +56,69 @@ import {
 } from './utils';
 
 const logger = getLogger();
+
+// Collect and print every route-phase `performance.measure` we can find. Called before
+// each route returns (initial + every refresh) so timings are visible without having to
+// complete the full swap flow — `calculatePerformance` in flows/swap.ts only fires after
+// the user approves the intent and execution finishes, which is too late for diagnosing
+// route latency in isolation.
+//
+// Each phase is gated on its start-mark existing so an exact-out path doesn't blow up
+// looking for `route-max-bridge-fee-start` (exact-in-only). Marks are NOT cleared here;
+// calculatePerformance handles cleanup at end-of-swap. On refresh, each pair is
+// overwritten by the new call's marks, so the print reflects the latest run.
+const printRouteTimings = () => {
+  try {
+    const measures: PerformanceMeasure[] = [];
+    const entries = performance.getEntries();
+    const has = (name: string) => entries.some((e) => e.name === name);
+
+    if (has('route-fetch-start')) {
+      measures.push(
+        performance.measure('route-fetch-duration', 'route-fetch-start', 'route-fetch-end')
+      );
+    }
+    if (has('route-dst-quote-start')) {
+      measures.push(
+        performance.measure(
+          'route-dst-quote-duration',
+          'route-dst-quote-start',
+          'route-dst-quote-end'
+        )
+      );
+    }
+    if (has('route-source-quote-start')) {
+      measures.push(
+        performance.measure(
+          'route-source-quote-duration',
+          'route-source-quote-start',
+          'route-source-quote-end'
+        )
+      );
+    }
+    if (has('route-max-bridge-fee-start')) {
+      measures.push(
+        performance.measure(
+          'route-max-bridge-fee-duration',
+          'route-max-bridge-fee-start',
+          'route-max-bridge-fee-end'
+        )
+      );
+    }
+    if (has('route-verify-start')) {
+      measures.push(
+        performance.measure('route-verify-duration', 'route-verify-start', 'route-verify-end')
+      );
+    }
+
+    console.log('Timings for route:');
+    for (const measure of measures) {
+      console.log(`${measure.name}: ${measure.duration}`);
+    }
+  } catch (e) {
+    logger.error('printRouteTimings', e);
+  }
+};
 
 export const requiresSafeAccount = (chain: Chain | undefined): boolean =>
   !!chain && chain.swapSupported && !chain.pectraUpgradeSupport;
@@ -141,17 +204,13 @@ export const resolveChainExecutions = ({
   };
 };
 
-type AggregatorInput = ReturnType<typeof toAggregatorInputs>[number];
 // Per-holding shape carrying both the swap *taker* (on-chain executor — Calibur ephemeral on
 // 7702 chains, Safe contract on non-Pectra chains) and the *receiver* (output recipient). For
 // source-side swaps the two are always equal — output stays at the wrapper for the bridge step
 // to consume — but they're stored as distinct fields so every call site has to acknowledge
-// each role explicitly. Names mirror the ca-common wrapper vocabulary
-// (`HoldingWithSwapAddresses`).
-type AggregatorInputWithSwapAddresses = AggregatorInput & {
-  takerAddress: Bytes;
-  receiverAddress: Bytes;
-};
+// each role explicitly. Matches ca-common's `SourceWithValue` exactly — re-exported under the
+// SDK-flavored name so older test imports keep working.
+type AggregatorInputWithSwapAddresses = SourceWithValue;
 type SourceExecutionRecord = Record<number, SourceExecution>;
 
 // Source executions are just the per-source-chain slice of the combined chain-execution map.
@@ -590,11 +649,11 @@ const resolveSourceBalances = (
 
 /**
  * Builds assetsUsed, bridgeAssets, dstEOAToEphTx, and dstTotalCOTAmount from
- * autoSelectSources results. Skips dst-chain entries from bridgeAssets and
+ * `selectSources` results. Skips dst-chain entries from bridgeAssets and
  * tracks dst COT for bridge amount deduction.
  */
 const buildExactOutSourceAssets = (
-  usedCOTs: Awaited<ReturnType<typeof autoSelectSources>>['usedCOTs'],
+  usedCOTs: Awaited<ReturnType<typeof selectSources>>['usedCOTs'],
   sourceSwapQuotes: QuoteResponse[],
   dstChainId: number,
   dstCOTDecimals: number
@@ -693,6 +752,7 @@ const _exactOutRoute = async (
   // Fetch unfiltered balances. allowedSources/removeSources were previously passed
   // here so getBalancesForSwap could pre-filter; we now apply both per-call in refresh
   // (so a refresh with a different fromSources doesn't have to re-fetch).
+  performance.mark('route-fetch-start');
   const {
     feeStore,
     balances: rawBalances,
@@ -703,6 +763,7 @@ const _exactOutRoute = async (
     toTokenAddress: input.toTokenAddress,
     dstChain,
   });
+  performance.mark('route-fetch-end');
 
   const { cot: dstChainCOT, address: dstChainCOTAddress } = getCOTForChainId(
     input.toChainId,
@@ -903,7 +964,9 @@ const _exactOutRoute = async (
       return { creationTime: Date.now(), tokenSwap, gasSwap };
     };
 
+    performance.mark('route-dst-quote-start');
     destination.swap = await getDstSwap();
+    performance.mark('route-dst-quote-end');
     destination.getDstSwap = getDstSwap;
 
     logger.debug('destination swaps', destination.swap);
@@ -960,8 +1023,15 @@ const _exactOutRoute = async (
 
     const sourceExecutions = pickSourceExecutions(chainExecutions, sortedBalances);
 
-    const { quoteResponses: rawSourceSwapQuotes, usedCOTs: rawUsedCOTs } = await autoSelectSources({
-      holdings: toAggregatorInputsWithSwapAddresses(sortedBalances, sourceExecutions),
+    // Hands the priority-ordered holdings (each carrying `value` in USD) to ca-common's
+    // `selectSources`. That implementation only surveys the priority-ordered prefix whose
+    // cumulative USD value covers `outputRequired × prefixHeadroom` (default 1.25), and
+    // expands to additional holdings only if the prefix under-delivers — so the typical
+    // route surveys a handful of holdings instead of every dust balance across 10+
+    // chains.
+    performance.mark('route-source-quote-start');
+    const { quoteResponses: rawSourceSwapQuotes, usedCOTs: rawUsedCOTs } = await selectSources({
+      sources: toAggregatorInputsWithSwapAddresses(sortedBalances, sourceExecutions),
       outputRequired: sourceSwapOutputRequired,
       aggregators: params.aggregators,
       commonCurrencyID: params.cotCurrencyID,
@@ -971,6 +1041,7 @@ const _exactOutRoute = async (
       }
       throw e;
     });
+    performance.mark('route-source-quote-end');
 
     // autoSelectSources is sized against sourceSwapOutputRequired (= bridgeOutput +
     // bridgeFees + srcBuffer). When dst-chain holdings sit in the
@@ -1094,7 +1165,11 @@ const _exactOutRoute = async (
     // before returning so any SDK ↔ server config drift surfaces here instead of mid-execution.
     // After the first refresh resolves it, subsequent refreshes just hit the already-settled
     // microtask.
+    performance.mark('route-verify-start');
     await executionsVerification;
+    performance.mark('route-verify-end');
+
+    printRouteTimings();
 
     return buildSwapRouteResult({
       type: 'EXACT_OUT',
@@ -1227,6 +1302,7 @@ const _exactInRoute = async (
     throw Errors.chainNotFound(input.toChainId);
   }
 
+  performance.mark('route-fetch-start');
   const {
     feeStore,
     balances: rawBalances,
@@ -1237,6 +1313,7 @@ const _exactInRoute = async (
     toTokenAddress: input.toTokenAddress,
     dstChain,
   });
+  performance.mark('route-fetch-end');
 
   if (rawBalances.length === 0) {
     throw Errors.noBalanceForAddress(params.address.eoa);
@@ -1306,11 +1383,13 @@ const _exactInRoute = async (
 
     let sourceSwaps: QuoteResponse[] = [];
     if (isSrcSwapRequired) {
+      performance.mark('route-source-quote-start');
       const response = await liquidateSourceHoldings({
         holdings: toAggregatorInputsWithSwapAddresses(srcBalances, sourceExecutions),
         aggregators: params.aggregators,
         commonCurrencyID: params.cotCurrencyID,
       });
+      performance.mark('route-source-quote-end');
 
       if (!response.length) {
         throw Errors.quoteFailed('source swap returned no quotes');
@@ -1335,6 +1414,7 @@ const _exactInRoute = async (
 
     let bridgeInput: BridgeInput = null;
     if (isBridgeRequired) {
+      performance.mark('route-max-bridge-fee-start');
       const { fee: maxFee } = await calculateMaxBridgeFee({
         assets: toBridgeAssetInputs(bridgeAssets),
         dst: {
@@ -1345,6 +1425,7 @@ const _exactInRoute = async (
         feeStore,
         chainList: params.chainList,
       });
+      performance.mark('route-max-bridge-fee-end');
 
       dstSwapInputAmountInDecimal = dstSwapInputAmountInDecimal.minus(maxFee);
       logger.debug('exact-in: after bridge fee deduction', {
@@ -1469,13 +1550,19 @@ const _exactInRoute = async (
       return { gasSwap: null, tokenSwap, creationTime: Date.now() };
     };
 
+    performance.mark('route-dst-quote-start');
     destination.swap = await getDstSwap();
+    performance.mark('route-dst-quote-end');
     destination.getDstSwap = getDstSwap;
 
     // VSC verification fired in the background while quotes ran; resolve it before returning.
     // After the first refresh resolves it, subsequent refreshes just hit the already-settled
     // microtask.
+    performance.mark('route-verify-start');
     await executionsVerification;
+    performance.mark('route-verify-end');
+
+    printRouteTimings();
 
     return buildSwapRouteResult({
       type: 'EXACT_IN',

--- a/src/swap/route.ts
+++ b/src/swap/route.ts
@@ -795,25 +795,30 @@ const _exactOutRoute = async (
       tokenSwap?.quote.input.amount ?? cotTransferAmount
     ).add(gasInCOT);
 
-    // Apply min(5%, $2) buffer to destination input amount — leftover is returned in COT.
-    const { amountWithBuffer, buffer: dstBuffer } = applyBufferWithCap(
-      destination.inputAmount.min,
-      BUFFER_EXACT_OUT.DESTINATION_SWAP_BUFFER_PCT,
-      BUFFER_EXACT_OUT.DESTINATION_SWAP_MAX_IN_USD
-    );
-    const rounded = amountWithBuffer.toDP(dstChainCOT.decimals, Decimal.ROUND_CEIL);
-
     if (originalMax === null) {
+      // First call: size the bridge by adding the destination buffer (min(10%, $2)).
+      // Leftover COT at the wrapper post-swap is swept back to the EOA.
+      const { amountWithBuffer, buffer: dstBuffer } = applyBufferWithCap(
+        destination.inputAmount.min,
+        BUFFER_EXACT_OUT.DESTINATION_SWAP_BUFFER_PCT,
+        BUFFER_EXACT_OUT.DESTINATION_SWAP_MAX_IN_USD
+      );
+      const rounded = amountWithBuffer.toDP(dstChainCOT.decimals, Decimal.ROUND_CEIL);
       originalMax = rounded;
-    } else if (rounded.gt(originalMax)) {
+      destination.inputAmount.max = rounded;
+      buffer = buffer.add(dstBuffer);
+    } else if (destination.inputAmount.min.gt(originalMax)) {
+      // Requote: the bridge has already been sized for `originalMax`. A requote whose
+      // input requirement still fits inside that budget is fine — leftover gets swept.
+      // Only reject when the requote genuinely outgrows what the bridge funded; do NOT
+      // re-add the buffer on top of newInputMin (that would shrink the usable budget
+      // and reject valid requotes that actually fit). inputAmount.max stays pinned at
+      // originalMax — the bridge already happened, the budget is fixed.
       throw Errors.ratesChangedBeyondTolerance(
-        Number(rounded.toFixed()),
+        Number(destination.inputAmount.min.toFixed()),
         `max budget: ${originalMax.toFixed()}`
       );
     }
-
-    destination.inputAmount.max = rounded;
-    buffer = buffer.add(dstBuffer);
 
     return { creationTime: Date.now(), tokenSwap, gasSwap };
   };
@@ -1019,6 +1024,7 @@ const _exactOutRoute = async (
       swaps: sourceSwapQuotes,
       creationTime: sourceSwapCreationTime,
       executions: sourceExecutions,
+      srcBuffer,
     },
     bridge: bridgeInput,
     destination,
@@ -1043,6 +1049,11 @@ export type SwapRoute = {
     swaps: QuoteResponse[];
     creationTime: number;
     executions: SourceExecutionRecord;
+    // Headroom in COT units that source swaps are allowed to lose on a re-quote when one
+    // or more source legs revert. EXACT_OUT carries `min(2%, $1)` of bridgeOutputWithFees
+    // (see SOURCE_SWAP_BUFFER_PCT / SOURCE_SWAP_MAX_IN_USD). EXACT_IN has no source-side
+    // headroom, so this is 0.
+    srcBuffer: Decimal;
   };
   bridge: BridgeInput;
   destination: {
@@ -1366,6 +1377,7 @@ const _exactInRoute = async (
       swaps: sourceSwaps,
       creationTime: sourceSwapCreationTime,
       executions: sourceExecutions,
+      srcBuffer: new Decimal(0),
     },
     bridge: bridgeInput,
     destination,

--- a/src/swap/route.ts
+++ b/src/swap/route.ts
@@ -370,6 +370,16 @@ enum BUFFER_EXACT_OUT {
   SOURCE_SWAP_MAX_IN_USD = 1, // <-- another magic
 }
 
+// EXACT_IN: source swaps run with the user's exact input, so we can't oversize them like
+// EXACT_OUT does. Instead we under-size the dst-swap input by `srcBuffer` and let leftover
+// COT sweep back to the EOA. That keeps the dst swap funded if a source leg reverts and
+// re-quotes up to `srcBuffer` lower; `retryWithSlippageCheck` uses the same value as its
+// retry tolerance.
+enum BUFFER_EXACT_IN {
+  SOURCE_SWAP_BUFFER_PCT = 0.5,
+  SOURCE_SWAP_MAX_IN_USD = 1,
+}
+
 // Headroom on the destination-swap input when source and destination collapse into a single
 // same-wrapper batch. Absorbs aggregator slippage between the source quote (which lands COT at
 // the wrapper) and the destination quote (which spends that COT) inside one atomic execution.
@@ -1207,8 +1217,10 @@ export type SwapRoute = {
     executions: SourceExecutionRecord;
     // Headroom in COT units that source swaps are allowed to lose on a re-quote when one
     // or more source legs revert. EXACT_OUT carries `min(2%, $1)` of bridgeOutputWithFees
-    // (see SOURCE_SWAP_BUFFER_PCT / SOURCE_SWAP_MAX_IN_USD). EXACT_IN has no source-side
-    // headroom, so this is 0.
+    // (see BUFFER_EXACT_OUT). EXACT_IN carries `min(0.5%, $1)` of swapCombinedBalance
+    // (see BUFFER_EXACT_IN) and also subtracts the same amount from the dst-swap input so
+    // the under-sized dst swap stays funded if a source leg re-quotes lower; combined-batch
+    // routes leave this at 0 since CombinedSwapHandler re-quotes both legs together.
     srcBuffer: Decimal;
   };
   bridge: BridgeInput;
@@ -1486,10 +1498,28 @@ const _exactInRoute = async (
       sourceSwaps.every((s) => Number(s.chainID) === currentInput.toChainId) &&
       !!sourceExecutions[currentInput.toChainId] &&
       equalFold(sourceExecutions[currentInput.toChainId].address, destinationExecution.address);
+
+    // Source-retry headroom. Only meaningful when there's an actual source swap that could
+    // revert and re-quote. Combined case uses CombinedSwapHandler (which re-quotes both legs
+    // together) and already applies COMBINED_SAME_CHAIN_BUFFER_PCT below — leave srcBuffer
+    // at 0 there to avoid double-reducing the dst input.
+    const srcBuffer =
+      isSrcSwapRequired && !willBeCombined
+        ? Decimal.min(
+            swapCombinedBalance.mul(BUFFER_EXACT_IN.SOURCE_SWAP_BUFFER_PCT / 100),
+            BUFFER_EXACT_IN.SOURCE_SWAP_MAX_IN_USD
+          )
+        : new Decimal(0);
+
     if (willBeCombined && needsDstSwap) {
       dstSwapInputAmountInDecimal = dstSwapInputAmountInDecimal.mul(
         1 - COMBINED_SAME_CHAIN_BUFFER_PCT / 100
       );
+    } else if (srcBuffer.gt(0) && needsDstSwap) {
+      // Under-size the dst-swap input by srcBuffer so a source re-quote drop up to that
+      // amount doesn't strand the dst-swap transferFrom on an under-supplied wrapper.
+      // Leftover COT post-swap is swept back to the EOA by the existing dst sweeper.
+      dstSwapInputAmountInDecimal = dstSwapInputAmountInDecimal.minus(srcBuffer);
     }
 
     dstSwapInputAmountInDecimal = dstSwapInputAmountInDecimal.toDP(
@@ -1570,7 +1600,7 @@ const _exactInRoute = async (
         swaps: sourceSwaps,
         creationTime: sourceSwapCreationTime,
         executions: sourceExecutions,
-        srcBuffer: new Decimal(0),
+        srcBuffer,
       },
       bridge: bridgeInput,
       destination,

--- a/src/swap/route.ts
+++ b/src/swap/route.ts
@@ -215,18 +215,51 @@ export const determineSwapRoute = async (
     aggregators: Aggregator[];
     cotCurrencyID: CurrencyID;
   }
-): Promise<SwapRoute> => {
+): Promise<{
+  route: SwapRoute;
+  refresh: (input: SwapData) => Promise<SwapRoute>;
+}> => {
   logger.debug('determineSwapRoute', {
     input,
     options,
   });
   console.time('swap-route-time');
-  const response = await (input.mode === SwapMode.EXACT_OUT
-    ? _exactOutRoute(input.data, options)
-    : _exactInRoute(input.data, options));
-  console.timeEnd('swap-route-time');
 
-  return response;
+  // Each inner route returns { route, refresh } with `refresh` accepting the unwrapped
+  // mode-specific data. We wrap that here so the outer refresh accepts the discriminated
+  // `SwapData` and rejects mode mismatches at runtime — refresh is a within-session
+  // operation, switching modes mid-session is a caller bug.
+  if (input.mode === SwapMode.EXACT_OUT) {
+    const { route, refresh: innerRefresh } = await _exactOutRoute(input.data, options);
+    console.timeEnd('swap-route-time');
+    return {
+      route,
+      // Marked async so the mode-check throw becomes a rejection instead of a synchronous
+      // exception (callers `await` the result and expect Promise semantics for errors).
+      refresh: async (next: SwapData) => {
+        if (next.mode !== SwapMode.EXACT_OUT) {
+          throw Errors.internal(
+            `refresh cannot switch swap mode (got ${next.mode}, expected EXACT_OUT)`
+          );
+        }
+        return innerRefresh(next.data);
+      },
+    };
+  }
+
+  const { route, refresh: innerRefresh } = await _exactInRoute(input.data, options);
+  console.timeEnd('swap-route-time');
+  return {
+    route,
+    refresh: async (next: SwapData) => {
+      if (next.mode !== SwapMode.EXACT_IN) {
+        throw Errors.internal(
+          `refresh cannot switch swap mode (got ${next.mode}, expected EXACT_IN)`
+        );
+      }
+      return innerRefresh(next.data);
+    },
+  };
 };
 
 export const applyBuffer = (amount: Decimal, bufferPercent: number): Decimal =>
@@ -339,15 +372,16 @@ const deductReservedBalance = (
   });
 };
 
-/** Fetches fee store, balances, oracle prices, and destination token info in parallel. */
+/** Fetches fee store, balances, oracle prices, and destination token info in parallel.
+ *  Returns the *unfiltered* balance set — `fromSources` / `removeSources` are now
+ *  applied by `_exactOutRoute`'s refresh body so a refresh with a different
+ *  fromSources doesn't have to refetch. */
 const fetchRouteData = async (
   params: SwapParams & { publicClientList: PublicClientList },
   opts: {
     toChainId: number;
     toTokenAddress: Hex;
     dstChain: ReturnType<SwapParams['chainList']['getChainByID']> & {};
-    allowedSources?: Source[];
-    removeSources?: Source[];
   }
 ) => {
   const oraclePricesPromise = params.cosmosQueryClient.fetchPriceOracle();
@@ -361,8 +395,6 @@ const fetchRouteData = async (
           chainList: params.chainList,
           vscClient: params.vscClient,
           filterWithSupportedTokens: false,
-          allowedSources: opts.allowedSources,
-          removeSources: opts.removeSources,
           publicClientList: params.publicClientList,
         }).then((r) => r.balances),
     oraclePricesPromise,
@@ -635,33 +667,32 @@ const _exactOutRoute = async (
     aggregators: Aggregator[];
     cotCurrencyID: CurrencyID;
   }
-): Promise<SwapRoute> => {
+): Promise<{
+  route: SwapRoute;
+  refresh: (input: ExactOutSwapInput) => Promise<SwapRoute>;
+}> => {
+  // === CLOSURE: computed once per swap() session, reused on every refresh ===========
+  //
+  // Stable across refresh: dst chain identity, oracle prices, fee store, dst-token
+  // metadata, the unfiltered raw balance set, and chain-level wrapper executions. The
+  // refresh body re-applies fromSources / removeSources filters against `rawBalances`,
+  // re-runs the aggregator quotes, and rebuilds the bridge intent. Balances are NOT
+  // re-fetched — refresh latency drops by the fetch round-trip + the fanout that
+  // getBalancesForSwap incurs on its own (vservice + transfer-fee per native chain).
+  //
+  // Caveat: a user who moves funds during the intent-approval window will see the
+  // pre-move balance set in subsequent refreshes. The aggregator quote at execution
+  // time will catch any actual insufficiency; we accept the small stale-state window
+  // in exchange for the latency win.
+
   const dstChain = params.chainList.getChainByID(input.toChainId);
   if (!dstChain) {
     throw Errors.chainNotFound(input.toChainId);
   }
 
-  // toAmount / toNativeAmount sentinel semantics (same shape for both):
-  //   > 0n   : shortfall — bridge this amount. Remove from dst-chain sources entirely.
-  //   < -1n  : surplus — reserve abs(value) from dst balance, use the rest as a swap source.
-  //   === -1n: exactly enough — remove from dst-chain sources entirely.
-  const removeSources: Source[] = [];
-  if (input.toAmount === -1n || input.toAmount > 0n) {
-    removeSources.push({
-      chainId: input.toChainId,
-      tokenAddress: input.toTokenAddress,
-    });
-  }
-  const reserveTokenAmount = input.toAmount < -1n ? -input.toAmount : undefined;
-  const reserveNativeAmount =
-    input.toNativeAmount && input.toNativeAmount < -1n ? -input.toNativeAmount : undefined;
-  if (input.toNativeAmount === -1n || (input.toNativeAmount && input.toNativeAmount > 0n)) {
-    removeSources.push({
-      chainId: input.toChainId,
-      tokenAddress: ZERO_ADDRESS,
-    });
-  }
-
+  // Fetch unfiltered balances. allowedSources/removeSources were previously passed
+  // here so getBalancesForSwap could pre-filter; we now apply both per-call in refresh
+  // (so a refresh with a different fromSources doesn't have to re-fetch).
   const {
     feeStore,
     balances: rawBalances,
@@ -671,379 +702,420 @@ const _exactOutRoute = async (
     toChainId: input.toChainId,
     toTokenAddress: input.toTokenAddress,
     dstChain,
-    allowedSources: input.fromSources,
-    removeSources,
   });
-
-  // When using preloaded balances, apply the allowedSources/removeSources filters inline.
-  let balances = rawBalances;
-  if (params.preloadedBalances) {
-    if (input.fromSources?.length) {
-      balances = filterAllowedSources(balances, input.fromSources);
-    }
-    balances = filterRemoveSources(balances, removeSources);
-  }
-
-  // Surplus case: reserve the required amount from dst-chain balance so only the
-  // surplus is available as a swap source.
-  if (reserveTokenAmount) {
-    balances = deductReservedBalance(
-      balances,
-      input.toChainId,
-      normalizeToComparisonAddr(input.toTokenAddress),
-      reserveTokenAmount,
-      dstTokenInfo.decimals
-    );
-  }
-  if (reserveNativeAmount) {
-    balances = deductReservedBalance(
-      balances,
-      input.toChainId,
-      normalizeToComparisonAddr(ZERO_ADDRESS),
-      reserveNativeAmount,
-      dstChain.nativeCurrency.decimals
-    );
-  }
-
-  const dstOmniversalChainID = new OmniversalChainID(Universe.ETHEREUM, input.toChainId);
-
-  logger.debug('exact-out: fetched balances', { balances, input });
 
   const { cot: dstChainCOT, address: dstChainCOTAddress } = getCOTForChainId(
     input.toChainId,
     params.cotCurrencyID
   );
+  const dstOmniversalChainID = new OmniversalChainID(Universe.ETHEREUM, input.toChainId);
 
-  let gasInCOT = new Decimal(0);
-  if (input.toNativeAmount && input.toNativeAmount > 0n) {
-    // Convert to COT
-    gasInCOT = convertGasToToken(
-      {
-        contractAddress: dstChainCOTAddress,
-        decimals: dstChainCOT.decimals,
-      },
-      oraclePrices,
-      dstChain.id,
-      dstChain.universe,
-      divDecimals(input.toNativeAmount, dstChain.nativeCurrency.decimals)
-    ).mul(1.02);
-  }
-
-  let buffer = new Decimal(0);
-
-  const needsTokenSwap =
-    input.toAmount > 0n && !equalFold(input.toTokenAddress, dstChainCOTAddress);
-  const needsGasSwap = !gasInCOT.isZero();
-
-  // Resolve every chain we'll need a wrapper on in a single sync pass:
-  //   dst + every source chain (deduped). Safe addresses are computed locally; the only
-  //   async piece (`verification`) is awaited at the very end before the route returns.
-  const sortedBalances = sortSourcesByPriority(balances, {
-    tokenAddress: input.toTokenAddress,
-    symbol: dstTokenInfo.symbol,
-    chainID: dstChain.id,
-  });
+  // Chain-level Safe addresses are deterministic from the ephemeral, so resolve once
+  // across the dst chain plus every chain that appears in the unfiltered balance set.
+  // Any fromSources used in refresh is necessarily a subset.
   const { executions: chainExecutions, verification: executionsVerification } =
     resolveChainExecutions({
-      chainIds: [input.toChainId, ...sortedBalances.map((b) => b.chainID)],
+      chainIds: [input.toChainId, ...rawBalances.map((b) => b.chainID)],
       ephemeralAddress: params.address.ephemeral,
       chainList: params.chainList,
       vscClient: params.vscClient,
     });
-  const destinationExecution: DestinationExecution =
-    needsTokenSwap || needsGasSwap
-      ? chainExecutions[input.toChainId]
-      : buildDirectEoaDestinationExecution(params.address.eoa);
-  // Aggregator simulation context (taker_address / fromAddress) must be the wrapper — that's
-  // the on-chain executor at runtime, so the aggregator's permit/approval routing has to match.
-  // Output recipient is the user's EOA so we never need to sweep token or native dust out of
-  // the wrapper post-swap. Safe doesn't implement ERC-7914, so the previous
-  // wrapper-as-recipient + sweep pattern broke `approveNative`. Splitting these two roles
-  // (userAddress vs receiverAddress) lets the aggregator simulate as the wrapper but deliver
-  // output to the EOA. Applies uniformly to 7702 (Calibur) and `safe_account` modes.
-  const dstSwapTakerInBytes = convertTo32Bytes(destinationExecution.address);
-  const dstSwapReceiverInBytes = convertTo32Bytes(params.address.eoa);
 
-  // COT required for direct transfer when toToken IS COT and toAmount is a positive
-  // shortfall. Zero when a swap resolves it, or under sentinel toAmount (-1n / <-1n).
-  const cotTransferAmount =
-    input.toAmount > 0n && !needsTokenSwap
-      ? divDecimals(input.toAmount, dstChainCOT.decimals)
-      : new Decimal(0);
-
-  const destination = createDestination(
-    input.toChainId,
-    destinationExecution,
-    cotTransferAmount.add(gasInCOT)
-  );
-
-  let originalMax: Decimal | null = null;
-  const getDstSwap = async (): Promise<DestinationSwap> => {
-    if (!needsTokenSwap && !needsGasSwap) {
-      return { creationTime: Date.now(), tokenSwap: null, gasSwap: null };
+  // === REFRESH: re-runs per call ===================================================
+  //
+  // toChainId / toTokenAddress are immutable across refresh (they're the destination
+  // identity — refresh re-quoting against a different destination is a different swap).
+  // toAmount / toNativeAmount sentinels and fromSources MAY change between calls, so
+  // every dependent value (removeSources, gasInCOT, needsTokenSwap, …) is recomputed
+  // here from `currentInput`, not closed over the initial input.
+  const refresh = async (currentInput: ExactOutSwapInput): Promise<SwapRoute> => {
+    // toAmount / toNativeAmount sentinel semantics (same shape for both):
+    //   > 0n   : shortfall — bridge this amount. Remove from dst-chain sources entirely.
+    //   < -1n  : surplus — reserve abs(value) from dst balance, use the rest as a swap source.
+    //   === -1n: exactly enough — remove from dst-chain sources entirely.
+    const removeSources: Source[] = [];
+    if (currentInput.toAmount === -1n || currentInput.toAmount > 0n) {
+      removeSources.push({
+        chainId: currentInput.toChainId,
+        tokenAddress: currentInput.toTokenAddress,
+      });
+    }
+    const reserveTokenAmount = currentInput.toAmount < -1n ? -currentInput.toAmount : undefined;
+    const reserveNativeAmount =
+      currentInput.toNativeAmount && currentInput.toNativeAmount < -1n
+        ? -currentInput.toNativeAmount
+        : undefined;
+    if (
+      currentInput.toNativeAmount === -1n ||
+      (currentInput.toNativeAmount && currentInput.toNativeAmount > 0n)
+    ) {
+      removeSources.push({
+        chainId: currentInput.toChainId,
+        tokenAddress: ZERO_ADDRESS,
+      });
     }
 
-    const [tokenSwap, gasSwap] = await Promise.all([
-      needsTokenSwap
-        ? getDestinationExactOutSwap({
-            takerAddress: dstSwapTakerInBytes,
-            receiverAddress: dstSwapReceiverInBytes,
-            requirement: {
-              chainID: dstOmniversalChainID,
-              amountRaw: BigInt(input.toAmount),
-              tokenAddress: convertTo32Bytes(input.toTokenAddress),
-            },
-            aggregators: params.aggregators,
-          })
-        : null,
-      needsGasSwap
-        ? getDestinationExactInSwap({
-            takerAddress: dstSwapTakerInBytes,
-            receiverAddress: dstSwapReceiverInBytes,
-            chain: dstOmniversalChainID,
-            inputAmount: mulDecimals(gasInCOT, dstChainCOT.decimals),
-            outputToken: EADDRESS_32_BYTES,
-            aggregators: params.aggregators,
-          })
-        : null,
-    ]);
+    // Always apply filters against the closure's unfiltered set so a refresh with a
+    // different fromSources doesn't carry over a previous filter.
+    let balances = rawBalances;
+    if (currentInput.fromSources?.length) {
+      balances = filterAllowedSources(balances, currentInput.fromSources);
+    }
+    balances = filterRemoveSources(balances, removeSources);
 
-    // COT input = swap quote input (or direct COT transfer) + gas
-    destination.inputAmount.min = new Decimal(
-      tokenSwap?.quote.input.amount ?? cotTransferAmount
-    ).add(gasInCOT);
-
-    if (originalMax === null) {
-      // First call: size the bridge by adding the destination buffer (min(10%, $2)).
-      // Leftover COT at the wrapper post-swap is swept back to the EOA.
-      const { amountWithBuffer, buffer: dstBuffer } = applyBufferWithCap(
-        destination.inputAmount.min,
-        BUFFER_EXACT_OUT.DESTINATION_SWAP_BUFFER_PCT,
-        BUFFER_EXACT_OUT.DESTINATION_SWAP_MAX_IN_USD
+    // Surplus case: reserve the required amount from dst-chain balance so only the
+    // surplus is available as a swap source.
+    if (reserveTokenAmount) {
+      balances = deductReservedBalance(
+        balances,
+        currentInput.toChainId,
+        normalizeToComparisonAddr(currentInput.toTokenAddress),
+        reserveTokenAmount,
+        dstTokenInfo.decimals
       );
-      const rounded = amountWithBuffer.toDP(dstChainCOT.decimals, Decimal.ROUND_CEIL);
-      originalMax = rounded;
-      destination.inputAmount.max = rounded;
-      buffer = buffer.add(dstBuffer);
-    } else if (destination.inputAmount.min.gt(originalMax)) {
-      // Requote: the bridge has already been sized for `originalMax`. A requote whose
-      // input requirement still fits inside that budget is fine — leftover gets swept.
-      // Only reject when the requote genuinely outgrows what the bridge funded; do NOT
-      // re-add the buffer on top of newInputMin (that would shrink the usable budget
-      // and reject valid requotes that actually fit). inputAmount.max stays pinned at
-      // originalMax — the bridge already happened, the budget is fixed.
-      throw Errors.ratesChangedBeyondTolerance(
-        Number(destination.inputAmount.min.toFixed()),
-        `max budget: ${originalMax.toFixed()}`
+    }
+    if (reserveNativeAmount) {
+      balances = deductReservedBalance(
+        balances,
+        currentInput.toChainId,
+        normalizeToComparisonAddr(ZERO_ADDRESS),
+        reserveNativeAmount,
+        dstChain.nativeCurrency.decimals
       );
     }
 
-    return { creationTime: Date.now(), tokenSwap, gasSwap };
-  };
+    logger.debug('exact-out: fetched balances', { balances, input: currentInput });
 
-  destination.swap = await getDstSwap();
-  destination.getDstSwap = getDstSwap;
+    let gasInCOT = new Decimal(0);
+    if (currentInput.toNativeAmount && currentInput.toNativeAmount > 0n) {
+      // Convert to COT
+      gasInCOT = convertGasToToken(
+        {
+          contractAddress: dstChainCOTAddress,
+          decimals: dstChainCOT.decimals,
+        },
+        oraclePrices,
+        dstChain.id,
+        dstChain.universe,
+        divDecimals(currentInput.toNativeAmount, dstChain.nativeCurrency.decimals)
+      ).mul(1.02);
+    }
 
-  logger.debug('destination swaps', destination.swap);
+    let buffer = new Decimal(0);
 
-  // One balance per chain, mapped to its COT for collection fee estimation
-  const cotBalancesPerChain = uniqBy(
-    balances.filter((b) => new Decimal(b.amount).gt(0)),
-    (b) => b.chainID
-  ).map((b) => {
-    const { cot: chainCOT, address: cotAddress } = getCOTForChainId(
-      b.chainID,
-      params.cotCurrencyID
+    const needsTokenSwap =
+      currentInput.toAmount > 0n && !equalFold(currentInput.toTokenAddress, dstChainCOTAddress);
+    const needsGasSwap = !gasInCOT.isZero();
+
+    const sortedBalances = sortSourcesByPriority(balances, {
+      tokenAddress: currentInput.toTokenAddress,
+      symbol: dstTokenInfo.symbol,
+      chainID: dstChain.id,
+    });
+    let destinationExecution: DestinationExecution =
+      needsTokenSwap || needsGasSwap
+        ? chainExecutions[currentInput.toChainId]
+        : buildDirectEoaDestinationExecution(params.address.eoa);
+    // Aggregator simulation context (taker_address / fromAddress) must be the wrapper —
+    // that's the on-chain executor at runtime, so the aggregator's permit/approval routing
+    // has to match. Output recipient is the user's EOA so we never need to sweep token or
+    // native dust out of the wrapper post-swap. Safe doesn't implement ERC-7914, so the
+    // previous wrapper-as-recipient + sweep pattern broke `approveNative`. Splitting these
+    // two roles (userAddress vs receiverAddress) lets the aggregator simulate as the wrapper
+    // but deliver output to the EOA. Applies uniformly to 7702 (Calibur) and `safe_account`.
+    const dstSwapTakerInBytes = convertTo32Bytes(destinationExecution.address);
+    const dstSwapReceiverInBytes = convertTo32Bytes(params.address.eoa);
+
+    // COT required for direct transfer when toToken IS COT and toAmount is a positive
+    // shortfall. Zero when a swap resolves it, or under sentinel toAmount (-1n / <-1n).
+    const cotTransferAmount =
+      currentInput.toAmount > 0n && !needsTokenSwap
+        ? divDecimals(currentInput.toAmount, dstChainCOT.decimals)
+        : new Decimal(0);
+
+    const destination = createDestination(
+      currentInput.toChainId,
+      destinationExecution,
+      cotTransferAmount.add(gasInCOT)
     );
-    return {
-      value: b.value,
-      chainID: b.chainID,
-      contractAddress: cotAddress,
-      decimals: chainCOT.decimals,
+
+    let originalMax: Decimal | null = null;
+    const getDstSwap = async (): Promise<DestinationSwap> => {
+      if (!needsTokenSwap && !needsGasSwap) {
+        return { creationTime: Date.now(), tokenSwap: null, gasSwap: null };
+      }
+
+      const [tokenSwap, gasSwap] = await Promise.all([
+        needsTokenSwap
+          ? getDestinationExactOutSwap({
+              takerAddress: dstSwapTakerInBytes,
+              receiverAddress: dstSwapReceiverInBytes,
+              requirement: {
+                chainID: dstOmniversalChainID,
+                amountRaw: BigInt(currentInput.toAmount),
+                tokenAddress: convertTo32Bytes(currentInput.toTokenAddress),
+              },
+              aggregators: params.aggregators,
+            })
+          : null,
+        needsGasSwap
+          ? getDestinationExactInSwap({
+              takerAddress: dstSwapTakerInBytes,
+              receiverAddress: dstSwapReceiverInBytes,
+              chain: dstOmniversalChainID,
+              inputAmount: mulDecimals(gasInCOT, dstChainCOT.decimals),
+              outputToken: EADDRESS_32_BYTES,
+              aggregators: params.aggregators,
+            })
+          : null,
+      ]);
+
+      // COT input = swap quote input (or direct COT transfer) + gas
+      destination.inputAmount.min = new Decimal(
+        tokenSwap?.quote.input.amount ?? cotTransferAmount
+      ).add(gasInCOT);
+
+      if (originalMax === null) {
+        // First call: size the bridge by adding the destination buffer (min(10%, $2)).
+        // Leftover COT at the wrapper post-swap is swept back to the EOA.
+        const { amountWithBuffer, buffer: dstBuffer } = applyBufferWithCap(
+          destination.inputAmount.min,
+          BUFFER_EXACT_OUT.DESTINATION_SWAP_BUFFER_PCT,
+          BUFFER_EXACT_OUT.DESTINATION_SWAP_MAX_IN_USD
+        );
+        const rounded = amountWithBuffer.toDP(dstChainCOT.decimals, Decimal.ROUND_CEIL);
+        originalMax = rounded;
+        destination.inputAmount.max = rounded;
+        buffer = buffer.add(dstBuffer);
+      } else if (destination.inputAmount.min.gt(originalMax)) {
+        // Requote: the bridge has already been sized for `originalMax`. A requote whose
+        // input requirement still fits inside that budget is fine — leftover gets swept.
+        // Only reject when the requote genuinely outgrows what the bridge funded; do NOT
+        // re-add the buffer on top of newInputMin (that would shrink the usable budget
+        // and reject valid requotes that actually fit). inputAmount.max stays pinned at
+        // originalMax — the bridge already happened, the budget is fixed.
+        throw Errors.ratesChangedBeyondTolerance(
+          Number(destination.inputAmount.min.toFixed()),
+          `max budget: ${originalMax.toFixed()}`
+        );
+      }
+
+      return { creationTime: Date.now(), tokenSwap, gasSwap };
     };
-  });
 
-  const estimatedCollectionFee = estimateCollectionFee(
-    cotBalancesPerChain,
-    destination.inputAmount.max,
-    feeStore
-  );
-  const estimatedBridgeFees = feeStore
-    .calculateFulfilmentFee({
-      decimals: dstChainCOT.decimals,
-      destinationChainID: Number(input.toChainId),
-      destinationTokenAddress: dstChainCOTAddress,
-    })
-    .add(estimatedCollectionFee);
+    destination.swap = await getDstSwap();
+    destination.getDstSwap = getDstSwap;
 
-  const bridgeOutput = destination.inputAmount.max;
-  const bridgeOutputWithFees = bridgeOutput.add(estimatedBridgeFees);
+    logger.debug('destination swaps', destination.swap);
 
-  const { amountWithBuffer: sourceSwapOutputRequired, buffer: srcBuffer } = applyBufferWithCap(
-    bridgeOutputWithFees,
-    BUFFER_EXACT_OUT.SOURCE_SWAP_BUFFER_PCT,
-    BUFFER_EXACT_OUT.SOURCE_SWAP_MAX_IN_USD
-  );
+    // One balance per chain, mapped to its COT for collection fee estimation
+    const cotBalancesPerChain = uniqBy(
+      balances.filter((b) => new Decimal(b.amount).gt(0)),
+      (b) => b.chainID
+    ).map((b) => {
+      const { cot: chainCOT, address: cotAddress } = getCOTForChainId(
+        b.chainID,
+        params.cotCurrencyID
+      );
+      return {
+        value: b.value,
+        chainID: b.chainID,
+        contractAddress: cotAddress,
+        decimals: chainCOT.decimals,
+      };
+    });
 
-  buffer = buffer.add(srcBuffer);
+    const estimatedCollectionFee = estimateCollectionFee(
+      cotBalancesPerChain,
+      destination.inputAmount.max,
+      feeStore
+    );
+    const estimatedBridgeFees = feeStore
+      .calculateFulfilmentFee({
+        decimals: dstChainCOT.decimals,
+        destinationChainID: Number(currentInput.toChainId),
+        destinationTokenAddress: dstChainCOTAddress,
+      })
+      .add(estimatedCollectionFee);
 
-  logger.debug('exact-out: source swap requirements', {
-    dstChainCOTAddress,
-    srcBuffer: srcBuffer.toFixed(),
-    buffer: buffer.toFixed(),
-    estimatedBridgeFees: estimatedBridgeFees.toFixed(),
-    bridgeOutput: bridgeOutput.toFixed(),
-    sourceSwapOutputRequired: sourceSwapOutputRequired.toFixed(),
-  });
+    const bridgeOutput = destination.inputAmount.max;
+    const bridgeOutputWithFees = bridgeOutput.add(estimatedBridgeFees);
 
-  const sourceExecutions = pickSourceExecutions(chainExecutions, sortedBalances);
+    const { amountWithBuffer: sourceSwapOutputRequired, buffer: srcBuffer } = applyBufferWithCap(
+      bridgeOutputWithFees,
+      BUFFER_EXACT_OUT.SOURCE_SWAP_BUFFER_PCT,
+      BUFFER_EXACT_OUT.SOURCE_SWAP_MAX_IN_USD
+    );
 
-  const { quoteResponses: rawSourceSwapQuotes, usedCOTs: rawUsedCOTs } = await autoSelectSources({
-    holdings: toAggregatorInputsWithSwapAddresses(sortedBalances, sourceExecutions),
-    outputRequired: sourceSwapOutputRequired,
-    aggregators: params.aggregators,
-    commonCurrencyID: params.cotCurrencyID,
-  }).catch((e) => {
-    if (e instanceof Error && e.message === 'NOT_ENOUGH_SWAP_FOR_REQUIREMENT') {
-      throw Errors.quoteError();
-    }
-    throw e;
-  });
+    buffer = buffer.add(srcBuffer);
 
-  // autoSelectSources is sized against sourceSwapOutputRequired (= bridgeOutput +
-  // bridgeFees + srcBuffer). When dst-chain holdings sit in the
-  // (bridgeOutput, sourceSwapOutputRequired) window, they get fully consumed and a tiny
-  // non-dst source is selected to cover the fee/buffer headroom. That non-dst contribution
-  // isn't actually needed — dst-chain alone already covers bridgeOutput — and if left in
-  // place it both drives `bridgeAmount` negative below and strands the non-dst source-swap
-  // output at the source-chain wrapper (no bridge step would pick it up). Drop non-dst
-  // selections in that case; the existing isBridgeRequired check then naturally evaluates
-  // to false.
-  const dstContribution = rawUsedCOTs
-    .reduce(
-      (sum, c) =>
-        Number(c.originalHolding.chainID.chainID) === input.toChainId
-          ? sum.plus(c.amountUsed)
-          : sum,
-      new Decimal(0)
-    )
-    .plus(
-      rawSourceSwapQuotes.reduce(
-        (sum, q) => (q.chainID === input.toChainId ? sum.plus(q.quote.output.amount) : sum),
+    logger.debug('exact-out: source swap requirements', {
+      dstChainCOTAddress,
+      srcBuffer: srcBuffer.toFixed(),
+      buffer: buffer.toFixed(),
+      estimatedBridgeFees: estimatedBridgeFees.toFixed(),
+      bridgeOutput: bridgeOutput.toFixed(),
+      sourceSwapOutputRequired: sourceSwapOutputRequired.toFixed(),
+    });
+
+    const sourceExecutions = pickSourceExecutions(chainExecutions, sortedBalances);
+
+    const { quoteResponses: rawSourceSwapQuotes, usedCOTs: rawUsedCOTs } = await autoSelectSources({
+      holdings: toAggregatorInputsWithSwapAddresses(sortedBalances, sourceExecutions),
+      outputRequired: sourceSwapOutputRequired,
+      aggregators: params.aggregators,
+      commonCurrencyID: params.cotCurrencyID,
+    }).catch((e) => {
+      if (e instanceof Error && e.message === 'NOT_ENOUGH_SWAP_FOR_REQUIREMENT') {
+        throw Errors.quoteError();
+      }
+      throw e;
+    });
+
+    // autoSelectSources is sized against sourceSwapOutputRequired (= bridgeOutput +
+    // bridgeFees + srcBuffer). When dst-chain holdings sit in the
+    // (bridgeOutput, sourceSwapOutputRequired) window, they get fully consumed and a tiny
+    // non-dst source is selected to cover the fee/buffer headroom. That non-dst contribution
+    // isn't actually needed — dst-chain alone already covers bridgeOutput — and if left in
+    // place it both drives `bridgeAmount` negative below and strands the non-dst source-swap
+    // output at the source-chain wrapper (no bridge step would pick it up). Drop non-dst
+    // selections in that case; the existing isBridgeRequired check then naturally evaluates
+    // to false.
+    const dstContribution = rawUsedCOTs
+      .reduce(
+        (sum, c) =>
+          Number(c.originalHolding.chainID.chainID) === currentInput.toChainId
+            ? sum.plus(c.amountUsed)
+            : sum,
         new Decimal(0)
       )
+      .plus(
+        rawSourceSwapQuotes.reduce(
+          (sum, q) =>
+            q.chainID === currentInput.toChainId ? sum.plus(q.quote.output.amount) : sum,
+          new Decimal(0)
+        )
+      );
+
+    const dropNonDst = dstContribution.gte(bridgeOutput);
+    const sourceSwapQuotes = dropNonDst
+      ? rawSourceSwapQuotes.filter((q) => q.chainID === currentInput.toChainId)
+      : rawSourceSwapQuotes;
+    const usedCOTs = dropNonDst
+      ? rawUsedCOTs.filter(
+          (c) => Number(c.originalHolding.chainID.chainID) === currentInput.toChainId
+        )
+      : rawUsedCOTs;
+    if (dropNonDst) {
+      logger.debug('exact-out: dst-chain covers bridgeOutput, dropping non-dst selections', {
+        dstContribution: dstContribution.toFixed(),
+        bridgeOutput: bridgeOutput.toFixed(),
+        droppedQuotes: rawSourceSwapQuotes.length - sourceSwapQuotes.length,
+        droppedCOTs: rawUsedCOTs.length - usedCOTs.length,
+      });
+    }
+
+    logger.debug('sourceSwap', {
+      sourceSwapQuotes,
+    });
+
+    const sourceSwapCreationTime = Date.now();
+
+    const { assetsUsed, bridgeAssets, dstTotalCOTAmount, dstEOAToEphTx } =
+      buildExactOutSourceAssets(
+        usedCOTs,
+        sourceSwapQuotes,
+        currentInput.toChainId,
+        dstChainCOT.decimals
+      );
+
+    destination.eoaToDestinationAccount = dstEOAToEphTx;
+
+    if (
+      !needsTokenSwap &&
+      !needsGasSwap &&
+      hasDestinationChainSourceSwapOutput(
+        sourceSwapQuotes,
+        sourceExecutions,
+        currentInput.toChainId,
+        params.address.eoa
+      )
+    ) {
+      // Source swaps land COT on the dst chain at a non-EOA wrapper, so the dst leg can't
+      // stay as `direct_eoa` after all. The wrapper was already resolved up-front (same
+      // chain, same ephemeral) — flip is a sync lookup, no extra VSC roundtrip.
+      destinationExecution = chainExecutions[currentInput.toChainId];
+      destination.execution = destinationExecution;
+    }
+
+    const isBridgeRequired = !(
+      sourceSwapQuotes.every((q) => q.chainID === currentInput.toChainId) &&
+      usedCOTs.every((q) => Number(q.originalHolding.chainID.chainID) === currentInput.toChainId)
     );
 
-  const dropNonDst = dstContribution.gte(bridgeOutput);
-  const sourceSwapQuotes = dropNonDst
-    ? rawSourceSwapQuotes.filter((q) => q.chainID === input.toChainId)
-    : rawSourceSwapQuotes;
-  const usedCOTs = dropNonDst
-    ? rawUsedCOTs.filter((c) => Number(c.originalHolding.chainID.chainID) === input.toChainId)
-    : rawUsedCOTs;
-  if (dropNonDst) {
-    logger.debug('exact-out: dst-chain covers bridgeOutput, dropping non-dst selections', {
-      dstContribution: dstContribution.toFixed(),
-      bridgeOutput: bridgeOutput.toFixed(),
-      droppedQuotes: rawSourceSwapQuotes.length - sourceSwapQuotes.length,
-      droppedCOTs: rawUsedCOTs.length - usedCOTs.length,
-    });
-  }
-
-  logger.debug('sourceSwap', {
-    sourceSwapQuotes,
-  });
-
-  const sourceSwapCreationTime = Date.now();
-
-  const { assetsUsed, bridgeAssets, dstTotalCOTAmount, dstEOAToEphTx } = buildExactOutSourceAssets(
-    usedCOTs,
-    sourceSwapQuotes,
-    input.toChainId,
-    dstChainCOT.decimals
-  );
-
-  destination.eoaToDestinationAccount = dstEOAToEphTx;
-
-  if (
-    !needsTokenSwap &&
-    !needsGasSwap &&
-    hasDestinationChainSourceSwapOutput(
-      sourceSwapQuotes,
-      sourceExecutions,
-      input.toChainId,
-      params.address.eoa
-    )
-  ) {
-    // Source swaps land COT on the dst chain at a non-EOA wrapper, so the dst leg can't
-    // stay as `direct_eoa` after all. The wrapper was already resolved up-front (same
-    // chain, same ephemeral) — flip is a sync lookup, no extra VSC roundtrip.
-    destination.execution = chainExecutions[input.toChainId];
-  }
-
-  const isBridgeRequired = !(
-    sourceSwapQuotes.every((q) => q.chainID === input.toChainId) &&
-    usedCOTs.every((q) => Number(q.originalHolding.chainID.chainID) === input.toChainId)
-  );
-
-  let bridgeInput: BridgeInput = null;
-  if (isBridgeRequired) {
-    // Deduct dst-chain COT (already on destination, doesn't need bridging).
-    const bridgeAmount = bridgeOutput.minus(dstTotalCOTAmount);
-    if (bridgeAmount.lte(0)) {
-      // Invariant: the dst-chain drop above guarantees dstTotalCOTAmount ≤ bridgeOutput
-      // whenever isBridgeRequired is true. Reaching this branch means the invariant was
-      // violated (e.g. a future change to autoSelectSources or buildExactOutSourceAssets
-      // breaks the accounting). Log so the regression is visible, but skip the bridge
-      // rather than build a degenerate zero/negative-amount intent.
-      logger.warn('exact-out: non-positive bridgeAmount after dst-chain drop, skipping bridge', {
-        bridgeAmount: bridgeAmount.toFixed(),
-        bridgeOutput: bridgeOutput.toFixed(),
-        dstTotalCOTAmount: dstTotalCOTAmount.toFixed(),
-      });
-    } else {
-      const pendingBridge: PendingBridgeInput = {
-        amount: bridgeAmount,
-        assets: bridgeAssets,
-        chainID: input.toChainId,
-        decimals: dstChainCOT.decimals,
-        recipientAddress: destination.execution.address,
-        tokenAddress: convertToEVMAddress(dstChainCOT.tokenAddress),
-      };
-      const intentResponse = createIntent({
-        dstChain,
-        assets: bridgeAssets,
-        feeStore,
-        output: pendingBridge,
-        address: pendingBridge.recipientAddress,
-      });
-      bridgeInput = { ...pendingBridge, estimatedFees: intentResponse.intent.fees };
+    let bridgeInput: BridgeInput = null;
+    if (isBridgeRequired) {
+      // Deduct dst-chain COT (already on destination, doesn't need bridging).
+      const bridgeAmount = bridgeOutput.minus(dstTotalCOTAmount);
+      if (bridgeAmount.lte(0)) {
+        // Invariant: the dst-chain drop above guarantees dstTotalCOTAmount ≤ bridgeOutput
+        // whenever isBridgeRequired is true. Reaching this branch means the invariant was
+        // violated (e.g. a future change to autoSelectSources or buildExactOutSourceAssets
+        // breaks the accounting). Log so the regression is visible, but skip the bridge
+        // rather than build a degenerate zero/negative-amount intent.
+        logger.warn('exact-out: non-positive bridgeAmount after dst-chain drop, skipping bridge', {
+          bridgeAmount: bridgeAmount.toFixed(),
+          bridgeOutput: bridgeOutput.toFixed(),
+          dstTotalCOTAmount: dstTotalCOTAmount.toFixed(),
+        });
+      } else {
+        const pendingBridge: PendingBridgeInput = {
+          amount: bridgeAmount,
+          assets: bridgeAssets,
+          chainID: currentInput.toChainId,
+          decimals: dstChainCOT.decimals,
+          recipientAddress: destination.execution.address,
+          tokenAddress: convertToEVMAddress(dstChainCOT.tokenAddress),
+        };
+        const intentResponse = createIntent({
+          dstChain,
+          assets: bridgeAssets,
+          feeStore,
+          output: pendingBridge,
+          address: pendingBridge.recipientAddress,
+        });
+        bridgeInput = { ...pendingBridge, estimatedFees: intentResponse.intent.fees };
+      }
     }
-  }
 
-  logger.debug('exact-out: bridge', { bridgeAssets, bridgeInput, assetsUsed, dstEOAToEphTx });
+    logger.debug('exact-out: bridge', { bridgeAssets, bridgeInput, assetsUsed, dstEOAToEphTx });
 
-  // VSC verification is fire-and-forget during the rest of route calc; resolve it now
-  // before returning so any SDK ↔ server config drift surfaces here instead of mid-execution.
-  await executionsVerification;
+    // VSC verification is fire-and-forget during the rest of route calc; resolve it now
+    // before returning so any SDK ↔ server config drift surfaces here instead of mid-execution.
+    // After the first refresh resolves it, subsequent refreshes just hit the already-settled
+    // microtask.
+    await executionsVerification;
 
-  return buildSwapRouteResult({
-    type: 'EXACT_OUT',
-    source: {
-      swaps: sourceSwapQuotes,
-      creationTime: sourceSwapCreationTime,
-      executions: sourceExecutions,
-      srcBuffer,
-    },
-    bridge: bridgeInput,
-    destination,
-    dstTokenInfo,
-    aggregators: params.aggregators,
-    oraclePrices,
-    balances,
-    assetsUsed,
-    buffer: buffer.toFixed(),
-  });
+    return buildSwapRouteResult({
+      type: 'EXACT_OUT',
+      source: {
+        swaps: sourceSwapQuotes,
+        creationTime: sourceSwapCreationTime,
+        executions: sourceExecutions,
+        srcBuffer,
+      },
+      bridge: bridgeInput,
+      destination,
+      dstTokenInfo,
+      aggregators: params.aggregators,
+      oraclePrices,
+      balances,
+      assetsUsed,
+      buffer: buffer.toFixed(),
+    });
+  };
+
+  return { route: await refresh(input), refresh };
 };
 
 type DestinationSwap = {
@@ -1134,7 +1206,17 @@ const _exactInRoute = async (
     publicClientList: PublicClientList;
     cotCurrencyID: CurrencyID;
   }
-): Promise<SwapRoute> => {
+): Promise<{
+  route: SwapRoute;
+  refresh: (input: ExactInSwapInput) => Promise<SwapRoute>;
+}> => {
+  // === CLOSURE: computed once per swap() session, reused on every refresh ===========
+  //
+  // Stable: dst chain identity, raw balance set, oracle prices, fee store, dst token
+  // metadata, and chain-level wrapper executions. The closure does NOT pre-apply
+  // `input.from` filtering — that may change across refresh and is recomputed per call
+  // via `resolveSourceBalances` inside refresh.
+
   logger.debug('exactInRoute', {
     input,
     params,
@@ -1145,263 +1227,274 @@ const _exactInRoute = async (
     throw Errors.chainNotFound(input.toChainId);
   }
 
-  const { feeStore, balances, oraclePrices, dstTokenInfo } = await fetchRouteData(params, {
+  const {
+    feeStore,
+    balances: rawBalances,
+    oraclePrices,
+    dstTokenInfo,
+  } = await fetchRouteData(params, {
     toChainId: input.toChainId,
     toTokenAddress: input.toTokenAddress,
     dstChain,
   });
 
-  if (balances.length === 0) {
+  if (rawBalances.length === 0) {
     throw Errors.noBalanceForAddress(params.address.eoa);
   }
-
-  logger.debug('exact-in: fetched balances', { balances });
-
-  const { srcBalances, assetsUsed } = resolveSourceBalances(input.from, balances);
 
   const { cot: dstChainCOT, address: dstChainCOTAddress } = getCOTForChainId(
     input.toChainId,
     params.cotCurrencyID
   );
-
   const dstOmniversalChainID = new OmniversalChainID(Universe.ETHEREUM, input.toChainId);
 
-  // Resolve every chain we'll need a wrapper on (dst + every source chain) in a single
-  // sync pass. VSC verification fires in the background via `executionsVerification` and
-  // is awaited right before the route returns.
+  // Resolve every chain we'll need a wrapper on across the full unfiltered balance set
+  // (any refresh `from` is necessarily a subset). VSC verification fires in the
+  // background and is awaited inside refresh just before the route returns.
   const { executions: chainExecutions, verification: executionsVerification } =
     resolveChainExecutions({
-      chainIds: [input.toChainId, ...srcBalances.map((b) => b.chainID)],
+      chainIds: [input.toChainId, ...rawBalances.map((b) => b.chainID)],
       ephemeralAddress: params.address.ephemeral,
       chainList: params.chainList,
       vscClient: params.vscClient,
     });
-  const sourceExecutions = pickSourceExecutions(chainExecutions, srcBalances);
 
-  const bridgeAssets: BridgeAsset[] = [];
+  // === REFRESH: re-runs per call ===================================================
+  const refresh = async (currentInput: ExactInSwapInput): Promise<SwapRoute> => {
+    logger.debug('exact-in: fetched balances', { balances: rawBalances });
 
-  // Filter out COT's in sources
-  const cotSources: FlatBalance[] = [];
-  let cotCombinedBalance = new Decimal(0);
+    const { srcBalances, assetsUsed } = resolveSourceBalances(currentInput.from, rawBalances);
+    const sourceExecutions = pickSourceExecutions(chainExecutions, srcBalances);
 
-  for (const source of srcBalances) {
-    const { address: cotAddress } = getCOTForChainId(source.chainID, params.cotCurrencyID);
-    if (equalFold(convertToEVMAddress(source.tokenAddress), cotAddress)) {
-      cotSources.push(source);
-      cotCombinedBalance = cotCombinedBalance.add(source.amount);
+    const bridgeAssets: BridgeAsset[] = [];
 
-      bridgeAssets.push({
-        chainID: source.chainID,
-        contractAddress: convertToEVMAddress(source.tokenAddress),
-        decimals: source.decimals,
-        eoaBalance: new Decimal(source.amount),
-        ephemeralBalance: new Decimal(0),
-      });
-    }
-  }
+    // Filter out COT's in sources
+    const cotSources: FlatBalance[] = [];
+    let cotCombinedBalance = new Decimal(0);
 
-  logger.debug('exact-in: cot sources', {
-    cotCombinedBalance,
-    cotSources,
-    bridgeAssets,
-  });
+    for (const source of srcBalances) {
+      const { address: cotAddress } = getCOTForChainId(source.chainID, params.cotCurrencyID);
+      if (equalFold(convertToEVMAddress(source.tokenAddress), cotAddress)) {
+        cotSources.push(source);
+        cotCombinedBalance = cotCombinedBalance.add(source.amount);
 
-  // Check if source swap is required (if all source balances are not COT currencyID)
-  const isSrcSwapRequired = cotSources.length !== srcBalances.length;
-  // Check if bridge is required (if all source balances are not on destination chain)
-  const isBridgeRequired = !srcBalances.every((b) => b.chainID === input.toChainId);
-
-  logger.debug('exact-in: swap flags', {
-    isSrcSwapRequired,
-    isBridgeRequired,
-  });
-
-  let sourceSwaps: QuoteResponse[] = [];
-  if (isSrcSwapRequired) {
-    const response = await liquidateSourceHoldings({
-      holdings: toAggregatorInputsWithSwapAddresses(srcBalances, sourceExecutions),
-      aggregators: params.aggregators,
-      commonCurrencyID: params.cotCurrencyID,
-    });
-
-    if (!response.length) {
-      throw Errors.quoteFailed('source swap returned no quotes');
-    }
-
-    sourceSwaps = response;
-  }
-  const sourceSwapCreationTime = Date.now();
-
-  let swapCombinedBalance = new Decimal(0);
-  for (const swap of sourceSwaps) {
-    accumulateSwapIntoBridgeAssets(bridgeAssets, swap);
-    swapCombinedBalance = swapCombinedBalance.add(swap.quote.output.amount);
-  }
-
-  let dstSwapInputAmountInDecimal = Decimal.add(cotCombinedBalance, swapCombinedBalance);
-
-  logger.debug('exact-in: combined cot after source swaps', {
-    dstSwapInputAmountInDecimal: dstSwapInputAmountInDecimal.toFixed(),
-    bridgeAssets,
-  });
-
-  let bridgeInput: BridgeInput = null;
-  if (isBridgeRequired) {
-    const { fee: maxFee } = await calculateMaxBridgeFee({
-      assets: toBridgeAssetInputs(bridgeAssets),
-      dst: {
-        chainId: input.toChainId,
-        tokenAddress: dstChainCOTAddress,
-        decimals: dstChainCOT.decimals,
-      },
-      feeStore,
-      chainList: params.chainList,
-    });
-
-    dstSwapInputAmountInDecimal = dstSwapInputAmountInDecimal.minus(maxFee);
-    logger.debug('exact-in: after bridge fee deduction', {
-      dstSwapInputAmountInDecimal: dstSwapInputAmountInDecimal.toFixed(),
-      maxFee: maxFee.toFixed(),
-    });
-    if (dstSwapInputAmountInDecimal.isNegative()) {
-      throw Errors.internal('bridge fees exceeds source amount');
-    }
-
-    bridgeInput = {
-      amount: dstSwapInputAmountInDecimal,
-      assets: bridgeAssets,
-      chainID: input.toChainId,
-      decimals: dstChainCOT.decimals,
-      recipientAddress: params.address.ephemeral,
-      tokenAddress: convertToEVMAddress(dstChainCOT.tokenAddress),
-      estimatedFees: createIntent({
-        dstChain,
-        assets: bridgeAssets,
-        feeStore,
-        output: {
-          chainID: input.toChainId,
-          tokenAddress: dstChainCOTAddress,
-          decimals: dstChainCOT.decimals,
-          amount: new Decimal(0),
-        },
-        address: params.address.ephemeral,
-      }).intent.fees,
-    };
-  }
-
-  logger.debug('exact-in: before destination swap', {
-    dstSwapInputAmountInDecimal: dstSwapInputAmountInDecimal.toFixed(),
-  });
-
-  const needsDstSwap = !equalFold(input.toTokenAddress, dstChainCOTAddress);
-  const hasDestinationChainSourceOutput = hasDestinationChainSourceSwapOutput(
-    sourceSwaps,
-    sourceExecutions,
-    input.toChainId,
-    params.address.eoa
-  );
-  // Same chain executions resolved up-front; just pick (or downgrade to direct_eoa).
-  const destinationExecution: DestinationExecution =
-    needsDstSwap || hasDestinationChainSourceOutput
-      ? chainExecutions[input.toChainId]
-      : buildDirectEoaDestinationExecution(params.address.eoa);
-
-  // If the source swap(s) and the destination swap collapse to one same-wrapper batch (no
-  // bridge in between), the dst aggregator will pull COT from the same wrapper the source
-  // swap just deposited it into. Apply headroom on the dst input so per-leg slippage
-  // between the two aggregator quotes can't strand the dst transferFrom on an under-supplied
-  // wrapper. Leftover COT is swept back to the EOA by the existing dst sweeper.
-  const willBeCombined =
-    !isBridgeRequired &&
-    sourceSwaps.length > 0 &&
-    sourceSwaps.every((s) => Number(s.chainID) === input.toChainId) &&
-    !!sourceExecutions[input.toChainId] &&
-    equalFold(sourceExecutions[input.toChainId].address, destinationExecution.address);
-  if (willBeCombined && needsDstSwap) {
-    dstSwapInputAmountInDecimal = dstSwapInputAmountInDecimal.mul(
-      1 - COMBINED_SAME_CHAIN_BUFFER_PCT / 100
-    );
-  }
-
-  dstSwapInputAmountInDecimal = dstSwapInputAmountInDecimal.toDP(
-    dstChainCOT.decimals,
-    Decimal.ROUND_FLOOR
-  );
-  // See exact-out path: aggregator simulates as the wrapper (it's the on-chain executor) but
-  // delivers swap output directly to the user's EOA. Wrapper holds the COT input; the EOA
-  // receives the output. Splitting userAddress (taker) and receiverAddress prevents simulation
-  // mismatches that previously caused GS013 reverts on Safe-mode chains.
-  const dstSwapTakerInBytes = convertTo32Bytes(destinationExecution.address);
-  const dstSwapReceiverInBytes = convertTo32Bytes(params.address.eoa);
-  const destination = createDestination(
-    input.toChainId,
-    destinationExecution,
-    dstSwapInputAmountInDecimal
-  );
-
-  if (bridgeInput) {
-    bridgeInput.recipientAddress = destinationExecution.address;
-  }
-
-  // If dst token isn't COT and user holds COT on the dst chain,
-  // that COT must be moved from EOA → destination execution account for the destination swap.
-  const dstChainCOTSource = cotSources.find((c) =>
-    equalFold(convertToEVMAddress(c.tokenAddress), dstChainCOTAddress)
-  );
-  if (needsDstSwap && dstChainCOTSource) {
-    destination.eoaToDestinationAccount = {
-      amount: mulDecimals(dstChainCOTSource.amount, dstChainCOTSource.decimals),
-      contractAddress: dstChainCOTAddress,
-    };
-  }
-
-  const getDstSwap = async () => {
-    let tokenSwap = null;
-    if (needsDstSwap) {
-      tokenSwap = await getDestinationExactInSwap({
-        takerAddress: dstSwapTakerInBytes,
-        receiverAddress: dstSwapReceiverInBytes,
-        chain: dstOmniversalChainID,
-        inputAmount: mulDecimals(dstSwapInputAmountInDecimal, dstChainCOT.decimals),
-        outputToken: convertTo32Bytes(input.toTokenAddress),
-        aggregators: params.aggregators,
-        inputCurrency: dstChainCOT.currencyID,
-      });
-
-      // Rate guard on requote: check output didn't drop beyond 0.5% tolerance
-      if (destination.swap.tokenSwap) {
-        const prevAmountRaw = destination.swap.tokenSwap.quote.output.amountRaw;
-        const newAmountRaw = tokenSwap.quote.output.amountRaw;
-        if (newAmountRaw < (prevAmountRaw * 995n) / 1000n) {
-          throw Errors.ratesChangedBeyondTolerance(newAmountRaw, '0.5%');
-        }
+        bridgeAssets.push({
+          chainID: source.chainID,
+          contractAddress: convertToEVMAddress(source.tokenAddress),
+          decimals: source.decimals,
+          eoaBalance: new Decimal(source.amount),
+          ephemeralBalance: new Decimal(0),
+        });
       }
     }
 
-    return { gasSwap: null, tokenSwap, creationTime: Date.now() };
+    logger.debug('exact-in: cot sources', {
+      cotCombinedBalance,
+      cotSources,
+      bridgeAssets,
+    });
+
+    // Check if source swap is required (if all source balances are not COT currencyID)
+    const isSrcSwapRequired = cotSources.length !== srcBalances.length;
+    // Check if bridge is required (if all source balances are not on destination chain)
+    const isBridgeRequired = !srcBalances.every((b) => b.chainID === currentInput.toChainId);
+
+    logger.debug('exact-in: swap flags', {
+      isSrcSwapRequired,
+      isBridgeRequired,
+    });
+
+    let sourceSwaps: QuoteResponse[] = [];
+    if (isSrcSwapRequired) {
+      const response = await liquidateSourceHoldings({
+        holdings: toAggregatorInputsWithSwapAddresses(srcBalances, sourceExecutions),
+        aggregators: params.aggregators,
+        commonCurrencyID: params.cotCurrencyID,
+      });
+
+      if (!response.length) {
+        throw Errors.quoteFailed('source swap returned no quotes');
+      }
+
+      sourceSwaps = response;
+    }
+    const sourceSwapCreationTime = Date.now();
+
+    let swapCombinedBalance = new Decimal(0);
+    for (const swap of sourceSwaps) {
+      accumulateSwapIntoBridgeAssets(bridgeAssets, swap);
+      swapCombinedBalance = swapCombinedBalance.add(swap.quote.output.amount);
+    }
+
+    let dstSwapInputAmountInDecimal = Decimal.add(cotCombinedBalance, swapCombinedBalance);
+
+    logger.debug('exact-in: combined cot after source swaps', {
+      dstSwapInputAmountInDecimal: dstSwapInputAmountInDecimal.toFixed(),
+      bridgeAssets,
+    });
+
+    let bridgeInput: BridgeInput = null;
+    if (isBridgeRequired) {
+      const { fee: maxFee } = await calculateMaxBridgeFee({
+        assets: toBridgeAssetInputs(bridgeAssets),
+        dst: {
+          chainId: currentInput.toChainId,
+          tokenAddress: dstChainCOTAddress,
+          decimals: dstChainCOT.decimals,
+        },
+        feeStore,
+        chainList: params.chainList,
+      });
+
+      dstSwapInputAmountInDecimal = dstSwapInputAmountInDecimal.minus(maxFee);
+      logger.debug('exact-in: after bridge fee deduction', {
+        dstSwapInputAmountInDecimal: dstSwapInputAmountInDecimal.toFixed(),
+        maxFee: maxFee.toFixed(),
+      });
+      if (dstSwapInputAmountInDecimal.isNegative()) {
+        throw Errors.internal('bridge fees exceeds source amount');
+      }
+
+      bridgeInput = {
+        amount: dstSwapInputAmountInDecimal,
+        assets: bridgeAssets,
+        chainID: currentInput.toChainId,
+        decimals: dstChainCOT.decimals,
+        recipientAddress: params.address.ephemeral,
+        tokenAddress: convertToEVMAddress(dstChainCOT.tokenAddress),
+        estimatedFees: createIntent({
+          dstChain,
+          assets: bridgeAssets,
+          feeStore,
+          output: {
+            chainID: currentInput.toChainId,
+            tokenAddress: dstChainCOTAddress,
+            decimals: dstChainCOT.decimals,
+            amount: new Decimal(0),
+          },
+          address: params.address.ephemeral,
+        }).intent.fees,
+      };
+    }
+
+    logger.debug('exact-in: before destination swap', {
+      dstSwapInputAmountInDecimal: dstSwapInputAmountInDecimal.toFixed(),
+    });
+
+    const needsDstSwap = !equalFold(currentInput.toTokenAddress, dstChainCOTAddress);
+    const hasDestinationChainSourceOutput = hasDestinationChainSourceSwapOutput(
+      sourceSwaps,
+      sourceExecutions,
+      currentInput.toChainId,
+      params.address.eoa
+    );
+    // Same chain executions resolved up-front; just pick (or downgrade to direct_eoa).
+    const destinationExecution: DestinationExecution =
+      needsDstSwap || hasDestinationChainSourceOutput
+        ? chainExecutions[currentInput.toChainId]
+        : buildDirectEoaDestinationExecution(params.address.eoa);
+
+    // If the source swap(s) and the destination swap collapse to one same-wrapper batch (no
+    // bridge in between), the dst aggregator will pull COT from the same wrapper the source
+    // swap just deposited it into. Apply headroom on the dst input so per-leg slippage
+    // between the two aggregator quotes can't strand the dst transferFrom on an under-supplied
+    // wrapper. Leftover COT is swept back to the EOA by the existing dst sweeper.
+    const willBeCombined =
+      !isBridgeRequired &&
+      sourceSwaps.length > 0 &&
+      sourceSwaps.every((s) => Number(s.chainID) === currentInput.toChainId) &&
+      !!sourceExecutions[currentInput.toChainId] &&
+      equalFold(sourceExecutions[currentInput.toChainId].address, destinationExecution.address);
+    if (willBeCombined && needsDstSwap) {
+      dstSwapInputAmountInDecimal = dstSwapInputAmountInDecimal.mul(
+        1 - COMBINED_SAME_CHAIN_BUFFER_PCT / 100
+      );
+    }
+
+    dstSwapInputAmountInDecimal = dstSwapInputAmountInDecimal.toDP(
+      dstChainCOT.decimals,
+      Decimal.ROUND_FLOOR
+    );
+    // See exact-out path: aggregator simulates as the wrapper (it's the on-chain executor) but
+    // delivers swap output directly to the user's EOA. Wrapper holds the COT input; the EOA
+    // receives the output. Splitting userAddress (taker) and receiverAddress prevents simulation
+    // mismatches that previously caused GS013 reverts on Safe-mode chains.
+    const dstSwapTakerInBytes = convertTo32Bytes(destinationExecution.address);
+    const dstSwapReceiverInBytes = convertTo32Bytes(params.address.eoa);
+    const destination = createDestination(
+      currentInput.toChainId,
+      destinationExecution,
+      dstSwapInputAmountInDecimal
+    );
+
+    if (bridgeInput) {
+      bridgeInput.recipientAddress = destinationExecution.address;
+    }
+
+    // If dst token isn't COT and user holds COT on the dst chain,
+    // that COT must be moved from EOA → destination execution account for the destination swap.
+    const dstChainCOTSource = cotSources.find((c) =>
+      equalFold(convertToEVMAddress(c.tokenAddress), dstChainCOTAddress)
+    );
+    if (needsDstSwap && dstChainCOTSource) {
+      destination.eoaToDestinationAccount = {
+        amount: mulDecimals(dstChainCOTSource.amount, dstChainCOTSource.decimals),
+        contractAddress: dstChainCOTAddress,
+      };
+    }
+
+    const getDstSwap = async () => {
+      let tokenSwap = null;
+      if (needsDstSwap) {
+        tokenSwap = await getDestinationExactInSwap({
+          takerAddress: dstSwapTakerInBytes,
+          receiverAddress: dstSwapReceiverInBytes,
+          chain: dstOmniversalChainID,
+          inputAmount: mulDecimals(dstSwapInputAmountInDecimal, dstChainCOT.decimals),
+          outputToken: convertTo32Bytes(currentInput.toTokenAddress),
+          aggregators: params.aggregators,
+          inputCurrency: dstChainCOT.currencyID,
+        });
+
+        // Rate guard on requote: check output didn't drop beyond 0.5% tolerance
+        if (destination.swap.tokenSwap) {
+          const prevAmountRaw = destination.swap.tokenSwap.quote.output.amountRaw;
+          const newAmountRaw = tokenSwap.quote.output.amountRaw;
+          if (newAmountRaw < (prevAmountRaw * 995n) / 1000n) {
+            throw Errors.ratesChangedBeyondTolerance(newAmountRaw, '0.5%');
+          }
+        }
+      }
+
+      return { gasSwap: null, tokenSwap, creationTime: Date.now() };
+    };
+
+    destination.swap = await getDstSwap();
+    destination.getDstSwap = getDstSwap;
+
+    // VSC verification fired in the background while quotes ran; resolve it before returning.
+    // After the first refresh resolves it, subsequent refreshes just hit the already-settled
+    // microtask.
+    await executionsVerification;
+
+    return buildSwapRouteResult({
+      type: 'EXACT_IN',
+      source: {
+        swaps: sourceSwaps,
+        creationTime: sourceSwapCreationTime,
+        executions: sourceExecutions,
+        srcBuffer: new Decimal(0),
+      },
+      bridge: bridgeInput,
+      destination,
+      dstTokenInfo,
+      aggregators: params.aggregators,
+      oraclePrices,
+      balances: rawBalances,
+      assetsUsed,
+      buffer: '0',
+    });
   };
 
-  destination.swap = await getDstSwap();
-  destination.getDstSwap = getDstSwap;
-
-  // VSC verification fired in the background while quotes ran; resolve it before returning.
-  await executionsVerification;
-
-  return buildSwapRouteResult({
-    type: 'EXACT_IN',
-    source: {
-      swaps: sourceSwaps,
-      creationTime: sourceSwapCreationTime,
-      executions: sourceExecutions,
-      srcBuffer: new Decimal(0),
-    },
-    bridge: bridgeInput,
-    destination,
-    dstTokenInfo,
-    aggregators: params.aggregators,
-    oraclePrices,
-    balances,
-    assetsUsed,
-    buffer: '0',
-  });
+  return { route: await refresh(input), refresh };
 };

--- a/src/swap/route.ts
+++ b/src/swap/route.ts
@@ -365,9 +365,9 @@ source amount will be like max + (s1 + s2)sF + (s1 + s2)cF + fF
 
 enum BUFFER_EXACT_OUT {
   DESTINATION_SWAP_BUFFER_PCT = 10,
-  DESTINATION_SWAP_MAX_IN_USD = 2, // <-- magic number ???
+  DESTINATION_SWAP_MAX_IN_USD = 2,
   SOURCE_SWAP_BUFFER_PCT = 2,
-  SOURCE_SWAP_MAX_IN_USD = 1, // <-- another magic
+  SOURCE_SWAP_MAX_IN_USD = 1,
 }
 
 // EXACT_IN: source swaps run with the user's exact input, so we can't oversize them like
@@ -1098,6 +1098,26 @@ const _exactOutRoute = async (
 
     logger.debug('sourceSwap', {
       sourceSwapQuotes,
+    });
+
+    // selectSources' partial-quote loop overshoots by ~2.5%+ (safetyMultiplier=1.025 then
+    // accepts the first quote where output ≥ remainder), so the final source-swap quote
+    // typically delivers more COT than the target sourceSwapOutputRequired. The overshoot
+    // lands at the wrapper / bridged forward and ultimately sweeps back to the user, so
+    // surface it as additional buffer alongside srcBuffer / dstBuffer. Clamped at 0 because
+    // the dropNonDst branch above may legitimately under-deliver vs sourceSwapOutputRequired
+    // (dst-chain alone covers bridgeOutput, fees/srcBuffer are no longer needed).
+    const actualSourceOutput = usedCOTs
+      .reduce((sum, c) => sum.plus(c.amountUsed), new Decimal(0))
+      .plus(sourceSwapQuotes.reduce((sum, q) => sum.plus(q.quote.output.amount), new Decimal(0)));
+    const convergenceExcess = Decimal.max(0, actualSourceOutput.minus(sourceSwapOutputRequired));
+    buffer = buffer.add(convergenceExcess);
+
+    logger.debug('exact-out: loose-convergence excess', {
+      actualSourceOutput: actualSourceOutput.toFixed(),
+      sourceSwapOutputRequired: sourceSwapOutputRequired.toFixed(),
+      convergenceExcess: convergenceExcess.toFixed(),
+      buffer: buffer.toFixed(),
     });
 
     const sourceSwapCreationTime = Date.now();

--- a/src/swap/route.ts
+++ b/src/swap/route.ts
@@ -1238,9 +1238,10 @@ export type SwapRoute = {
     // Headroom in COT units that source swaps are allowed to lose on a re-quote when one
     // or more source legs revert. EXACT_OUT carries `min(2%, $1)` of bridgeOutputWithFees
     // (see BUFFER_EXACT_OUT). EXACT_IN carries `min(0.5%, $1)` of swapCombinedBalance
-    // (see BUFFER_EXACT_IN) and also subtracts the same amount from the dst-swap input so
-    // the under-sized dst swap stays funded if a source leg re-quotes lower; combined-batch
-    // routes leave this at 0 since CombinedSwapHandler re-quotes both legs together.
+    // (see BUFFER_EXACT_IN). Non-combined EXACT_IN also subtracts this from the dst-swap
+    // input so the dst swap stays funded if a source leg re-quotes lower; combined routes
+    // under-size the dst-swap input by `COMBINED_SAME_CHAIN_BUFFER_PCT` instead, but still
+    // carry `srcBuffer` as the retry tolerance consumed by CombinedSwapHandler.
     srcBuffer: Decimal;
   };
   bridge: BridgeInput;
@@ -1519,17 +1520,17 @@ const _exactInRoute = async (
       !!sourceExecutions[currentInput.toChainId] &&
       equalFold(sourceExecutions[currentInput.toChainId].address, destinationExecution.address);
 
-    // Source-retry headroom. Only meaningful when there's an actual source swap that could
-    // revert and re-quote. Combined case uses CombinedSwapHandler (which re-quotes both legs
-    // together) and already applies COMBINED_SAME_CHAIN_BUFFER_PCT below — leave srcBuffer
-    // at 0 there to avoid double-reducing the dst input.
-    const srcBuffer =
-      isSrcSwapRequired && !willBeCombined
-        ? Decimal.min(
-            swapCombinedBalance.mul(BUFFER_EXACT_IN.SOURCE_SWAP_BUFFER_PCT / 100),
-            BUFFER_EXACT_IN.SOURCE_SWAP_MAX_IN_USD
-          )
-        : new Decimal(0);
+    // Source-retry headroom in COT units. Consumed by SourceSwapsHandler /
+    // CombinedSwapHandler on revert+re-quote as the absolute amount of source-output drop
+    // they tolerate. Combined routes use COMBINED_SAME_CHAIN_BUFFER_PCT for the dst-input
+    // under-sizing (via the `willBeCombined` branch below); srcBuffer here is only the
+    // retry tolerance.
+    const srcBuffer = isSrcSwapRequired
+      ? Decimal.min(
+          swapCombinedBalance.mul(BUFFER_EXACT_IN.SOURCE_SWAP_BUFFER_PCT / 100),
+          BUFFER_EXACT_IN.SOURCE_SWAP_MAX_IN_USD
+        )
+      : new Decimal(0);
 
     if (willBeCombined && needsDstSwap) {
       dstSwapInputAmountInDecimal = dstSwapInputAmountInDecimal.mul(

--- a/src/swap/safetx.ts
+++ b/src/swap/safetx.ts
@@ -10,7 +10,7 @@ import {
   type PublicClient,
   type WalletClient,
 } from 'viem';
-import type { Chain } from '../commons';
+import { type Chain, getLogger } from '../commons';
 import type { Tx } from '../commons/types/swap-types';
 import { Errors } from '../core/errors';
 import { switchChain } from '../core/utils';
@@ -31,6 +31,8 @@ import {
   SAFE_ZERO_ADDRESS,
   type SafeOperation,
 } from './safe.constants';
+
+const logger = getLogger();
 
 export type SafeTxFields = {
   baseGas: bigint;
@@ -455,30 +457,81 @@ export const createSafeExecuteEOASubmittedTx = async ({
     value: nativeValue,
   });
 
-  const submitAndWait = async (txFields: SafeTxFields, txSignature: Hex) => {
-    const hash = await eoaWallet.writeContract({
-      abi: SAFE_ABI,
-      account: actualAddress,
-      address: safeAddress,
-      args: [
-        txFields.to,
-        txFields.value,
-        txFields.data,
-        txFields.operation,
-        txFields.safeTxGas,
-        txFields.baseGas,
-        txFields.gasPrice,
-        txFields.gasToken,
-        txFields.refundReceiver,
-        txSignature,
-      ],
-      chain,
-      functionName: 'execTransaction',
-      gas,
+  const buildMetadata = (hash?: Hex) => ({
+    chainId: chain.id,
+    from: actualAddress,
+    safeAddress,
+    hash,
+  });
+
+  const buildDetail = (txFields: SafeTxFields, txSignature: Hex, hash?: Hex) => ({
+    ...buildMetadata(hash),
+    calls,
+    executeData: {
+      to: safeAddress,
       value: nativeValue,
-      ...spreadFeeParams(feeParams),
-    });
+      data: encodeFunctionData({
+        abi: SAFE_ABI,
+        functionName: 'execTransaction',
+        args: [
+          txFields.to,
+          txFields.value,
+          txFields.data,
+          txFields.operation,
+          txFields.safeTxGas,
+          txFields.baseGas,
+          txFields.gasPrice,
+          txFields.gasToken,
+          txFields.refundReceiver,
+          txSignature,
+        ],
+      }),
+    },
+  });
+
+  const submitAndWait = async (txFields: SafeTxFields, txSignature: Hex) => {
+    let hash: Hex;
+    try {
+      hash = await eoaWallet.writeContract({
+        abi: SAFE_ABI,
+        account: actualAddress,
+        address: safeAddress,
+        args: [
+          txFields.to,
+          txFields.value,
+          txFields.data,
+          txFields.operation,
+          txFields.safeTxGas,
+          txFields.baseGas,
+          txFields.gasPrice,
+          txFields.gasToken,
+          txFields.refundReceiver,
+          txSignature,
+        ],
+        chain,
+        functionName: 'execTransaction',
+        gas,
+        value: nativeValue,
+        ...spreadFeeParams(feeParams),
+      });
+    } catch (error) {
+      logger.error('[TX_FAIL] safe_execute_eoa_error', error, buildMetadata());
+      // Detail at debug level: calldata embeds the user's signature, must not leave the console.
+      logger.debug('[TX_FAIL] safe_execute_eoa_error:detail', buildDetail(txFields, txSignature));
+      throw error;
+    }
     const receipt = await publicClient.waitForTransactionReceipt({ hash });
+    if (receipt.status !== 'success') {
+      logger.error(
+        '[TX_FAIL] safe_execute_eoa_error',
+        new Error(`Safe execTransaction reverted: ${hash}`),
+        buildMetadata(hash)
+      );
+      logger.debug(
+        '[TX_FAIL] safe_execute_eoa_error:detail',
+        buildDetail(txFields, txSignature, hash)
+      );
+    }
     return { hash, receipt };
   };
 

--- a/src/swap/sbc.ts
+++ b/src/swap/sbc.ts
@@ -304,13 +304,37 @@ export const caliburExecute = async ({
     request,
   });
 
-  return actualWallet.writeContract({
-    ...request,
-    account: actualAddress,
-    chain,
-    gas,
-    ...spreadFeeParams(feeParams),
-  });
+  try {
+    return await actualWallet.writeContract({
+      ...request,
+      account: actualAddress,
+      chain,
+      gas,
+      ...spreadFeeParams(feeParams),
+    });
+  } catch (error) {
+    logger.error('[TX_FAIL] calibur_execute_eoa_error', error, {
+      chainId: chain.id,
+      from: actualAddress,
+      targetAddress,
+    });
+    // Detail at debug level: calldata embeds the user's signature, must not leave the console.
+    logger.debug('[TX_FAIL] calibur_execute_eoa_error:detail', {
+      chainId: chain.id,
+      from: actualAddress,
+      calls,
+      executeData: {
+        to: targetAddress,
+        value,
+        data: encodeFunctionData({
+          abi: request.abi,
+          functionName: request.functionName,
+          args: request.args,
+        }),
+      },
+    });
+    throw error;
+  }
 };
 
 const packSignatureAndHookData = (signature: Hex, hookData: Hex = '0x') => {

--- a/src/swap/utils.ts
+++ b/src/swap/utils.ts
@@ -1,4 +1,5 @@
 import {
+  type Aggregator,
   type Bytes,
   ChaindataMap,
   CurrencyID,
@@ -509,6 +510,36 @@ export const packERC20Approve = (spender: Hex, amount: bigint) => {
     functionName: 'approve',
   });
 };
+
+/**
+ * Wraps an aggregator so every `getQuotes` call logs its wall clock + the set of chains
+ * the requests target. Quote latency varies a lot by chain (HyperEVM/Citrea are typically
+ * slower than Base/Arbitrum) and by aggregator (LiFi vs Bebop vs Fibrous), so per-call
+ * attribution is what lets us see which combination is the bottleneck inside
+ * `autoSelectSources` / `getDstSwap`.
+ *
+ * Wrap at SDK entry where the Aggregator list is constructed (`flows/swap.ts`,
+ * `flows/calculateMaxForSwap.ts`). The print fails silently — telemetry must not be
+ * load-bearing.
+ */
+export const withAggregatorTiming = (inner: Aggregator, name: string): Aggregator => ({
+  getQuotes: async (requests) => {
+    const t0 = performance.now();
+    try {
+      return await inner.getQuotes(requests);
+    } finally {
+      try {
+        const chainIds = [...new Set(requests.map((r) => Number(r.chain.chainID)))];
+        const ms = (performance.now() - t0).toFixed(0);
+        console.log(
+          `agg:${name} chains=[${chainIds.join(',')}] requests=${requests.length} ms=${ms}`
+        );
+      } catch {
+        // ignore — telemetry is not load-bearing
+      }
+    }
+  },
+});
 
 export const fetchTransferFees = async (
   chains: Chain[],

--- a/src/swap/utils.ts
+++ b/src/swap/utils.ts
@@ -1,5 +1,4 @@
 import {
-  type Aggregator,
   type Bytes,
   ChaindataMap,
   CurrencyID,
@@ -510,36 +509,6 @@ export const packERC20Approve = (spender: Hex, amount: bigint) => {
     functionName: 'approve',
   });
 };
-
-/**
- * Wraps an aggregator so every `getQuotes` call logs its wall clock + the set of chains
- * the requests target. Quote latency varies a lot by chain (HyperEVM/Citrea are typically
- * slower than Base/Arbitrum) and by aggregator (LiFi vs Bebop vs Fibrous), so per-call
- * attribution is what lets us see which combination is the bottleneck inside
- * `autoSelectSources` / `getDstSwap`.
- *
- * Wrap at SDK entry where the Aggregator list is constructed (`flows/swap.ts`,
- * `flows/calculateMaxForSwap.ts`). The print fails silently — telemetry must not be
- * load-bearing.
- */
-export const withAggregatorTiming = (inner: Aggregator, name: string): Aggregator => ({
-  getQuotes: async (requests) => {
-    const t0 = performance.now();
-    try {
-      return await inner.getQuotes(requests);
-    } finally {
-      try {
-        const chainIds = [...new Set(requests.map((r) => Number(r.chain.chainID)))];
-        const ms = (performance.now() - t0).toFixed(0);
-        console.log(
-          `agg:${name} chains=[${chainIds.join(',')}] requests=${requests.length} ms=${ms}`
-        );
-      } catch {
-        // ignore — telemetry is not load-bearing
-      }
-    }
-  },
-});
 
 export const fetchTransferFees = async (
   chains: Chain[],

--- a/src/swap/utils.ts
+++ b/src/swap/utils.ts
@@ -511,12 +511,21 @@ export const packERC20Approve = (spender: Hex, amount: bigint) => {
   });
 };
 
-export const fetchTransferFees = async (chains: Chain[]): Promise<Map<number, Decimal>> => {
+export const fetchTransferFees = async (
+  chains: Chain[],
+  publicClientList?: PublicClientList
+): Promise<Map<number, Decimal>> => {
   const feeByChainID = new Map<number, Decimal>();
   await Promise.all(
     chains.map(async (chain) => {
       try {
-        const fee = await estimateRepresentativeSwapNativeReserveFee({ chain });
+        // Reuse the cached, multicall-batched PublicClient when the caller supplies a
+        // PublicClientList. Falls back to a fresh fallback client so legacy call sites
+        // (and unit tests) keep working without threading it through.
+        const fee = await estimateRepresentativeSwapNativeReserveFee({
+          chain,
+          publicClient: publicClientList?.get(chain.id),
+        });
         feeByChainID.set(chain.id, divDecimals(fee, chain.nativeCurrency.decimals));
       } catch (e) {
         logger.error('fetchTransferFees', e, { chainID: chain.id });

--- a/src/swap/utils.ts
+++ b/src/swap/utils.ts
@@ -38,7 +38,6 @@ import {
   type DestinationExecution,
   getLogger,
   type SBCTx,
-  type Source,
   SUPPORTED_CHAINS,
   type SuccessfulSwapResult,
   SWAP_STEPS,
@@ -664,21 +663,9 @@ export const vscBalancesToAssets = (
 export const ankrBalanceToAssets = (
   chainList: ChainListType,
   ankrBalances: AnkrBalances,
-  filterWithSupportedTokens: boolean,
-  allowedSources: Source[] = [],
-  removeSources: Source[] = []
+  filterWithSupportedTokens: boolean
 ) => {
   const assets: UserAssetDatum[] = [];
-
-  const allowed = (chainId: number, tokenAddress: Hex) => {
-    if (allowedSources.length === 0) {
-      return true;
-    }
-
-    return !!allowedSources.find(
-      (s) => s.chainId === chainId && equalFold(s.tokenAddress, tokenAddress)
-    );
-  };
 
   for (const asset of ankrBalances) {
     if (new Decimal(asset.balance).equals(0)) {
@@ -691,18 +678,7 @@ export const ankrBalanceToAssets = (
       convertTo32BytesHex(asset.tokenAddress)
     );
 
-    // Check if user has allowed this source to be used - defaults to all being allowed
-    const isAllowed = allowed(asset.chainID, asset.tokenAddress);
-
-    const removeSource = !!removeSources.find(
-      (rs) => rs.chainId === asset.chainID && equalFold(rs.tokenAddress, asset.tokenAddress)
-    );
-
-    if ((filterWithSupportedTokens && !isSupportedToken) || !isAllowed) {
-      continue;
-    }
-
-    if (removeSource) {
+    if (filterWithSupportedTokens && !isSupportedToken) {
       continue;
     }
 

--- a/tests/core/utils/balance.utils.empty-balanceusd.test.ts
+++ b/tests/core/utils/balance.utils.empty-balanceusd.test.ts
@@ -1,0 +1,116 @@
+// Regression: VSC /swap-balances returns balanceUsd: "" for unpriced long-tail tokens.
+// swapAssetsToAnkrBalances passed the empty string through, ankrBalanceToAssets called
+// `new Decimal("")`, decimal.js threw "Invalid argument", the whole route fetch rejected,
+// and the SDK consumer's swap modal ended up with assets.length === 0.
+
+import { Universe } from '@avail-project/ca-common';
+import { describe, expect, it, vi } from 'vitest';
+
+import { getBalancesForSwap } from '../../../src/core/utils/balance.utils';
+
+describe('getBalancesForSwap — empty balanceUsd on unpriced tokens', () => {
+  // Real chain entry so the asset survives the `getChainByID` lookup inside
+  // ankrBalanceToAssets and reaches the `new Decimal(asset.balanceUSD)` call that used
+  // to throw. ankrName is empty + swapSupported is false so fetchTransferFees fans out
+  // to zero chains (no RPC stubbing needed for this regression).
+  const chain = {
+    ankrName: '',
+    custom: { icon: '', knownTokens: [] },
+    id: 1,
+    name: 'Ethereum',
+    nativeCurrency: { decimals: 18, name: 'Ether', symbol: 'ETH' },
+    swapSupported: false,
+    universe: Universe.ETHEREUM,
+  } as never;
+
+  const chainList = {
+    chains: [chain],
+    getChainByID: (id: number) => (id === 1 ? chain : undefined),
+    getTokenByAddress: () => undefined,
+  } as never;
+
+  const baseAsset = {
+    balanceRawInteger: '1',
+    blockchain: '1',
+    contractAddress: '0x000000000000000000000000000000000000abcd' as const,
+    holderAddress: '0x1111111111111111111111111111111111111111' as const,
+    thumbnail: '',
+    tokenDecimals: 18,
+    tokenName: 'Long Tail Token',
+    tokenSymbol: 'LIKE',
+    tokenType: 'ERC20' as const,
+  };
+
+  it('does not throw when balanceUsd is an empty string', async () => {
+    const vscClient = {
+      getSwapBalances: vi.fn().mockResolvedValue([
+        {
+          ...baseAsset,
+          balance: '1000',
+          balanceUsd: '', // <-- the bug: triggers `new Decimal("")` deep in ankrBalanceToAssets
+          tokenPrice: '',
+        },
+      ]),
+    } as never;
+
+    // If the bug were live this would reject with "[DecimalError] Invalid argument".
+    await expect(
+      getBalancesForSwap({
+        evmAddress: '0x1111111111111111111111111111111111111111',
+        chainList,
+        vscClient,
+        filterWithSupportedTokens: false,
+      })
+    ).resolves.toBeDefined();
+  });
+
+  it('treats empty balanceUsd as $0 (asset stays visible with zero USD value)', async () => {
+    const vscClient = {
+      getSwapBalances: vi.fn().mockResolvedValue([
+        {
+          ...baseAsset,
+          balance: '500',
+          balanceUsd: '',
+          tokenPrice: '',
+        },
+      ]),
+    } as never;
+
+    const result = await getBalancesForSwap({
+      evmAddress: '0x1111111111111111111111111111111111111111',
+      chainList,
+      vscClient,
+      filterWithSupportedTokens: false,
+    });
+
+    // The unpriced asset should still surface, just with $0 USD value — losing the asset
+    // entirely would be worse than showing 0 (user sees they hold it; aggregator just
+    // doesn't try to price it).
+    expect(result.assets).toHaveLength(1);
+    expect(result.assets[0].symbol).toBe('LIKE');
+    expect(result.assets[0].balanceInFiat).toBe(0);
+    expect(result.assets[0].breakdown[0].balanceInFiat).toBe(0);
+  });
+
+  it('passes through normal (non-empty) balanceUsd values unchanged', async () => {
+    const vscClient = {
+      getSwapBalances: vi.fn().mockResolvedValue([
+        {
+          ...baseAsset,
+          balance: '500',
+          balanceUsd: '12.34',
+          tokenPrice: '0.02468',
+        },
+      ]),
+    } as never;
+
+    await expect(
+      getBalancesForSwap({
+        evmAddress: '0x1111111111111111111111111111111111111111',
+        chainList,
+        vscClient,
+        filterWithSupportedTokens: false,
+      })
+    ).resolves.toBeDefined();
+  });
+});

--- a/tests/core/utils/balance.utils.test.ts
+++ b/tests/core/utils/balance.utils.test.ts
@@ -77,6 +77,9 @@ describe('getBalancesForSwap', () => {
     // Only chains with positive native balance are fanned out to fee estimation;
     // the second arg is the optional shared PublicClientList (undefined in this test).
     expect(fetchTransferFeesMock).toHaveBeenCalledWith([chain], undefined);
+    // ankrBalanceToAssets no longer receives allowedSources/removeSources — fromSources
+    // filtering moved into _exactOutRoute's refresh body so a refresh with a different
+    // fromSources doesn't have to refetch balances.
     expect(ankrBalanceToAssetsMock).toHaveBeenCalledWith(
       chainList,
       [
@@ -86,9 +89,7 @@ describe('getBalancesForSwap', () => {
           balance: '2.000000000000000000',
         }),
       ],
-      false,
-      undefined,
-      undefined
+      false
     );
   });
 
@@ -123,12 +124,6 @@ describe('getBalancesForSwap', () => {
       filterWithSupportedTokens: false,
     });
 
-    expect(ankrBalanceToAssetsMock).toHaveBeenCalledWith(
-      chainList,
-      [],
-      false,
-      undefined,
-      undefined
-    );
+    expect(ankrBalanceToAssetsMock).toHaveBeenCalledWith(chainList, [], false);
   });
 });

--- a/tests/core/utils/balance.utils.test.ts
+++ b/tests/core/utils/balance.utils.test.ts
@@ -74,7 +74,9 @@ describe('getBalancesForSwap', () => {
     expect(vscClient.getSwapBalances).toHaveBeenCalledWith(
       '0x1111111111111111111111111111111111111111'
     );
-    expect(fetchTransferFeesMock).toHaveBeenCalledWith([chain]);
+    // Only chains with positive native balance are fanned out to fee estimation;
+    // the second arg is the optional shared PublicClientList (undefined in this test).
+    expect(fetchTransferFeesMock).toHaveBeenCalledWith([chain], undefined);
     expect(ankrBalanceToAssetsMock).toHaveBeenCalledWith(
       chainList,
       [

--- a/tests/core/utils/common.utils.test.ts
+++ b/tests/core/utils/common.utils.test.ts
@@ -12,7 +12,11 @@ vi.mock('../../../src/core/chains', () => ({
 }));
 
 import { ZERO_ADDRESS } from '../../../src/core/constants';
-import { assetListWithDepositDeducted } from '../../../src/core/utils/common.utils';
+import {
+  assetListWithDepositDeducted,
+  divDecimals,
+  mulDecimals,
+} from '../../../src/core/utils/common.utils';
 
 describe('assetListWithDepositDeducted', () => {
   beforeEach(() => {
@@ -142,5 +146,42 @@ describe('assetListWithDepositDeducted', () => {
     );
 
     expect(result[0]?.balance.toFixed()).toBe('0');
+  });
+});
+
+// Regression: failed swap of PEPE → USDC (Arbitrum, exact-out) demanded transferFrom of
+// 266_077_560_050_515_585_070 wei from an EOA holding 266_077_560_050_515_585_065 — exactly
+// 5 wei over balance. Root cause: Decimal.js default precision is 20 significant figures
+// with ROUND_HALF_UP, so any raw → Decimal → raw round-trip through divDecimals/mulDecimals
+// rounds up at the 21st digit. Any 18-decimal token balance ≥ ~100 tokens (21+ digits raw)
+// is vulnerable.
+describe('divDecimals / mulDecimals raw round-trip (regression: 5-wei PEPE overshoot)', () => {
+  it('does not overshoot a 21-digit raw balance through divDecimals → mulDecimals', () => {
+    // Actual on-chain EOA PEPE balance from the failed tx (21 digits, 18 decimals).
+    const rawBalance = 266_077_560_050_515_585_065n;
+    const decimals = 18;
+
+    const human = divDecimals(rawBalance, decimals);
+    const roundtrip = mulDecimals(human, decimals);
+
+    // Must never exceed the original balance — that's what makes the transferFrom revert.
+    expect(roundtrip <= rawBalance).toBe(true);
+    // Stronger: a faithful round-trip returns the exact original.
+    expect(roundtrip).toBe(rawBalance);
+  });
+
+  it('preserves exact 18-decimal raw amounts at and beyond 20 significant figures', () => {
+    // Smallest 21-digit raw amount (100 tokens at 18 decimals, exactly representable in 21 digits).
+    const cases: bigint[] = [
+      100_000_000_000_000_000_000n, // 100.0 — boundary (21 digits, but trailing zeros, safe)
+      100_000_000_000_000_000_001n, // 100.0…01 — first 21-digit value that can drift
+      999_999_999_999_999_999_999n, // 999.999… — max 21-digit
+      266_077_560_050_515_585_065n, // the failing PEPE balance
+      1_000_000_000_000_000_000_000n, // 1_000 tokens (22 digits) — even more vulnerable
+    ];
+    for (const raw of cases) {
+      const roundtrip = mulDecimals(divDecimals(raw, 18), 18);
+      expect(roundtrip).toBe(raw);
+    }
   });
 });

--- a/tests/flows/characterization/swap-pipeline.test.ts
+++ b/tests/flows/characterization/swap-pipeline.test.ts
@@ -317,7 +317,10 @@ describe('swap pipeline characterization', () => {
     allowanceByChain: Record<number, bigint>,
     vscClientOverrides: Record<string, unknown> = {}
   ) => {
-    determineSwapRouteMock.mockResolvedValue(route);
+    // determineSwapRoute now returns { route, refresh }. Stub refresh as a constant
+    // resolver returning the same route — the characterization scenarios don't exercise
+    // intent-refresh paths, so the function never actually fires.
+    determineSwapRouteMock.mockResolvedValue({ route, refresh: vi.fn().mockResolvedValue(route) });
     getAllowancesMock.mockResolvedValue(allowanceByChain);
     createRFFromIntentMock.mockImplementation(async () => ({
       msgBasicCosmos: {},

--- a/tests/flows/swap.test.ts
+++ b/tests/flows/swap.test.ts
@@ -138,7 +138,8 @@ describe('swap() orchestrator dispatch', () => {
   });
 
   it('routes through CombinedSwapHandler when route.combined === true', async () => {
-    determineSwapRouteMock.mockResolvedValue(makeRoute(true));
+    const route = makeRoute(true);
+    determineSwapRouteMock.mockResolvedValue({ route, refresh: vi.fn().mockResolvedValue(route) });
 
     await swap(baseInput() as never, baseOptions() as never, CurrencyID.USDC);
 
@@ -149,7 +150,8 @@ describe('swap() orchestrator dispatch', () => {
   });
 
   it('routes through Source/Bridge/Destination handlers when route.combined === false', async () => {
-    determineSwapRouteMock.mockResolvedValue(makeRoute(false));
+    const route = makeRoute(false);
+    determineSwapRouteMock.mockResolvedValue({ route, refresh: vi.fn().mockResolvedValue(route) });
 
     await swap(baseInput() as never, baseOptions() as never, CurrencyID.USDC);
 

--- a/tests/flows/swapAndExecute.test.ts
+++ b/tests/flows/swapAndExecute.test.ts
@@ -143,6 +143,9 @@ describe('SwapAndExecuteQuery fee estimation', () => {
       {
         getAddresses: vi.fn().mockResolvedValue([USER_ADDRESS]),
       } as never,
+      // EOA address is now passed in by the caller (already synced by `withReinit`),
+      // so the query no longer re-issues `getAddresses()` on entry.
+      USER_ADDRESS,
       vi.fn().mockResolvedValue({
         assets: [],
         balances: [],

--- a/tests/helpers/swap-route-fixtures.ts
+++ b/tests/helpers/swap-route-fixtures.ts
@@ -26,14 +26,18 @@ import { ChainList } from '../../src/core/chains';
 import { equalFold } from '../../src/core/utils';
 import type { FlatBalance } from '../../src/swap/data';
 import { determineSwapRoute, type SwapRoute } from '../../src/swap/route';
+import { SAFE_PROXY_FACTORY } from '../../src/swap/safe.constants';
+import { predictSafeAccountAddress } from '../../src/swap/safetx';
 import { PublicClientList } from '../../src/swap/utils';
 
 export const TEST_EOA: Hex = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 export const TEST_EPHEMERAL: Hex = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
-export const TEST_SAFE_FACTORY: Hex = '0x4444444444444444444444444444444444444444';
 
-const safeAddressForChain = (chainId: number): Hex =>
-  `0x${chainId.toString(16).padStart(40, '0')}`.replace('0x', '0xc0c0').slice(0, 42) as Hex;
+// VSC mock: the SDK now derives the Safe address locally via CREATE2 and asserts the
+// server-returned address matches before the route is returned. The mock must therefore
+// echo back the same locally-computed address; returning anything else would trip the
+// verification check.
+export const TEST_SAFE_FACTORY: Hex = SAFE_PROXY_FACTORY;
 
 export const mainnetChainList = (): ChainListType => new ChainList(Environment.JADE);
 
@@ -108,13 +112,13 @@ export const makeMockVscClient = (): VSCClient =>
     vscPublishRFF: vi.fn().mockResolvedValue({ id: Long.fromNumber(0) }),
     vscCreateSponsoredApprovals: vi.fn().mockResolvedValue({ approvals: [], failedChainIds: [] }),
     vscCreateRFF: vi.fn().mockResolvedValue(undefined),
-    vscGetSafeAccountAddress: vi.fn(async (chainId: number, _owner: Hex) => ({
-      address: safeAddressForChain(chainId),
+    vscGetSafeAccountAddress: vi.fn(async (_chainId: number, owner: Hex) => ({
+      address: predictSafeAccountAddress(owner),
       factoryAddress: TEST_SAFE_FACTORY,
       exists: true,
     })),
-    vscEnsureSafeAccount: vi.fn(async ({ chainId }) => ({
-      address: safeAddressForChain(chainId),
+    vscEnsureSafeAccount: vi.fn(async ({ owner }) => ({
+      address: predictSafeAccountAddress(owner),
       deployTxHash: null,
       exists: true,
     })),

--- a/tests/helpers/swap-route-fixtures.ts
+++ b/tests/helpers/swap-route-fixtures.ts
@@ -222,7 +222,9 @@ export const runDetermineSwapRoute = async (
     cotCurrencyID: CurrencyID.USDC,
   } as never;
 
-  const route = await determineSwapRoute(params.input, options);
+  // determineSwapRoute now returns { route, refresh }. The integration fixtures only
+  // care about the initial route — refresh is exercised by the dedicated win-5 tests.
+  const { route } = await determineSwapRoute(params.input, options);
   return { route, aggregator, vscClient };
 };
 

--- a/tests/services/swapNativeReserveFee.test.ts
+++ b/tests/services/swapNativeReserveFee.test.ts
@@ -17,12 +17,14 @@ vi.mock('../../src/core/utils/contract.utils', () => ({
 import {
   DEFAULT_SWAP_NATIVE_RESERVE_GAS,
   estimateRepresentativeSwapNativeReserveFee,
+  SAFE_ACCOUNT_SWAP_NATIVE_RESERVE_GAS,
 } from '../../src/services/swapNativeReserveFee';
 
 describe('estimateRepresentativeSwapNativeReserveFee', () => {
   const client = {
     chain: { id: 4114 },
   } as unknown as PublicClient;
+  // Pectra / 7702-capable chain (Citrea testnet) — Calibur execution path.
   const chain = {
     id: 4114,
     nativeCurrency: {
@@ -30,6 +32,20 @@ describe('estimateRepresentativeSwapNativeReserveFee', () => {
       name: 'cBTC',
       symbol: 'cBTC',
     },
+    swapSupported: true,
+    pectraUpgradeSupport: true,
+  } as never;
+  // Non-pectra swap chain (HyperEVM) — Safe execTransaction path. Heavier per-tx gas (sig
+  // verification + multiSend fan-out), bounded above by the chain's 3M small-block limit.
+  const safeChain = {
+    id: 999,
+    nativeCurrency: {
+      decimals: 18,
+      name: 'HYPE',
+      symbol: 'HYPE',
+    },
+    swapSupported: true,
+    pectraUpgradeSupport: false,
   } as never;
 
   beforeEach(() => {
@@ -94,5 +110,55 @@ describe('estimateRepresentativeSwapNativeReserveFee', () => {
     const [{ tx }] = estimateFeeContextMock.mock.calls[0]?.[2] ?? [];
     expect((tx.data as string).length).toBeGreaterThan(4000);
     expect(result).toBe(120n);
+  });
+
+  // Regression: production failure on HyperEVM where the EOA ran out of native because the
+  // reserve was sized for a 2-call Calibur execute (~1.5M gas) while the actual submission
+  // ran a Safe `execTransaction` with multiSend fan-out. EOA balance 529,093,107,360,245
+  // vs required value+gas 849,636,684,432,245. Safe-mode chains must reserve against the
+  // 3M small-block ceiling, not the Calibur default.
+  it('reserves against the 3M small-block ceiling on non-pectra (Safe-mode) chains', async () => {
+    await estimateRepresentativeSwapNativeReserveFee({
+      chain: safeChain,
+    });
+
+    expect(finalizeFeeEstimatesMock).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          gasEstimate: SAFE_ACCOUNT_SWAP_NATIVE_RESERVE_GAS,
+          gasEstimateKind: 'raw',
+        }),
+      ],
+      expect.anything()
+    );
+    expect(SAFE_ACCOUNT_SWAP_NATIVE_RESERVE_GAS).toBeGreaterThan(DEFAULT_SWAP_NATIVE_RESERVE_GAS);
+  });
+
+  it('keeps the Calibur default reserve on pectra-capable chains', async () => {
+    await estimateRepresentativeSwapNativeReserveFee({
+      chain, // chain.pectraUpgradeSupport: true
+    });
+
+    expect(finalizeFeeEstimatesMock).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          gasEstimate: DEFAULT_SWAP_NATIVE_RESERVE_GAS,
+          gasEstimateKind: 'raw',
+        }),
+      ],
+      expect.anything()
+    );
+  });
+
+  it('caller-supplied gasEstimate overrides the chain-mode default', async () => {
+    await estimateRepresentativeSwapNativeReserveFee({
+      chain: safeChain,
+      gasEstimate: 42_000n,
+    });
+
+    expect(finalizeFeeEstimatesMock).toHaveBeenCalledWith(
+      [expect.objectContaining({ gasEstimate: 42_000n })],
+      expect.anything()
+    );
   });
 });

--- a/tests/swap/combinedSwap.test.ts
+++ b/tests/swap/combinedSwap.test.ts
@@ -235,6 +235,7 @@ const makeRoute = (overrides?: {
   type?: 'EXACT_IN' | 'EXACT_OUT';
   srcInputAddr?: Hex;
   srcOutputAmountRaw?: bigint;
+  srcBuffer?: Decimal;
   destinationMode?: 'safe_account' | '7702';
   dstSwap?: ReturnType<typeof makeDstQuote> | null;
   gasSwap?: ReturnType<typeof makeGasSwap> | null;
@@ -266,6 +267,7 @@ const makeRoute = (overrides?: {
           mode,
         },
       },
+      srcBuffer: overrides?.srcBuffer ?? new Decimal(0),
     },
     bridge: null,
     destination: {
@@ -338,7 +340,6 @@ const baseOptions = () => {
       destinationChainID: CHAIN_ID,
       emitter,
       publicClientList: { get: vi.fn(() => publicClient) },
-      slippage: 0.005,
       vscClient,
       wallet: { cosmos: {} as never, eoa: {} as never, ephemeral: {} as never },
     } as never,
@@ -545,90 +546,128 @@ describe('CombinedSwapHandler.requoteBothLegs (retry on revert)', () => {
     createSBCTxFromCallsMock.mockResolvedValue({ kind: 'sbc' });
     checkAuthCodeSetMock.mockResolvedValue(true);
     waitForSBCTxReceiptMock.mockResolvedValue(undefined);
-    // Re-quoted source returns the same shape (identity output of 100 USDC).
+    // Default: source re-quote returns same output (no drop).
     liquidateSourceHoldingsMock.mockResolvedValue([makeSourceQuote()]);
-    autoSelectSourcesMock.mockResolvedValue({
-      quoteResponses: [makeSourceQuote()],
-      usedCOTs: [],
-    });
-    // Re-quoted dst returns same output (no slippage).
-    getDestinationExactInSwapMock.mockResolvedValue(makeDstQuote());
-    getDestinationExactOutSwapMock.mockResolvedValue(makeDstQuote());
   });
 
-  it('on revert, re-quotes EXACT_IN via liquidateSourceHoldings + getDestinationExactInSwap then retries', async () => {
+  it('on revert (EXACT_IN), re-quotes source via liquidateSourceHoldings, dst via route.destination.getDstSwap, then retries', async () => {
     const { options, vscClient } = baseOptions();
     vscClient.vscCreateSafeExecuteTx
       .mockRejectedValueOnce(new Error('execution reverted'))
       .mockResolvedValueOnce([BigInt(CHAIN_ID), SAFE_HASH]);
 
+    const route = makeRoute({ type: 'EXACT_IN' });
+    await new CombinedSwapHandler(route, options).process(makeMetadata() as never);
+
+    expect(liquidateSourceHoldingsMock).toHaveBeenCalledTimes(1);
+    expect(
+      (route as never as { destination: { getDstSwap: ReturnType<typeof vi.fn> } }).destination
+        .getDstSwap
+    ).toHaveBeenCalled();
+    // No direct getDestinationExactInSwap call — dst quoting is delegated to the closure.
+    expect(getDestinationExactInSwapMock).not.toHaveBeenCalled();
+    expect(vscClient.vscCreateSafeExecuteTx).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-quotes source with the SAME input amounts as the initial swaps (no re-approval/permit prompt)', async () => {
+    const { options, vscClient } = baseOptions();
+    vscClient.vscCreateSafeExecuteTx
+      .mockRejectedValueOnce(new Error('execution reverted'))
+      .mockResolvedValueOnce([BigInt(CHAIN_ID), SAFE_HASH]);
+
+    // Initial source input is 100_000_000n via makeSourceQuote default.
     await new CombinedSwapHandler(makeRoute({ type: 'EXACT_IN' }), options).process(
       makeMetadata() as never
     );
 
-    expect(liquidateSourceHoldingsMock).toHaveBeenCalledTimes(1);
-    expect(getDestinationExactInSwapMock).toHaveBeenCalledTimes(1);
+    const callArgs = liquidateSourceHoldingsMock.mock.calls[0][0] as {
+      holdings: { amountRaw: bigint }[];
+    };
+    expect(callArgs.holdings).toHaveLength(1);
+    expect(callArgs.holdings[0].amountRaw).toBe(100_000_000n);
+  });
+
+  it('on revert (EXACT_OUT), re-quotes dst FIRST (so getDstSwap rate guard fails fast), then source', async () => {
+    const { options, vscClient } = baseOptions();
+    vscClient.vscCreateSafeExecuteTx
+      .mockRejectedValueOnce(new Error('execution reverted'))
+      .mockResolvedValueOnce([BigInt(CHAIN_ID), SAFE_HASH]);
+
+    const callOrder: string[] = [];
+    const route = makeRoute({
+      type: 'EXACT_OUT',
+      getDstSwapImpl: async () => {
+        callOrder.push('getDstSwap');
+        return { creationTime: Date.now(), gasSwap: null, tokenSwap: makeDstQuote() };
+      },
+    });
+    liquidateSourceHoldingsMock.mockImplementation(async () => {
+      callOrder.push('liquidateSourceHoldings');
+      return [makeSourceQuote()];
+    });
+
+    await new CombinedSwapHandler(route, options).process(makeMetadata() as never);
+
+    expect(callOrder).toEqual(['getDstSwap', 'liquidateSourceHoldings']);
+  });
+
+  it('accepts retry when source-output drop is within srcBuffer', async () => {
+    // srcBuffer = 1 USDC (1_000_000 raw). New source produces 99.5 USDC (drop = 0.5) →
+    // within buffer → retry succeeds.
+    const { options, vscClient } = baseOptions();
+    vscClient.vscCreateSafeExecuteTx
+      .mockRejectedValueOnce(new Error('execution reverted'))
+      .mockResolvedValueOnce([BigInt(CHAIN_ID), SAFE_HASH]);
+
+    liquidateSourceHoldingsMock.mockResolvedValue([
+      makeSourceQuote({ outputAmountRaw: 99_500_000n }),
+    ]);
+
+    await expect(
+      new CombinedSwapHandler(
+        makeRoute({ type: 'EXACT_IN', srcBuffer: new Decimal(1) }),
+        options
+      ).process(makeMetadata() as never)
+    ).resolves.toBeUndefined();
     expect(vscClient.vscCreateSafeExecuteTx).toHaveBeenCalledTimes(2);
   });
 
-  it('on revert (EXACT_OUT), requotes destination via route.destination.getDstSwap FIRST, then reselects source via autoSelectSources', async () => {
+  it('throws slippage error when source-output drop exceeds srcBuffer', async () => {
+    // srcBuffer = 0.5 USDC (500_000 raw). New source produces 98 USDC (drop = 2) → exceeds
+    // buffer → throws.
     const { options, vscClient } = baseOptions();
-    vscClient.vscCreateSafeExecuteTx
-      .mockRejectedValueOnce(new Error('execution reverted'))
-      .mockResolvedValueOnce([BigInt(CHAIN_ID), SAFE_HASH]);
+    vscClient.vscCreateSafeExecuteTx.mockRejectedValue(new Error('execution reverted'));
 
-    const route = makeRoute({ type: 'EXACT_OUT' });
-    // Track call order across both mocks.
-    const callOrder: string[] = [];
-    (
-      route as never as { destination: { getDstSwap: ReturnType<typeof vi.fn> } }
-    ).destination.getDstSwap = vi.fn().mockImplementation(async () => {
-      callOrder.push('getDstSwap');
-      return {
-        creationTime: Date.now(),
-        gasSwap: null,
-        tokenSwap: makeDstQuote(),
-      };
-    });
-    autoSelectSourcesMock.mockImplementation(async () => {
-      callOrder.push('autoSelectSources');
-      return { quoteResponses: [makeSourceQuote()], usedCOTs: [] };
-    });
+    liquidateSourceHoldingsMock.mockResolvedValue([
+      makeSourceQuote({ outputAmountRaw: 98_000_000n }),
+    ]);
 
-    await new CombinedSwapHandler(route, options).process(makeMetadata() as never);
-
-    expect(callOrder).toEqual(['getDstSwap', 'autoSelectSources']);
-    // Direct call to getDestinationExactOutSwap should NOT happen — closure handles it.
-    expect(getDestinationExactOutSwapMock).not.toHaveBeenCalled();
+    await expect(
+      new CombinedSwapHandler(
+        makeRoute({ type: 'EXACT_IN', srcBuffer: new Decimal('0.5') }),
+        options
+      ).process(makeMetadata() as never)
+    ).rejects.toThrow(/buffer/i);
   });
 
-  it('on EXACT_OUT retry with gasSwap present, autoSelectSources outputRequired includes tokenSwap.input + gasSwap.input', async () => {
+  it('source buffer check applies to EXACT_OUT as well', async () => {
+    // srcBuffer = 0.5 USDC. New source produces 98 USDC (drop = 2) → exceeds → throws.
     const { options, vscClient } = baseOptions();
-    vscClient.vscCreateSafeExecuteTx
-      .mockRejectedValueOnce(new Error('execution reverted'))
-      .mockResolvedValueOnce([BigInt(CHAIN_ID), SAFE_HASH]);
+    vscClient.vscCreateSafeExecuteTx.mockRejectedValue(new Error('execution reverted'));
 
-    // Refreshed dst on retry: tokenSwap pulls 45 USDC, gasSwap pulls 4 USDC. Source must
-    // produce ≥ 49 USDC (sum) to cover both legs.
-    const route = makeRoute({
-      type: 'EXACT_OUT',
-      gasSwap: makeGasSwap({ inputAmountRaw: 5_000_000n }),
-      dstSwap: makeDstQuote({ inputAmountRaw: 50_000_000n }),
-      getDstSwapImpl: async () => ({
-        creationTime: Date.now(),
-        tokenSwap: makeDstQuote({ inputAmountRaw: 45_000_000n }),
-        gasSwap: makeGasSwap({ inputAmountRaw: 4_000_000n }),
-      }),
-    });
+    liquidateSourceHoldingsMock.mockResolvedValue([
+      makeSourceQuote({ outputAmountRaw: 98_000_000n }),
+    ]);
 
-    await new CombinedSwapHandler(route, options).process(makeMetadata() as never);
-
-    expect(autoSelectSourcesMock).toHaveBeenCalledTimes(1);
-    const callArgs = autoSelectSourcesMock.mock.calls[0][0] as { outputRequired: Decimal };
-    expect(callArgs.outputRequired.toFixed()).toBe('49');
+    await expect(
+      new CombinedSwapHandler(
+        makeRoute({ type: 'EXACT_OUT', srcBuffer: new Decimal('0.5') }),
+        options
+      ).process(makeMetadata() as never)
+    ).rejects.toThrow(/buffer/i);
   });
 
-  it('on EXACT_OUT retry, getDstSwap rate-guard throw propagates after MAX_RETRIES', async () => {
+  it('propagates getDstSwap throw (e.g. rate guard) without falling through to a source re-quote', async () => {
     const { options, vscClient } = baseOptions();
     vscClient.vscCreateSafeExecuteTx.mockRejectedValue(new Error('execution reverted'));
 
@@ -643,140 +682,47 @@ describe('CombinedSwapHandler.requoteBothLegs (retry on revert)', () => {
     await expect(
       new CombinedSwapHandler(route, options).process(makeMetadata() as never)
     ).rejects.toThrow();
-    // Initial attempt + retries: initial submit failed, then 2 retries each blocked by
-    // getDstSwap throwing. Submit is only called once (initial attempt) because each retry
-    // throws before reaching submit.
+    // Initial attempt submits once, fails, then each retry throws inside getDstSwap before
+    // reaching submit or source re-quote.
     expect(vscClient.vscCreateSafeExecuteTx).toHaveBeenCalledTimes(1);
+    expect(liquidateSourceHoldingsMock).not.toHaveBeenCalled();
   });
 
-  it('on EXACT_OUT retry with eoaToDestinationAccount set, autoSelectSources outputRequired subtracts the direct COT credit', async () => {
+  it('updates route.source.swaps and route.destination.swap after a successful retry', async () => {
     const { options, vscClient } = baseOptions();
     vscClient.vscCreateSafeExecuteTx
       .mockRejectedValueOnce(new Error('execution reverted'))
       .mockResolvedValueOnce([BigInt(CHAIN_ID), SAFE_HASH]);
 
-    // Refreshed dst: tokenSwap pulls 45 USDC + gasSwap pulls 4 USDC = 49 USDC total at the
-    // wrapper. EOA already supplies 20 USDC via the batched transferFrom — source must
-    // produce only 49 - 20 = 29 USDC.
+    // The retry path replaces source.swaps with the liquidate result; identify by a
+    // distinct output amount that doesn't match the initial.
+    const refreshedSrc = makeSourceQuote({ outputAmountRaw: 99_900_000n });
+    const refreshedDst = makeDstQuote({ inputAmountRaw: 99_400_000n });
+    liquidateSourceHoldingsMock.mockResolvedValue([refreshedSrc]);
+
     const route = makeRoute({
-      type: 'EXACT_OUT',
-      gasSwap: makeGasSwap({ inputAmountRaw: 5_000_000n }),
-      dstSwap: makeDstQuote({ inputAmountRaw: 50_000_000n }),
-      eoaToDestinationAccount: { amount: 20_000_000n, contractAddress: USDC },
+      type: 'EXACT_IN',
+      srcBuffer: new Decimal(1),
       getDstSwapImpl: async () => ({
         creationTime: Date.now(),
-        tokenSwap: makeDstQuote({ inputAmountRaw: 45_000_000n }),
-        gasSwap: makeGasSwap({ inputAmountRaw: 4_000_000n }),
+        gasSwap: null,
+        tokenSwap: refreshedDst,
       }),
     });
 
     await new CombinedSwapHandler(route, options).process(makeMetadata() as never);
 
-    expect(autoSelectSourcesMock).toHaveBeenCalledTimes(1);
-    const callArgs = autoSelectSourcesMock.mock.calls[0][0] as { outputRequired: Decimal };
-    expect(callArgs.outputRequired.toFixed()).toBe('29');
-  });
-
-  it('on EXACT_OUT retry, autoSelectSources outputRequired clamps to zero when direct COT credit >= dst requirement', async () => {
-    const { options, vscClient } = baseOptions();
-    vscClient.vscCreateSafeExecuteTx
-      .mockRejectedValueOnce(new Error('execution reverted'))
-      .mockResolvedValueOnce([BigInt(CHAIN_ID), SAFE_HASH]);
-
-    // EOA holds 100 USDC; refreshed dst needs only 49 USDC. Source needs 0 USDC — clamp.
-    const route = makeRoute({
-      type: 'EXACT_OUT',
-      gasSwap: makeGasSwap({ inputAmountRaw: 5_000_000n }),
-      dstSwap: makeDstQuote({ inputAmountRaw: 50_000_000n }),
-      eoaToDestinationAccount: { amount: 100_000_000n, contractAddress: USDC },
-      getDstSwapImpl: async () => ({
-        creationTime: Date.now(),
-        tokenSwap: makeDstQuote({ inputAmountRaw: 45_000_000n }),
-        gasSwap: makeGasSwap({ inputAmountRaw: 4_000_000n }),
-      }),
-    });
-
-    await new CombinedSwapHandler(route, options).process(makeMetadata() as never);
-
-    const callArgs = autoSelectSourcesMock.mock.calls[0][0] as { outputRequired: Decimal };
-    expect(callArgs.outputRequired.toFixed()).toBe('0');
-  });
-
-  it('on EXACT_IN retry with eoaToDestinationAccount set, getDestinationExactInSwap inputAmount includes the direct dst-chain COT credit (buffered)', async () => {
-    const { options, vscClient } = baseOptions();
-    vscClient.vscCreateSafeExecuteTx
-      .mockRejectedValueOnce(new Error('execution reverted'))
-      .mockResolvedValueOnce([BigInt(CHAIN_ID), SAFE_HASH]);
-
-    // Source re-quote returns 100 USDC; eoaToDestinationAccount adds 20 USDC via the
-    // batched transferFrom. Wrapper holds 120 USDC; dst should be quoted for
-    // 120 USDC * (1 - 0.5%) = 119.4 USDC = 119_400_000n.
-    const route = makeRoute({
-      type: 'EXACT_IN',
-      eoaToDestinationAccount: { amount: 20_000_000n, contractAddress: USDC },
-    });
-
-    await new CombinedSwapHandler(route, options).process(makeMetadata() as never);
-
-    expect(getDestinationExactInSwapMock).toHaveBeenCalledTimes(1);
-    const args = getDestinationExactInSwapMock.mock.calls[0][0] as { inputAmount: bigint };
-    expect(args.inputAmount).toBe(119_400_000n);
-  });
-
-  it('source slippage guard ignores the fixed direct-COT credit (only source-swap output counts)', async () => {
-    const { options, vscClient } = baseOptions();
-    vscClient.vscCreateSafeExecuteTx
-      .mockRejectedValueOnce(new Error('execution reverted'))
-      .mockResolvedValueOnce([BigInt(CHAIN_ID), SAFE_HASH]);
-
-    // Old source output 100 USDC. EOA contributes a fixed 50 USDC, but that is not
-    // source-quote performance and must not blunt the slippage guard. New source output
-    // drops to 99.7 USDC — within 0.5% slippage of the OLD source amount alone, so the
-    // retry should still proceed (no throw).
-    liquidateSourceHoldingsMock.mockResolvedValue([
-      makeSourceQuote({ outputAmountRaw: 99_700_000n }),
-    ]);
-
-    const route = makeRoute({
-      type: 'EXACT_IN',
-      eoaToDestinationAccount: { amount: 50_000_000n, contractAddress: USDC },
-    });
-
-    // Should not throw. Wrapper total: 99.7 + 50 = 149.7 USDC; dst input = 149.7 * 0.995.
-    await new CombinedSwapHandler(route, options).process(makeMetadata() as never);
-    const args = getDestinationExactInSwapMock.mock.calls[0][0] as { inputAmount: bigint };
-    expect(args.inputAmount).toBe(148_951_500n);
-  });
-
-  it('throws slippage error on EXACT_IN combined retry when source output drops > options.slippage even with no dst tokenSwap', async () => {
-    const { options, vscClient } = baseOptions();
-    vscClient.vscCreateSafeExecuteTx.mockRejectedValue(new Error('execution reverted'));
-
-    // Re-quoted source drops 20% — way beyond the 0.5% options.slippage. Even with no dst
-    // tokenSwap (toToken == COT case), this must still throw.
-    const degradedSrc = makeSourceQuote({ outputAmountRaw: 80_000_000n });
-    liquidateSourceHoldingsMock.mockResolvedValue([degradedSrc]);
-
-    await expect(
-      new CombinedSwapHandler(makeRoute({ dstSwap: null }), options).process(
-        makeMetadata() as never
-      )
-    ).rejects.toThrow(/slippage/i);
-  });
-
-  it('throws slippage error if re-quoted dst output drops more than options.slippage', async () => {
-    const { options, vscClient } = baseOptions();
-    vscClient.vscCreateSafeExecuteTx.mockRejectedValue(new Error('execution reverted'));
-    // Re-quoted dst output dropped from 90 USDH to 70 USDH — way over the 0.5% allowance.
-    getDestinationExactInSwapMock.mockResolvedValue(makeDstQuote({ inputAmountRaw: 99_500_000n }));
-    getDestinationExactInSwapMock.mockReset();
-    const degradedDst = makeDstQuote();
-    degradedDst.quote.output.amountRaw = 70_000_000n;
-    getDestinationExactInSwapMock.mockResolvedValue(degradedDst);
-
-    await expect(
-      new CombinedSwapHandler(makeRoute(), options).process(makeMetadata() as never)
-    ).rejects.toThrow();
+    expect(
+      (route as never as { source: { swaps: { quote: { output: { amountRaw: bigint } } }[] } })
+        .source.swaps[0].quote.output.amountRaw
+    ).toBe(99_900_000n);
+    expect(
+      (
+        route as never as {
+          destination: { swap: { tokenSwap: { quote: { input: { amountRaw: bigint } } } } };
+        }
+      ).destination.swap.tokenSwap.quote.input.amountRaw
+    ).toBe(99_400_000n);
   });
 
   it('caps retries at MAX_RETRIES (2) and propagates final failure', async () => {

--- a/tests/swap/combinedSwap.test.ts
+++ b/tests/swap/combinedSwap.test.ts
@@ -611,9 +611,13 @@ describe('CombinedSwapHandler.requoteBothLegs (retry on revert)', () => {
     expect(callOrder).toEqual(['getDstSwap', 'liquidateSourceHoldings']);
   });
 
-  it('accepts retry when source-output drop is within srcBuffer', async () => {
-    // srcBuffer = 1 USDC (1_000_000 raw). New source produces 99.5 USDC (drop = 0.5) →
-    // within buffer → retry succeeds.
+  // Combined batches are atomic: src outputs and dst inputs balance on the same wrapper
+  // inside one tx. The only invariant the retry must enforce is `sum(src.output) ≥
+  // sum(dst.input)`. The bridge-style buffer check (newTotal < oldTotal − srcBuffer) used
+  // to protect bridges where the bridge was already sized against the OLD src total; for
+  // combined there's no pre-commit to anchor against, so that check has been removed.
+  it('accepts retry when source output covers dst input (exact-fit)', async () => {
+    // New src output 99.5 USDC == dst input 99.5 USDC → exactly funded → retry succeeds.
     const { options, vscClient } = baseOptions();
     vscClient.vscCreateSafeExecuteTx
       .mockRejectedValueOnce(new Error('execution reverted'))
@@ -624,17 +628,17 @@ describe('CombinedSwapHandler.requoteBothLegs (retry on revert)', () => {
     ]);
 
     await expect(
-      new CombinedSwapHandler(
-        makeRoute({ type: 'EXACT_IN', srcBuffer: new Decimal(1) }),
-        options
-      ).process(makeMetadata() as never)
+      new CombinedSwapHandler(makeRoute({ type: 'EXACT_IN' }), options).process(
+        makeMetadata() as never
+      )
     ).resolves.toBeUndefined();
     expect(vscClient.vscCreateSafeExecuteTx).toHaveBeenCalledTimes(2);
   });
 
-  it('throws slippage error when source-output drop exceeds srcBuffer', async () => {
-    // srcBuffer = 0.5 USDC (500_000 raw). New source produces 98 USDC (drop = 2) → exceeds
-    // buffer → throws.
+  it('throws when source output cannot fund dst input', async () => {
+    // New src output 98 USDC < dst input 99.5 USDC → unfundable → throw.
+    // Old test used srcBuffer as the threshold; new logic compares src.output to dst.input
+    // directly, so `srcBuffer` is irrelevant here.
     const { options, vscClient } = baseOptions();
     vscClient.vscCreateSafeExecuteTx.mockRejectedValue(new Error('execution reverted'));
 
@@ -643,15 +647,13 @@ describe('CombinedSwapHandler.requoteBothLegs (retry on revert)', () => {
     ]);
 
     await expect(
-      new CombinedSwapHandler(
-        makeRoute({ type: 'EXACT_IN', srcBuffer: new Decimal('0.5') }),
-        options
-      ).process(makeMetadata() as never)
-    ).rejects.toThrow(/buffer/i);
+      new CombinedSwapHandler(makeRoute({ type: 'EXACT_IN' }), options).process(
+        makeMetadata() as never
+      )
+    ).rejects.toThrow(/source output .* cannot fund destination input/);
   });
 
-  it('source buffer check applies to EXACT_OUT as well', async () => {
-    // srcBuffer = 0.5 USDC. New source produces 98 USDC (drop = 2) → exceeds → throws.
+  it('src.output ≥ dst.input invariant applies to EXACT_OUT as well', async () => {
     const { options, vscClient } = baseOptions();
     vscClient.vscCreateSafeExecuteTx.mockRejectedValue(new Error('execution reverted'));
 
@@ -660,11 +662,99 @@ describe('CombinedSwapHandler.requoteBothLegs (retry on revert)', () => {
     ]);
 
     await expect(
-      new CombinedSwapHandler(
-        makeRoute({ type: 'EXACT_OUT', srcBuffer: new Decimal('0.5') }),
-        options
-      ).process(makeMetadata() as never)
-    ).rejects.toThrow(/buffer/i);
+      new CombinedSwapHandler(makeRoute({ type: 'EXACT_OUT' }), options).process(
+        makeMetadata() as never
+      )
+    ).rejects.toThrow(/source output .* cannot fund destination input/);
+  });
+
+  // Regression for "few failures, no TX_FAIL, oldTotal == newTotal exactly" pattern: on a
+  // combined retry, an aggregator that returns identical src quotes used to trip the dst
+  // rate-tolerance guard (`ratesChangedBeyondTolerance`) when the dst pool drifted. Combined
+  // retries now skip that guard — the only thing that matters is whether the requoted src
+  // output funds the requoted dst input.
+  it('skips dst rate guard on combined retry when src is stable and dst still funds', async () => {
+    const { options, vscClient } = baseOptions();
+    vscClient.vscCreateSafeExecuteTx
+      .mockRejectedValueOnce(new Error('execution reverted'))
+      .mockResolvedValueOnce([BigInt(CHAIN_ID), SAFE_HASH]);
+
+    // Mirror of the production pattern: identical src quote across attempts, dst quote
+    // requires slightly more input than the original max (which would have thrown
+    // ratesChangedBeyondTolerance with the old behavior) — but src still covers it.
+    liquidateSourceHoldingsMock.mockResolvedValue([
+      makeSourceQuote({ outputAmountRaw: 100_000_000n }), // unchanged
+    ]);
+    const dstAfterDrift = makeDstQuote({ inputAmountRaw: 99_900_000n }); // dst wants 99.9
+    const route = makeRoute({
+      type: 'EXACT_IN',
+      getDstSwapImpl: async () => ({
+        creationTime: Date.now(),
+        tokenSwap: dstAfterDrift,
+        gasSwap: null,
+      }),
+    });
+
+    await expect(
+      new CombinedSwapHandler(route, options).process(makeMetadata() as never)
+    ).resolves.toBeUndefined();
+
+    // Verify the dst closure was called with the skip-guard hint.
+    const dstCalls = (
+      route as never as {
+        destination: { getDstSwap: ReturnType<typeof vi.fn> };
+      }
+    ).destination.getDstSwap.mock.calls;
+    expect(dstCalls.length).toBeGreaterThan(0);
+    expect(dstCalls.at(-1)?.[0]).toEqual({ skipRateGuard: true });
+  });
+
+  // Funding invariant must account for `eoaToDestinationAccount` — pre-existing dst-chain
+  // COT that buildBatch permits/transfers from the EOA to the wrapper BEFORE the dst swap
+  // pulls. A route where src.output alone < dst.input but src.output + EOA→dst ≥ dst.input
+  // is valid on-chain, and the retry check must not falsely reject it.
+  it('counts eoaToDestinationAccount toward available COT when it matches the dst input token', async () => {
+    const { options, vscClient } = baseOptions();
+    vscClient.vscCreateSafeExecuteTx
+      .mockRejectedValueOnce(new Error('execution reverted'))
+      .mockResolvedValueOnce([BigInt(CHAIN_ID), SAFE_HASH]);
+
+    // dst input is 99.5 USDC; src output requoted to 60 USDC. Alone, this would fail the
+    // invariant. With a 40 USDC EOA→dst contribution (same USDC contract), the wrapper has
+    // 100 USDC total, comfortably covering the dst input.
+    liquidateSourceHoldingsMock.mockResolvedValue([
+      makeSourceQuote({ outputAmountRaw: 60_000_000n }),
+    ]);
+
+    const route = makeRoute({
+      type: 'EXACT_IN',
+      eoaToDestinationAccount: { amount: 40_000_000n, contractAddress: USDC },
+    });
+
+    await expect(
+      new CombinedSwapHandler(route, options).process(makeMetadata() as never)
+    ).resolves.toBeUndefined();
+    expect(vscClient.vscCreateSafeExecuteTx).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores eoaToDestinationAccount when its token does not match dst input', async () => {
+    const { options, vscClient } = baseOptions();
+    vscClient.vscCreateSafeExecuteTx.mockRejectedValue(new Error('execution reverted'));
+
+    // Same setup as above, but the EOA contribution is in a DIFFERENT token (KHYPE, not
+    // USDC). It can't fund the USDC dst input → invariant check still fails.
+    liquidateSourceHoldingsMock.mockResolvedValue([
+      makeSourceQuote({ outputAmountRaw: 60_000_000n }),
+    ]);
+
+    const route = makeRoute({
+      type: 'EXACT_IN',
+      eoaToDestinationAccount: { amount: 40_000_000n, contractAddress: KHYPE },
+    });
+
+    await expect(
+      new CombinedSwapHandler(route, options).process(makeMetadata() as never)
+    ).rejects.toThrow(/source output .* cannot fund destination input/);
   });
 
   it('propagates getDstSwap throw (e.g. rate guard) without falling through to a source re-quote', async () => {

--- a/tests/swap/dstBufferGuard.test.ts
+++ b/tests/swap/dstBufferGuard.test.ts
@@ -1,0 +1,230 @@
+// Regression coverage for the EXACT_OUT destination requote budget guard.
+//
+// Setup: user wants `toAmount` of a non-COT token on Arbitrum. Source funds on Base.
+// The route's getDstSwap closure (route.ts, _exactOutRoute) is the only place that
+// enforces a budget on dst-input growth across requotes. The bridge funds `originalMax`
+// (= initial inputMin + dstBuffer of min(10%, $2)) worth of COT at the destination
+// wrapper; on a requote the new inputMin must fit inside that budget, leftover gets
+// swept. The dst buffer is NOT re-added to newInputMin on the requote check — doing so
+// would double-count it and reject requotes that actually fit.
+
+import {
+  type Aggregator,
+  OmniversalChainID,
+  type QuoteResponse,
+  Universe,
+} from '@avail-project/ca-common';
+import Decimal from 'decimal.js';
+import { type Hex, toHex } from 'viem';
+import { describe, expect, it, vi } from 'vitest';
+
+const getDestinationExactOutSwapMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@avail-project/ca-common', async () => {
+  const actual = await vi.importActual<typeof import('@avail-project/ca-common')>(
+    '@avail-project/ca-common'
+  );
+  return {
+    ...actual,
+    getDestinationExactOutSwap: getDestinationExactOutSwapMock,
+  };
+});
+
+import { SUPPORTED_CHAINS } from '../../src/commons';
+import {
+  exactOutInput,
+  makeBalance,
+  makeOraclePrice,
+  runDetermineSwapRoute,
+} from '../helpers/swap-route-fixtures';
+
+const USDC_BASE: Hex = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const USDC_ARBITRUM: Hex = '0xaf88d065e77c8cc2239327c5edb3a432268e5831';
+const NONCOT_BASE: Hex = '0xeeee0000000000000000000000000000babe0001';
+const NONCOT_ARBITRUM: Hex = '0xeeee00000000000000000000000000000abb0001';
+
+const oraclePrices = [
+  makeOraclePrice(SUPPORTED_CHAINS.BASE, USDC_BASE),
+  makeOraclePrice(SUPPORTED_CHAINS.BASE, NONCOT_BASE),
+  makeOraclePrice(SUPPORTED_CHAINS.ARBITRUM, USDC_ARBITRUM),
+  makeOraclePrice(SUPPORTED_CHAINS.ARBITRUM, NONCOT_ARBITRUM),
+];
+
+// Build a fake aggregator that won't be used for the dst quote (mocked above) but is
+// still required as a value by the route + source-side calls.
+const stubAggregator: Aggregator = {
+  getQuotes: async (requests) =>
+    requests.map((r) => {
+      const inputRaw = r.type === 0 ? r.inputAmount : r.outputAmount;
+      const amountStr = new Decimal(inputRaw.toString()).div(Decimal.pow(10, 6)).toFixed(6);
+      return {
+        expiry: Math.floor(Date.now() / 1000) + 600,
+        input: {
+          contractAddress: '0x0000000000000000000000000000000000000001' as Hex,
+          amount: amountStr,
+          amountRaw: inputRaw,
+          decimals: 6,
+          value: Number(amountStr),
+          symbol: 'TST',
+        },
+        output: {
+          contractAddress: '0x0000000000000000000000000000000000000002' as Hex,
+          amount: amountStr,
+          amountRaw: inputRaw,
+          decimals: 6,
+          value: Number(amountStr),
+          symbol: 'TST',
+        },
+        txData: {
+          approvalAddress: '0x0000000000000000000000000000000000000003' as Hex,
+          tx: {
+            to: '0x0000000000000000000000000000000000000004' as Hex,
+            data: '0x' as Hex,
+            value: '0x0' as Hex,
+          },
+        },
+      };
+    }),
+};
+
+// Build a dst-side QuoteResponse with a given USDC input amount (raw) and the original
+// requirement as output. The rest of the fields are stubs — only quote.input.amount and
+// quote.output.amountRaw matter to the buffer-guard logic in _exactOutRoute.
+const makeDstQuoteResponse = (inputUSDCRaw: bigint, outputDstTokenRaw: bigint): QuoteResponse => {
+  const inputStr = new Decimal(inputUSDCRaw.toString()).div(Decimal.pow(10, 6)).toFixed(6);
+  const outputStr = new Decimal(outputDstTokenRaw.toString()).div(Decimal.pow(10, 6)).toFixed(6);
+  const tokenAddress32 = (hex: Hex) =>
+    toHex(Buffer.concat([Buffer.alloc(12, 0), Buffer.from(hex.slice(2), 'hex')]));
+  return {
+    chainID: SUPPORTED_CHAINS.ARBITRUM,
+    aggregator: stubAggregator,
+    holding: {
+      amountRaw: outputDstTokenRaw,
+      chainID: new OmniversalChainID(Universe.ETHEREUM, SUPPORTED_CHAINS.ARBITRUM),
+      tokenAddress: tokenAddress32(NONCOT_ARBITRUM),
+    } as never,
+    quote: {
+      expiry: Math.floor(Date.now() / 1000) + 600,
+      input: {
+        contractAddress: USDC_ARBITRUM,
+        amount: inputStr,
+        amountRaw: inputUSDCRaw,
+        decimals: 6,
+        value: Number(inputStr),
+        symbol: 'USDC',
+      },
+      output: {
+        contractAddress: NONCOT_ARBITRUM,
+        amount: outputStr,
+        amountRaw: outputDstTokenRaw,
+        decimals: 6,
+        value: Number(outputStr),
+        symbol: 'TST',
+      },
+      txData: {
+        approvalAddress: '0x0000000000000000000000000000000000000003' as Hex,
+        tx: {
+          to: '0x0000000000000000000000000000000000000004' as Hex,
+          data: '0x' as Hex,
+          value: '0x0' as Hex,
+        },
+      },
+    } as never,
+  };
+};
+
+describe('EXACT_OUT destination requote (buffer headroom)', () => {
+  it('accepts requote when newInputMin fits within originalMax (leftover swept)', async () => {
+    // toAmount = 50 NONCOT_ARBITRUM (50_000_000n raw at 6 decimals).
+    //
+    // First dst quote: input = 50 USDC, output = 50 NONCOT.
+    //   inputMin = 50, dstBuffer = min(10%·50, $2) = $2, max = 52. originalMax = 52.
+    //   Bridge brings 52 USDC to dst wrapper.
+    //
+    // Requote: input = 51 USDC (51 < 52 — fits inside the bridged budget).
+    //   Swap consumes 51 of the 52 bridged COT. Leftover 1 USDC swept to EOA by the
+    //   destination sweeper. inputAmount.max stays pinned at originalMax (the bridge
+    //   budget — it does not get re-bumped on requote).
+    getDestinationExactOutSwapMock
+      .mockResolvedValueOnce(makeDstQuoteResponse(50_000_000n, 50_000_000n))
+      .mockResolvedValueOnce(makeDstQuoteResponse(51_000_000n, 50_000_000n));
+
+    const { route } = await runDetermineSwapRoute({
+      input: exactOutInput({
+        fromSources: [{ chainId: SUPPORTED_CHAINS.BASE, tokenAddress: NONCOT_BASE }],
+        toChainId: SUPPORTED_CHAINS.ARBITRUM,
+        toTokenAddress: NONCOT_ARBITRUM,
+        toAmount: 50_000_000n,
+      }),
+      preloadedBalances: [makeBalance(SUPPORTED_CHAINS.BASE, NONCOT_BASE, '500')],
+      oraclePrices,
+    });
+
+    // After first dst quote, originalMax = inputMin (50) + buffer (2) = 52.
+    expect(route.destination.inputAmount.max.toFixed()).toBe('52');
+    expect(route.destination.inputAmount.min.toFixed()).toBe('50');
+
+    const result = await route.destination.getDstSwap();
+    expect(result).not.toBeNull();
+    expect(result!.tokenSwap?.quote.input.amountRaw).toBe(51_000_000n);
+
+    // inputAmount.max stays pinned at originalMax (52) — the bridge funded that, and
+    // re-bumping it on requote would be meaningless (the bridge already happened).
+    expect(route.destination.inputAmount.max.toFixed()).toBe('52');
+    // inputAmount.min reflects the latest quote's actual COT requirement.
+    expect(route.destination.inputAmount.min.toFixed()).toBe('51');
+  });
+
+  it('rejects requote when newInputMin exceeds originalMax (bridge budget genuinely insufficient)', async () => {
+    // First quote: input = 50 USDC → originalMax = 52.
+    // Requote: input = 60 USDC. 60 > 52 — bridge funded only 52 of COT, swap genuinely
+    // can't be paid for. Must throw.
+    getDestinationExactOutSwapMock
+      .mockResolvedValueOnce(makeDstQuoteResponse(50_000_000n, 50_000_000n))
+      .mockResolvedValueOnce(makeDstQuoteResponse(60_000_000n, 50_000_000n));
+
+    const { route } = await runDetermineSwapRoute({
+      input: exactOutInput({
+        fromSources: [{ chainId: SUPPORTED_CHAINS.BASE, tokenAddress: NONCOT_BASE }],
+        toChainId: SUPPORTED_CHAINS.ARBITRUM,
+        toTokenAddress: NONCOT_ARBITRUM,
+        toAmount: 50_000_000n,
+      }),
+      preloadedBalances: [makeBalance(SUPPORTED_CHAINS.BASE, NONCOT_BASE, '500')],
+      oraclePrices,
+    });
+
+    expect(route.destination.inputAmount.max.toFixed()).toBe('52');
+
+    await expect(route.destination.getDstSwap()).rejects.toThrow(
+      /ratesChangedBeyondTolerance|max budget/
+    );
+  });
+
+  it('accepts requote at the originalMax boundary (newInputMin == originalMax)', async () => {
+    // First: input = 50 → originalMax = 52.
+    // Requote: input = 52 (exactly equals originalMax). Should pass — bridge has 52,
+    // swap consumes all 52, no leftover but also no shortfall.
+    getDestinationExactOutSwapMock
+      .mockResolvedValueOnce(makeDstQuoteResponse(50_000_000n, 50_000_000n))
+      .mockResolvedValueOnce(makeDstQuoteResponse(52_000_000n, 50_000_000n));
+
+    const { route } = await runDetermineSwapRoute({
+      input: exactOutInput({
+        fromSources: [{ chainId: SUPPORTED_CHAINS.BASE, tokenAddress: NONCOT_BASE }],
+        toChainId: SUPPORTED_CHAINS.ARBITRUM,
+        toTokenAddress: NONCOT_ARBITRUM,
+        toAmount: 50_000_000n,
+      }),
+      preloadedBalances: [makeBalance(SUPPORTED_CHAINS.BASE, NONCOT_BASE, '500')],
+      oraclePrices,
+    });
+
+    expect(route.destination.inputAmount.max.toFixed()).toBe('52');
+
+    const result = await route.destination.getDstSwap();
+    expect(result).not.toBeNull();
+    expect(result!.tokenSwap?.quote.input.amountRaw).toBe(52_000_000n);
+    expect(route.destination.inputAmount.max.toFixed()).toBe('52');
+  });
+});

--- a/tests/swap/intent.test.ts
+++ b/tests/swap/intent.test.ts
@@ -1,0 +1,80 @@
+import Decimal from 'decimal.js';
+import type { Hex } from 'viem';
+import { describe, expect, it, vi } from 'vitest';
+import { SwapMode } from '../../src/commons';
+import { ZERO_ADDRESS } from '../../src/core/constants';
+import { createSwapIntent } from '../../src/swap/intent';
+
+describe('createSwapIntent', () => {
+  it('falls back to zero gas value when a gas quote has no USD output value', () => {
+    const chainList = {
+      getChainByID: vi.fn(() => ({
+        custom: { icon: '' },
+        id: 999,
+        name: 'HyperEVM',
+        nativeCurrency: { decimals: 18, symbol: 'ETH' },
+      })),
+    };
+
+    const route = {
+      type: 'EXACT_IN',
+      source: { creationTime: 1, executions: {}, swaps: [] },
+      bridge: null,
+      destination: {
+        chainId: 999,
+        eoaToDestinationAccount: null,
+        execution: {
+          address: '0x1111111111111111111111111111111111111111',
+          entryPoint: null,
+          mode: 'safe_account',
+        },
+        getDstSwap: vi.fn(async () => null),
+        inputAmount: { max: new Decimal(1), min: new Decimal(1) },
+        swap: {
+          creationTime: 1,
+          tokenSwap: null,
+          gasSwap: {
+            quote: {
+              output: {
+                amount: '0.0001',
+                amountRaw: 100_000_000_000_000n,
+                contractAddress: ZERO_ADDRESS,
+                decimals: 18,
+                symbol: 'ETH',
+              },
+            },
+          },
+        },
+      },
+      buffer: { amount: '0' },
+      dstTokenInfo: {
+        contractAddress: '0xcccccccccccccccccccccccccccccccccccccccc' as Hex,
+        decimals: 6,
+        symbol: 'USDC',
+      },
+      extras: { aggregators: [], assetsUsed: [], balances: [], oraclePrices: {} },
+    } as never;
+
+    const intent = createSwapIntent(
+      route,
+      {
+        mode: SwapMode.EXACT_IN,
+        data: {
+          from: [
+            {
+              amount: 1_000_000n,
+              chainId: 999,
+              tokenAddress: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as Hex,
+            },
+          ],
+          toChainId: 999,
+          toTokenAddress: '0xcccccccccccccccccccccccccccccccccccccccc' as Hex,
+        },
+      },
+      chainList as never
+    );
+
+    expect(intent.destination.gas.amount).toBe('0.0001');
+    expect(intent.destination.gas.value).toBe('0');
+  });
+});

--- a/tests/swap/ob.test.ts
+++ b/tests/swap/ob.test.ts
@@ -17,7 +17,7 @@ const caliburExecuteMock = vi.hoisted(() => vi.fn());
 const checkAuthCodeSetMock = vi.hoisted(() => vi.fn());
 const waitForSBCTxReceiptMock = vi.hoisted(() => vi.fn());
 const createBridgeRFFMock = vi.hoisted(() => vi.fn());
-const liquidateInputHoldingsMock = vi.hoisted(() => vi.fn());
+const liquidateSourceHoldingsMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@avail-project/ca-common', async () => {
   const actual = await vi.importActual<typeof import('@avail-project/ca-common')>(
@@ -25,7 +25,7 @@ vi.mock('@avail-project/ca-common', async () => {
   );
   return {
     ...actual,
-    liquidateInputHoldings: liquidateInputHoldingsMock,
+    liquidateSourceHoldings: liquidateSourceHoldingsMock,
   };
 });
 
@@ -201,7 +201,6 @@ describe('DestinationSwapHandler', () => {
         destinationChainID: 999,
         emitter,
         publicClientList: { get: vi.fn() },
-        slippage: 0.005,
         vscClient,
         wallet: {
           cosmos: {} as never,
@@ -285,7 +284,6 @@ describe('DestinationSwapHandler', () => {
         destinationChainID: 999,
         emitter,
         publicClientList: { get: vi.fn() },
-        slippage: 0.005,
         vscClient,
         wallet: {
           cosmos: {} as never,
@@ -416,7 +414,6 @@ describe('SourceSwapsHandler', () => {
         },
         emitter: { emit: vi.fn() },
         publicClientList: { get: vi.fn(() => ({})) },
-        slippage: 0.005,
         vscClient,
         wallet: {
           eoa: {} as never,
@@ -534,7 +531,6 @@ describe('SourceSwapsHandler', () => {
         },
         emitter: { emit: vi.fn() },
         publicClientList: { get: vi.fn(() => ({})) },
-        slippage: 0.005,
         vscClient,
         wallet: {
           eoa: {} as never,
@@ -689,7 +685,6 @@ describe('SourceSwapsHandler', () => {
           },
           emitter: { emit: vi.fn() },
           publicClientList: { get: vi.fn(() => ({})) },
-          slippage: 0.005,
           vscClient: {
             vscCreateSafeExecuteTx: vi.fn(),
             vscSBCTx: vi.fn(),
@@ -710,13 +705,11 @@ describe('SourceSwapsHandler', () => {
     } as never;
 
     const queueRequotes = (specs: SwapSpec[]) => {
-      for (const s of specs) {
-        liquidateInputHoldingsMock.mockResolvedValueOnce([makeQuote(s)]);
-      }
+      liquidateSourceHoldingsMock.mockResolvedValueOnce(specs.map(makeQuote));
     };
 
     beforeEach(() => {
-      liquidateInputHoldingsMock.mockReset();
+      liquidateSourceHoldingsMock.mockReset();
     });
 
     it('accepts retry when new total drops within srcBuffer', async () => {
@@ -798,6 +791,26 @@ describe('SourceSwapsHandler', () => {
       vi.spyOn(handler, 'process').mockResolvedValue([] as never);
 
       await expect(handler.retryWithSlippageCheck(metadata, [1])).resolves.not.toThrow();
+    });
+
+    it('normalizes mixed COT decimals before applying srcBuffer', async () => {
+      // Old = 100 + 100 USDC. New = 99.75 + 99.75 USDC.
+      // Normalized drop = 0.5, srcBuffer = 1.0 -> PASS.
+      // A raw bigint sum incorrectly treats the 18-decimal leg as a huge raw drop.
+      const handler = buildHandler({
+        srcBuffer: new Decimal('1'),
+        initialSwaps: [
+          { chainID: 1, outputAmountRaw: 100_000_000n, outputDecimals: 6 },
+          { chainID: 56, outputAmountRaw: 100_000_000_000_000_000_000n, outputDecimals: 18 },
+        ],
+      });
+      queueRequotes([
+        { chainID: 1, outputAmountRaw: 99_750_000n, outputDecimals: 6 },
+        { chainID: 56, outputAmountRaw: 99_750_000_000_000_000_000n, outputDecimals: 18 },
+      ]);
+      vi.spyOn(handler, 'process').mockResolvedValue([] as never);
+
+      await expect(handler.retryWithSlippageCheck(metadata, [1, 56])).resolves.not.toThrow();
     });
 
     it('rejects when fractional srcBuffer is exceeded', async () => {

--- a/tests/swap/ob.test.ts
+++ b/tests/swap/ob.test.ts
@@ -17,6 +17,17 @@ const caliburExecuteMock = vi.hoisted(() => vi.fn());
 const checkAuthCodeSetMock = vi.hoisted(() => vi.fn());
 const waitForSBCTxReceiptMock = vi.hoisted(() => vi.fn());
 const createBridgeRFFMock = vi.hoisted(() => vi.fn());
+const liquidateInputHoldingsMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@avail-project/ca-common', async () => {
+  const actual = await vi.importActual<typeof import('@avail-project/ca-common')>(
+    '@avail-project/ca-common'
+  );
+  return {
+    ...actual,
+    liquidateInputHoldings: liquidateInputHoldingsMock,
+  };
+});
 
 vi.mock('../../src/core/utils', async () => {
   const actual =
@@ -583,6 +594,222 @@ describe('SourceSwapsHandler', () => {
     );
 
     expect(handler.getPlannedSafeChains()).toEqual(new Set([999]));
+  });
+
+  describe('retryWithSlippageCheck (buffer-based guard)', () => {
+    type SwapSpec = {
+      chainID: number;
+      outputAmountRaw: bigint;
+      outputDecimals: number;
+    };
+
+    const makeQuote = (s: SwapSpec) =>
+      ({
+        chainID: s.chainID,
+        holding: {
+          amountRaw: 1_000_000n,
+          tokenAddress: convertTo32Bytes('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+        },
+        quote: {
+          input: {
+            amount: '1',
+            amountRaw: 1_000_000n,
+            contractAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            decimals: 6,
+            symbol: 'TOKEN',
+          },
+          output: {
+            amount: new Decimal(s.outputAmountRaw.toString())
+              .div(new Decimal(10).pow(s.outputDecimals))
+              .toFixed(),
+            amountRaw: s.outputAmountRaw,
+            contractAddress: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            decimals: s.outputDecimals,
+            symbol: 'USDC',
+          },
+          txData: {
+            approvalAddress: '0xcccccccccccccccccccccccccccccccccccccccc',
+            tx: {
+              data: '0x1234',
+              to: '0xdddddddddddddddddddddddddddddddddddddddd',
+              value: '0',
+            },
+          },
+        },
+      }) as never;
+
+    const buildHandler = ({
+      srcBuffer,
+      initialSwaps,
+    }: {
+      srcBuffer: Decimal;
+      initialSwaps: SwapSpec[];
+    }) => {
+      const executions = Object.fromEntries(
+        Array.from(new Set(initialSwaps.map((s) => s.chainID))).map((chainID) => [
+          chainID,
+          {
+            address: '0x3333333333333333333333333333333333333333',
+            entryPoint: null,
+            mode: 'safe_account',
+          },
+        ])
+      );
+
+      return new SourceSwapsHandler(
+        {
+          source: {
+            swaps: initialSwaps.map(makeQuote),
+            executions,
+            srcBuffer,
+          },
+        } as never,
+        {
+          address: {
+            cosmos: '',
+            eoa: '0x1111111111111111111111111111111111111111',
+            ephemeral: '0x2222222222222222222222222222222222222222',
+          },
+          aggregators: [],
+          cache: {
+            addAllowanceQuery: vi.fn(),
+            addPermitQuery: vi.fn(),
+            addSetCodeQuery: vi.fn(),
+          },
+          chainList: {
+            getChainByID: vi.fn(() => ({
+              blockExplorers: { default: { url: 'https://example.com' } },
+              id: 1,
+              name: 'Mock',
+            })),
+          },
+          cot: {
+            currencyID: CurrencyID.USDC,
+            symbol: 'USDC',
+          },
+          emitter: { emit: vi.fn() },
+          publicClientList: { get: vi.fn(() => ({})) },
+          slippage: 0.005,
+          vscClient: {
+            vscCreateSafeExecuteTx: vi.fn(),
+            vscSBCTx: vi.fn(),
+          },
+          wallet: {
+            eoa: {} as never,
+            ephemeral: { address: '0x2222222222222222222222222222222222222222' } as never,
+          },
+        } as never
+      );
+    };
+
+    const metadata = {
+      dst: { chid: ZERO_BYTES_32, swaps: [], tx_hash: ZERO_BYTES_32, univ: 1 },
+      has_xcs: true,
+      rff_id: 0n,
+      src: [],
+    } as never;
+
+    const queueRequotes = (specs: SwapSpec[]) => {
+      for (const s of specs) {
+        liquidateInputHoldingsMock.mockResolvedValueOnce([makeQuote(s)]);
+      }
+    };
+
+    beforeEach(() => {
+      liquidateInputHoldingsMock.mockReset();
+    });
+
+    it('accepts retry when new total drops within srcBuffer', async () => {
+      // Old failed total = 1.0 + 1.0 = 2.0 USDC.
+      // New failed total = 0.8 + 0.8 = 1.6 USDC. Drop = 0.4.
+      // srcBuffer = 1.0. Drop < buffer -> PASS.
+      const handler = buildHandler({
+        srcBuffer: new Decimal('1'),
+        initialSwaps: [
+          { chainID: 1, outputAmountRaw: 1_000_000n, outputDecimals: 6 },
+          { chainID: 56, outputAmountRaw: 1_000_000n, outputDecimals: 6 },
+        ],
+      });
+      queueRequotes([
+        { chainID: 1, outputAmountRaw: 800_000n, outputDecimals: 6 },
+        { chainID: 56, outputAmountRaw: 800_000n, outputDecimals: 6 },
+      ]);
+      const processSpy = vi.spyOn(handler, 'process').mockResolvedValue([] as never);
+
+      await expect(handler.retryWithSlippageCheck(metadata, [1, 56])).resolves.not.toThrow();
+      expect(processSpy).toHaveBeenCalledWith(metadata, expect.any(Map), false);
+    });
+
+    it('accepts retry at the srcBuffer boundary', async () => {
+      // Old = 2.0, new = 1.0, drop = 1.0, srcBuffer = 1.0 -> PASS (>=).
+      const handler = buildHandler({
+        srcBuffer: new Decimal('1'),
+        initialSwaps: [
+          { chainID: 1, outputAmountRaw: 1_000_000n, outputDecimals: 6 },
+          { chainID: 56, outputAmountRaw: 1_000_000n, outputDecimals: 6 },
+        ],
+      });
+      queueRequotes([
+        { chainID: 1, outputAmountRaw: 500_000n, outputDecimals: 6 },
+        { chainID: 56, outputAmountRaw: 500_000n, outputDecimals: 6 },
+      ]);
+      vi.spyOn(handler, 'process').mockResolvedValue([] as never);
+
+      await expect(handler.retryWithSlippageCheck(metadata, [1, 56])).resolves.not.toThrow();
+    });
+
+    it('rejects retry when new total drops beyond srcBuffer', async () => {
+      // Old = 2.0, new = 0.8, drop = 1.2, srcBuffer = 1.0 -> THROW.
+      const handler = buildHandler({
+        srcBuffer: new Decimal('1'),
+        initialSwaps: [
+          { chainID: 1, outputAmountRaw: 1_000_000n, outputDecimals: 6 },
+          { chainID: 56, outputAmountRaw: 1_000_000n, outputDecimals: 6 },
+        ],
+      });
+      queueRequotes([
+        { chainID: 1, outputAmountRaw: 400_000n, outputDecimals: 6 },
+        { chainID: 56, outputAmountRaw: 400_000n, outputDecimals: 6 },
+      ]);
+      const processSpy = vi.spyOn(handler, 'process').mockResolvedValue([] as never);
+
+      await expect(handler.retryWithSlippageCheck(metadata, [1, 56])).rejects.toThrow(/buffer/);
+      expect(processSpy).not.toHaveBeenCalled();
+    });
+
+    it('accepts retry when new total exceeds old total (no drop)', async () => {
+      const handler = buildHandler({
+        srcBuffer: new Decimal('0'),
+        initialSwaps: [{ chainID: 1, outputAmountRaw: 1_000_000n, outputDecimals: 6 }],
+      });
+      queueRequotes([{ chainID: 1, outputAmountRaw: 1_100_000n, outputDecimals: 6 }]);
+      vi.spyOn(handler, 'process').mockResolvedValue([] as never);
+
+      await expect(handler.retryWithSlippageCheck(metadata, [1])).resolves.not.toThrow();
+    });
+
+    it('uses a fractional srcBuffer correctly (sub-dollar headroom)', async () => {
+      // Old = 100 USDC, new = 99.5 USDC, drop = 0.5, srcBuffer = 0.8 -> PASS.
+      const handler = buildHandler({
+        srcBuffer: new Decimal('0.8'),
+        initialSwaps: [{ chainID: 1, outputAmountRaw: 100_000_000n, outputDecimals: 6 }],
+      });
+      queueRequotes([{ chainID: 1, outputAmountRaw: 99_500_000n, outputDecimals: 6 }]);
+      vi.spyOn(handler, 'process').mockResolvedValue([] as never);
+
+      await expect(handler.retryWithSlippageCheck(metadata, [1])).resolves.not.toThrow();
+    });
+
+    it('rejects when fractional srcBuffer is exceeded', async () => {
+      // Old = 100 USDC, new = 99 USDC, drop = 1, srcBuffer = 0.8 -> THROW.
+      const handler = buildHandler({
+        srcBuffer: new Decimal('0.8'),
+        initialSwaps: [{ chainID: 1, outputAmountRaw: 100_000_000n, outputDecimals: 6 }],
+      });
+      queueRequotes([{ chainID: 1, outputAmountRaw: 99_000_000n, outputDecimals: 6 }]);
+
+      await expect(handler.retryWithSlippageCheck(metadata, [1])).rejects.toThrow(/buffer/);
+    });
   });
 });
 

--- a/tests/swap/route.filter.test.ts
+++ b/tests/swap/route.filter.test.ts
@@ -1,0 +1,313 @@
+// Durable contract tests for the EXACT_OUT source-filter and dst-chain removal behavior,
+// pinned at the determineSwapRoute boundary so they're independent of where the filter is
+// physically implemented.
+//
+// Today the filter sits in two places: getBalancesForSwap (via ankrBalanceToAssets) for
+// the non-preloaded path, and route.ts's filterAllowedSources/filterRemoveSources for the
+// preloaded path. The Win 5 refactor will collapse both into the route.ts path so it can
+// be re-applied per-refresh against a fresh fromSources without re-fetching balances.
+// These tests describe the contract the consumer sees through `determineSwapRoute` and
+// must keep passing across that move.
+//
+// `runDetermineSwapRoute` uses preloadedBalances, so these tests exercise the route.ts
+// inline filter today and the unified route.ts filter post-refactor — same code, same
+// assertions, both before and after.
+
+import type { Hex } from 'viem';
+import { describe, expect, it } from 'vitest';
+import { SUPPORTED_CHAINS } from '../../src/commons';
+import {
+  exactOutInput,
+  makeBalance,
+  makeOraclePrice,
+  runDetermineSwapRoute,
+} from '../helpers/swap-route-fixtures';
+
+const USDC_BASE: Hex = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const USDC_ARBITRUM: Hex = '0xaf88d065e77c8cc2239327c5edb3a432268e5831';
+const USDC_HYPEREVM: Hex = '0xb88339CB7199b77E23DB6E890353E22632Ba630f';
+
+const NONCOT_BASE: Hex = '0xeeee0000000000000000000000000000babe0001';
+const NONCOT_ARBITRUM: Hex = '0xeeee00000000000000000000000000000abb0001';
+const NONCOT_HYPEREVM: Hex = '0xeeee0000000000000000000000000000face0001';
+
+const ZERO_ADDR: Hex = '0x0000000000000000000000000000000000000000';
+const EADDR: Hex = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+
+// Lowercased 32-byte hex fragments for comparing FlatBalance.tokenAddress (which is
+// pre-normalized to 32-byte hex with native => EADDRESS via toFlatBalance).
+const expand32 = (addr: Hex): string => `0x${'0'.repeat(24)}${addr.slice(2).toLowerCase()}`;
+
+const oraclePrices = [
+  makeOraclePrice(SUPPORTED_CHAINS.BASE, USDC_BASE),
+  makeOraclePrice(SUPPORTED_CHAINS.BASE, NONCOT_BASE),
+  makeOraclePrice(SUPPORTED_CHAINS.ARBITRUM, USDC_ARBITRUM),
+  makeOraclePrice(SUPPORTED_CHAINS.ARBITRUM, NONCOT_ARBITRUM),
+  makeOraclePrice(SUPPORTED_CHAINS.HYPEREVM, USDC_HYPEREVM),
+  makeOraclePrice(SUPPORTED_CHAINS.HYPEREVM, NONCOT_HYPEREVM),
+];
+
+// Common helper: ask whether `route.extras.balances` contains a (chainId, tokenAddress) pair.
+// Token-address compare is case-insensitive and uses the 32-byte hex form FlatBalance
+// stores, with the ZERO_ADDRESS ↔ EADDRESS normalization (native is stored as EADDRESS).
+const balancesContain = (
+  balances: { chainID: number; tokenAddress: string }[],
+  chainId: number,
+  tokenAddress: Hex
+): boolean => {
+  const lookup =
+    tokenAddress.toLowerCase() === ZERO_ADDR ? expand32(EADDR) : expand32(tokenAddress);
+  return balances.some(
+    (b) => b.chainID === chainId && b.tokenAddress.toLowerCase() === lookup.toLowerCase()
+  );
+};
+
+describe('EXACT_OUT filter contract — fromSources / removeSources', () => {
+  describe('fromSources (allowedSources)', () => {
+    it('empty / undefined fromSources: all balances remain available', async () => {
+      const { route } = await runDetermineSwapRoute({
+        input: exactOutInput({
+          toChainId: SUPPORTED_CHAINS.HYPEREVM,
+          toTokenAddress: NONCOT_HYPEREVM,
+          toAmount: 10_000_000n,
+        }),
+        preloadedBalances: [
+          makeBalance(SUPPORTED_CHAINS.BASE, NONCOT_BASE, '50'),
+          makeBalance(SUPPORTED_CHAINS.ARBITRUM, NONCOT_ARBITRUM, '50'),
+        ],
+        oraclePrices,
+      });
+
+      expect(balancesContain(route.extras.balances, SUPPORTED_CHAINS.BASE, NONCOT_BASE)).toBe(true);
+      expect(
+        balancesContain(route.extras.balances, SUPPORTED_CHAINS.ARBITRUM, NONCOT_ARBITRUM)
+      ).toBe(true);
+    });
+
+    it('single fromSources entry keeps only the matching (chainId, tokenAddress)', async () => {
+      const { route } = await runDetermineSwapRoute({
+        input: exactOutInput({
+          fromSources: [{ chainId: SUPPORTED_CHAINS.BASE, tokenAddress: NONCOT_BASE }],
+          toChainId: SUPPORTED_CHAINS.HYPEREVM,
+          toTokenAddress: NONCOT_HYPEREVM,
+          toAmount: 10_000_000n,
+        }),
+        preloadedBalances: [
+          makeBalance(SUPPORTED_CHAINS.BASE, NONCOT_BASE, '50'),
+          makeBalance(SUPPORTED_CHAINS.ARBITRUM, NONCOT_ARBITRUM, '50'),
+        ],
+        oraclePrices,
+      });
+
+      expect(balancesContain(route.extras.balances, SUPPORTED_CHAINS.BASE, NONCOT_BASE)).toBe(true);
+      expect(
+        balancesContain(route.extras.balances, SUPPORTED_CHAINS.ARBITRUM, NONCOT_ARBITRUM)
+      ).toBe(false);
+    });
+
+    it('fromSources excludes a chain entirely when none of its tokens are listed', async () => {
+      const { route } = await runDetermineSwapRoute({
+        input: exactOutInput({
+          fromSources: [{ chainId: SUPPORTED_CHAINS.BASE, tokenAddress: NONCOT_BASE }],
+          toChainId: SUPPORTED_CHAINS.HYPEREVM,
+          toTokenAddress: NONCOT_HYPEREVM,
+          toAmount: 10_000_000n,
+        }),
+        preloadedBalances: [
+          makeBalance(SUPPORTED_CHAINS.BASE, NONCOT_BASE, '100'),
+          makeBalance(SUPPORTED_CHAINS.ARBITRUM, USDC_ARBITRUM, '50', 6, 'USDC'),
+        ],
+        oraclePrices,
+      });
+
+      const arbitrumEntries = route.extras.balances.filter(
+        (b) => b.chainID === SUPPORTED_CHAINS.ARBITRUM
+      );
+      expect(arbitrumEntries).toHaveLength(0);
+    });
+
+    it('fromSources matches an uppercase token address against a lowercase balance', async () => {
+      const upper = NONCOT_BASE.toUpperCase().replace('0X', '0x') as Hex;
+      const { route } = await runDetermineSwapRoute({
+        input: exactOutInput({
+          fromSources: [{ chainId: SUPPORTED_CHAINS.BASE, tokenAddress: upper }],
+          toChainId: SUPPORTED_CHAINS.HYPEREVM,
+          toTokenAddress: NONCOT_HYPEREVM,
+          toAmount: 10_000_000n,
+        }),
+        preloadedBalances: [makeBalance(SUPPORTED_CHAINS.BASE, NONCOT_BASE, '50')],
+        oraclePrices,
+      });
+
+      expect(balancesContain(route.extras.balances, SUPPORTED_CHAINS.BASE, NONCOT_BASE)).toBe(true);
+    });
+
+    it('fromSources with ZERO_ADDRESS matches the native balance on that chain', async () => {
+      const { route } = await runDetermineSwapRoute({
+        input: exactOutInput({
+          fromSources: [{ chainId: SUPPORTED_CHAINS.BASE, tokenAddress: ZERO_ADDR }],
+          toChainId: SUPPORTED_CHAINS.HYPEREVM,
+          toTokenAddress: NONCOT_HYPEREVM,
+          toAmount: 10_000_000n,
+        }),
+        preloadedBalances: [
+          // FlatBalance stores native as EADDRESS (per toFlatBalance); makeBalance accepts
+          // the raw hex and 32-byte-pads it. Passing EADDR here matches what real callers
+          // see in their balance lists.
+          makeBalance(SUPPORTED_CHAINS.BASE, EADDR, '5', 18, 'ETH'),
+        ],
+        oraclePrices: [...oraclePrices, makeOraclePrice(SUPPORTED_CHAINS.BASE, EADDR)],
+      });
+
+      expect(balancesContain(route.extras.balances, SUPPORTED_CHAINS.BASE, EADDR)).toBe(true);
+    });
+
+    it('fromSources with EADDRESS also matches the native balance on that chain', async () => {
+      const { route } = await runDetermineSwapRoute({
+        input: exactOutInput({
+          fromSources: [{ chainId: SUPPORTED_CHAINS.BASE, tokenAddress: EADDR }],
+          toChainId: SUPPORTED_CHAINS.HYPEREVM,
+          toTokenAddress: NONCOT_HYPEREVM,
+          toAmount: 10_000_000n,
+        }),
+        preloadedBalances: [makeBalance(SUPPORTED_CHAINS.BASE, EADDR, '5', 18, 'ETH')],
+        oraclePrices: [...oraclePrices, makeOraclePrice(SUPPORTED_CHAINS.BASE, EADDR)],
+      });
+
+      expect(balancesContain(route.extras.balances, SUPPORTED_CHAINS.BASE, EADDR)).toBe(true);
+    });
+  });
+
+  describe('removeSources (derived from toAmount / toNativeAmount sentinels)', () => {
+    it('toAmount > 0n removes the dst-chain toToken from sources', async () => {
+      // Provide an Arbitrum non-COT balance so the route has somewhere else to draw from
+      // — otherwise the bridge build would fail for unrelated reasons and obscure the
+      // intent of this test.
+      const { route } = await runDetermineSwapRoute({
+        input: exactOutInput({
+          toChainId: SUPPORTED_CHAINS.HYPEREVM,
+          toTokenAddress: NONCOT_HYPEREVM,
+          toAmount: 10_000_000n,
+        }),
+        preloadedBalances: [
+          makeBalance(SUPPORTED_CHAINS.HYPEREVM, NONCOT_HYPEREVM, '50'),
+          makeBalance(SUPPORTED_CHAINS.ARBITRUM, NONCOT_ARBITRUM, '50'),
+        ],
+        oraclePrices,
+      });
+
+      expect(
+        balancesContain(route.extras.balances, SUPPORTED_CHAINS.HYPEREVM, NONCOT_HYPEREVM)
+      ).toBe(false);
+    });
+
+    it('toAmount === -1n (exactly-enough sentinel) removes the dst-chain toToken from sources', async () => {
+      const { route } = await runDetermineSwapRoute({
+        input: exactOutInput({
+          toChainId: SUPPORTED_CHAINS.HYPEREVM,
+          toTokenAddress: NONCOT_HYPEREVM,
+          toAmount: -1n,
+        }),
+        preloadedBalances: [
+          makeBalance(SUPPORTED_CHAINS.HYPEREVM, NONCOT_HYPEREVM, '50'),
+          makeBalance(SUPPORTED_CHAINS.ARBITRUM, NONCOT_ARBITRUM, '50'),
+        ],
+        oraclePrices,
+      });
+
+      expect(
+        balancesContain(route.extras.balances, SUPPORTED_CHAINS.HYPEREVM, NONCOT_HYPEREVM)
+      ).toBe(false);
+    });
+
+    it('toAmount < -1n (surplus sentinel) keeps the dst-chain toToken but reduces its amount', async () => {
+      // Reserve 10 USDC of the dst-chain token; balance was 50 USDC; expect ~40 remaining.
+      const { route } = await runDetermineSwapRoute({
+        input: exactOutInput({
+          toChainId: SUPPORTED_CHAINS.HYPEREVM,
+          toTokenAddress: USDC_HYPEREVM,
+          toAmount: -10_000_000n, // < -1n → reserve 10 USDC, surplus stays usable
+        }),
+        preloadedBalances: [makeBalance(SUPPORTED_CHAINS.HYPEREVM, USDC_HYPEREVM, '50', 6, 'USDC')],
+        oraclePrices,
+      });
+
+      // The dst-chain USDC must still be in the balance set (not removed)…
+      const dst = route.extras.balances.find(
+        (b) => b.chainID === SUPPORTED_CHAINS.HYPEREVM && b.tokenAddress === expand32(USDC_HYPEREVM)
+      );
+      expect(dst).toBeDefined();
+      // …with the reserved amount deducted (50 - 10 = 40).
+      expect(Number(dst!.amount)).toBe(40);
+    });
+
+    it('toNativeAmount > 0n removes the dst-chain native token from sources', async () => {
+      const { route } = await runDetermineSwapRoute({
+        input: exactOutInput({
+          toChainId: SUPPORTED_CHAINS.HYPEREVM,
+          toTokenAddress: NONCOT_HYPEREVM,
+          toAmount: 10_000_000n,
+          toNativeAmount: 1_000_000_000_000_000n, // 0.001 HYPE
+        }),
+        preloadedBalances: [
+          makeBalance(SUPPORTED_CHAINS.HYPEREVM, EADDR, '1', 18, 'HYPE'),
+          makeBalance(SUPPORTED_CHAINS.ARBITRUM, NONCOT_ARBITRUM, '50'),
+        ],
+        oraclePrices: [...oraclePrices, makeOraclePrice(SUPPORTED_CHAINS.HYPEREVM, EADDR)],
+      });
+
+      // EADDRESS native on the dst chain is dropped because toNativeAmount > 0n.
+      expect(balancesContain(route.extras.balances, SUPPORTED_CHAINS.HYPEREVM, EADDR)).toBe(false);
+    });
+
+    it('toNativeAmount === -1n removes the dst-chain native token from sources', async () => {
+      const { route } = await runDetermineSwapRoute({
+        input: exactOutInput({
+          toChainId: SUPPORTED_CHAINS.HYPEREVM,
+          toTokenAddress: NONCOT_HYPEREVM,
+          toAmount: 10_000_000n,
+          toNativeAmount: -1n,
+        }),
+        preloadedBalances: [
+          makeBalance(SUPPORTED_CHAINS.HYPEREVM, EADDR, '1', 18, 'HYPE'),
+          makeBalance(SUPPORTED_CHAINS.ARBITRUM, NONCOT_ARBITRUM, '50'),
+        ],
+        oraclePrices: [...oraclePrices, makeOraclePrice(SUPPORTED_CHAINS.HYPEREVM, EADDR)],
+      });
+
+      expect(balancesContain(route.extras.balances, SUPPORTED_CHAINS.HYPEREVM, EADDR)).toBe(false);
+    });
+  });
+
+  describe('fromSources and removeSources composition', () => {
+    it('removeSources still drops the dst-chain toToken even when fromSources allows it', async () => {
+      // Caller may have a stale fromSources list that includes dst-chain. The removeSources
+      // (driven by toAmount > 0n) is authoritative.
+      const { route } = await runDetermineSwapRoute({
+        input: exactOutInput({
+          fromSources: [
+            { chainId: SUPPORTED_CHAINS.HYPEREVM, tokenAddress: NONCOT_HYPEREVM },
+            { chainId: SUPPORTED_CHAINS.ARBITRUM, tokenAddress: NONCOT_ARBITRUM },
+          ],
+          toChainId: SUPPORTED_CHAINS.HYPEREVM,
+          toTokenAddress: NONCOT_HYPEREVM,
+          toAmount: 10_000_000n,
+        }),
+        preloadedBalances: [
+          makeBalance(SUPPORTED_CHAINS.HYPEREVM, NONCOT_HYPEREVM, '50'),
+          makeBalance(SUPPORTED_CHAINS.ARBITRUM, NONCOT_ARBITRUM, '50'),
+        ],
+        oraclePrices,
+      });
+
+      // dst-chain entry dropped (removeSources wins)…
+      expect(
+        balancesContain(route.extras.balances, SUPPORTED_CHAINS.HYPEREVM, NONCOT_HYPEREVM)
+      ).toBe(false);
+      // …Arbitrum non-dst entry preserved (fromSources allowed).
+      expect(
+        balancesContain(route.extras.balances, SUPPORTED_CHAINS.ARBITRUM, NONCOT_ARBITRUM)
+      ).toBe(true);
+    });
+  });
+});

--- a/tests/swap/route.refresh.test.ts
+++ b/tests/swap/route.refresh.test.ts
@@ -1,0 +1,202 @@
+// Win 5 contract: determineSwapRoute returns { route, refresh }. The `refresh` function
+// captures the closure's `feeStore`, `oraclePrices`, raw balances, dst-token metadata,
+// and chain executions; subsequent refresh() calls re-quote aggregators but skip the
+// slow refetches. These tests pin that contract by counting calls into the mocked
+// dependencies before/after refresh.
+
+import { type Aggregator, CurrencyID } from '@avail-project/ca-common';
+import type { Hex } from 'viem';
+import { describe, expect, it, type vi } from 'vitest';
+import type {
+  CosmosQueryClient,
+  OraclePriceResponse,
+  SwapParams,
+  VSCClient,
+} from '../../src/commons';
+import { SUPPORTED_CHAINS, SwapMode } from '../../src/commons';
+import { determineSwapRoute } from '../../src/swap/route';
+import type { PublicClientList } from '../../src/swap/utils';
+import {
+  exactInInput,
+  exactOutInput,
+  FakePublicClientList,
+  mainnetChainList,
+  makeBalance,
+  makeMockCosmosQueryClient,
+  makeMockVscClient,
+  makeOraclePrice,
+  makeRecordingAggregator,
+  TEST_EOA,
+  TEST_EPHEMERAL,
+} from '../helpers/swap-route-fixtures';
+
+const USDC_BASE: Hex = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const USDC_ARBITRUM: Hex = '0xaf88d065e77c8cc2239327c5edb3a432268e5831';
+const USDC_HYPEREVM: Hex = '0xb88339CB7199b77E23DB6E890353E22632Ba630f';
+const NONCOT_BASE: Hex = '0xeeee0000000000000000000000000000babe0001';
+const NONCOT_ARBITRUM: Hex = '0xeeee00000000000000000000000000000abb0001';
+const NONCOT_HYPEREVM: Hex = '0xeeee0000000000000000000000000000face0001';
+
+const oraclePrices: OraclePriceResponse = [
+  makeOraclePrice(SUPPORTED_CHAINS.BASE, USDC_BASE),
+  makeOraclePrice(SUPPORTED_CHAINS.BASE, NONCOT_BASE),
+  makeOraclePrice(SUPPORTED_CHAINS.ARBITRUM, USDC_ARBITRUM),
+  makeOraclePrice(SUPPORTED_CHAINS.ARBITRUM, NONCOT_ARBITRUM),
+  makeOraclePrice(SUPPORTED_CHAINS.HYPEREVM, USDC_HYPEREVM),
+  makeOraclePrice(SUPPORTED_CHAINS.HYPEREVM, NONCOT_HYPEREVM),
+];
+
+// Build the same option bag runDetermineSwapRoute uses, but expose the mocks so each
+// test can count call-counts before/after a refresh.
+const setup = (preloadedBalances: ReturnType<typeof makeBalance>[]) => {
+  const aggregator = makeRecordingAggregator();
+  const vscClient = makeMockVscClient();
+  const cosmosQueryClient = makeMockCosmosQueryClient(oraclePrices);
+  const chainList = mainnetChainList();
+  const publicClientList = new FakePublicClientList(chainList);
+
+  const options: SwapParams & {
+    publicClientList: PublicClientList;
+    aggregators: Aggregator[];
+    cotCurrencyID: CurrencyID;
+  } = {
+    address: { cosmos: 'avail1test', eoa: TEST_EOA, ephemeral: TEST_EPHEMERAL },
+    chainList,
+    cosmosQueryClient,
+    intentExplorerUrl: 'https://test.example',
+    onSwapIntent: ({ allow }: { allow: () => void }) => allow(),
+    preloadedBalances,
+    vscClient,
+    wallet: { cosmos: {} as never, eoa: {} as never, ephemeral: {} as never },
+    aggregators: [aggregator.aggregator],
+    publicClientList,
+    cotCurrencyID: CurrencyID.USDC,
+  } as never;
+
+  return { options, aggregator, vscClient, cosmosQueryClient };
+};
+
+const exactOut = (overrides: Partial<Parameters<typeof exactOutInput>[0]> = {}) =>
+  exactOutInput({
+    toChainId: SUPPORTED_CHAINS.HYPEREVM,
+    toTokenAddress: NONCOT_HYPEREVM,
+    toAmount: 10_000_000n,
+    ...overrides,
+  });
+
+describe('determineSwapRoute → { route, refresh } (Win 5 closure reuse)', () => {
+  it('returns both `route` and `refresh` on the initial call', async () => {
+    const { options } = setup([makeBalance(SUPPORTED_CHAINS.BASE, NONCOT_BASE, '100')]);
+    const result = await determineSwapRoute(exactOut(), options);
+
+    expect(result.route).toBeDefined();
+    expect(typeof result.refresh).toBe('function');
+  });
+
+  it('does not refetch oraclePrices when refresh() is called', async () => {
+    const { options, cosmosQueryClient } = setup([
+      makeBalance(SUPPORTED_CHAINS.BASE, NONCOT_BASE, '100'),
+    ]);
+    const initial = exactOut();
+    const { refresh } = await determineSwapRoute(initial, options);
+
+    // Initial call should have fetched oraclePrices once.
+    const initialOracleCalls = (cosmosQueryClient.fetchPriceOracle as ReturnType<typeof vi.fn>).mock
+      .calls.length;
+    expect(initialOracleCalls).toBe(1);
+
+    await refresh(initial);
+
+    // Refresh must NOT re-fetch oraclePrices.
+    const afterRefreshOracleCalls = (cosmosQueryClient.fetchPriceOracle as ReturnType<typeof vi.fn>)
+      .mock.calls.length;
+    expect(afterRefreshOracleCalls).toBe(initialOracleCalls);
+  });
+
+  it('does not call vscGetSafeAccountAddress again on refresh', async () => {
+    // HyperEVM source forces a Safe-account verification on initial call. Refresh must
+    // not re-fire that VSC roundtrip — the chain execution is fully cached.
+    const { options, vscClient } = setup([
+      makeBalance(SUPPORTED_CHAINS.HYPEREVM, NONCOT_HYPEREVM, '100'),
+    ]);
+    const initial = exactOut({
+      toChainId: SUPPORTED_CHAINS.ARBITRUM,
+      toTokenAddress: NONCOT_ARBITRUM,
+    });
+    const { refresh } = await determineSwapRoute(initial, options);
+
+    const initialVscCalls = (vscClient.vscGetSafeAccountAddress as ReturnType<typeof vi.fn>).mock
+      .calls.length;
+    expect(initialVscCalls).toBeGreaterThan(0); // HyperEVM source → at least one call.
+
+    await refresh(initial);
+
+    const afterRefreshVscCalls = (vscClient.vscGetSafeAccountAddress as ReturnType<typeof vi.fn>)
+      .mock.calls.length;
+    expect(afterRefreshVscCalls).toBe(initialVscCalls);
+  });
+
+  it('re-runs aggregator quotes on every refresh (the whole point of refresh)', async () => {
+    const { options, aggregator } = setup([makeBalance(SUPPORTED_CHAINS.BASE, NONCOT_BASE, '100')]);
+    const initial = exactOut();
+    const { refresh } = await determineSwapRoute(initial, options);
+
+    const initialQuoteCalls = aggregator.calls.length;
+    expect(initialQuoteCalls).toBeGreaterThan(0);
+
+    await refresh(initial);
+
+    // Refresh must re-quote — the reason it exists is to pick up rate movement.
+    expect(aggregator.calls.length).toBeGreaterThan(initialQuoteCalls);
+  });
+
+  it('applies a new fromSources filter on refresh against the closure-cached balance set', async () => {
+    const { options } = setup([
+      makeBalance(SUPPORTED_CHAINS.BASE, NONCOT_BASE, '100'),
+      makeBalance(SUPPORTED_CHAINS.ARBITRUM, NONCOT_ARBITRUM, '100'),
+    ]);
+    const initial = exactOut({
+      fromSources: [{ chainId: SUPPORTED_CHAINS.BASE, tokenAddress: NONCOT_BASE }],
+    });
+    const { route: initialRoute, refresh } = await determineSwapRoute(initial, options);
+
+    // Initial: only Base balance survives.
+    expect(initialRoute.extras.balances.some((b) => b.chainID === SUPPORTED_CHAINS.BASE)).toBe(
+      true
+    );
+    expect(initialRoute.extras.balances.some((b) => b.chainID === SUPPORTED_CHAINS.ARBITRUM)).toBe(
+      false
+    );
+
+    // Refresh with a different fromSources: Arbitrum-only.
+    const refreshed = await refresh({
+      mode: SwapMode.EXACT_OUT,
+      data: {
+        ...initial.data,
+        fromSources: [{ chainId: SUPPORTED_CHAINS.ARBITRUM, tokenAddress: NONCOT_ARBITRUM }],
+      },
+    });
+
+    // Now Arbitrum survives, Base is filtered out — proving the closure cached the
+    // UNFILTERED balance set and refresh re-applied the filter.
+    expect(refreshed.extras.balances.some((b) => b.chainID === SUPPORTED_CHAINS.ARBITRUM)).toBe(
+      true
+    );
+    expect(refreshed.extras.balances.some((b) => b.chainID === SUPPORTED_CHAINS.BASE)).toBe(false);
+  });
+
+  it('rejects refresh that changes swap mode', async () => {
+    const { options } = setup([makeBalance(SUPPORTED_CHAINS.BASE, NONCOT_BASE, '100')]);
+    const { refresh } = await determineSwapRoute(exactOut(), options);
+
+    await expect(
+      refresh(
+        exactInInput({
+          from: [{ chainId: SUPPORTED_CHAINS.BASE, tokenAddress: NONCOT_BASE }],
+          toChainId: SUPPORTED_CHAINS.ARBITRUM,
+          toTokenAddress: NONCOT_ARBITRUM,
+        })
+      )
+    ).rejects.toThrow(/cannot switch swap mode/i);
+  });
+});

--- a/tests/swap/route.refresh.test.ts
+++ b/tests/swap/route.refresh.test.ts
@@ -199,4 +199,39 @@ describe('determineSwapRoute → { route, refresh } (Win 5 closure reuse)', () =
       )
     ).rejects.toThrow(/cannot switch swap mode/i);
   });
+
+  // Regression: CombinedSwapHandler.requoteBothLegs invokes `route.destination.getDstSwap`
+  // with `{ skipRateGuard: true }` to bypass the 0.5% output-drop guard on combined
+  // retries (the combined batch enforces its own `src.output ≥ dst.input` invariant).
+  // The mocked closure in combinedSwap.test.ts proved the handler passes the flag — this
+  // test proves the REAL EXACT_IN closure honors it, by inflating the stored baseline
+  // beyond the 0.5% tolerance and observing throw-vs-no-throw across the two call shapes.
+  it('EXACT_IN getDstSwap: skipRateGuard bypasses the 0.5% output-drop guard', async () => {
+    const { options } = setup([makeBalance(SUPPORTED_CHAINS.BASE, NONCOT_BASE, '100')]);
+    const { route } = await determineSwapRoute(
+      exactInInput({
+        from: [{ chainId: SUPPORTED_CHAINS.BASE, tokenAddress: NONCOT_BASE }],
+        toChainId: SUPPORTED_CHAINS.ARBITRUM,
+        toTokenAddress: NONCOT_ARBITRUM,
+      }),
+      options
+    );
+
+    expect(route.destination.swap.tokenSwap).not.toBeNull();
+    const original = route.destination.swap.tokenSwap;
+    if (!original) throw new Error('precondition: tokenSwap must exist');
+
+    // Inflate the stored baseline so that the recording aggregator's next identity
+    // response will look like a >0.5% drop. The guard compares against
+    // `destination.swap.tokenSwap.quote.output.amountRaw`.
+    original.quote.output.amountRaw = original.quote.output.amountRaw * 10n;
+
+    // Default: rate guard active → throw.
+    await expect(route.destination.getDstSwap()).rejects.toThrow(/Rates changed/i);
+
+    // Combined retry path: skipRateGuard → pass through, return the fresh quote.
+    const result = await route.destination.getDstSwap({ skipRateGuard: true });
+    expect(result).not.toBeNull();
+    expect(result?.tokenSwap?.quote.output.amountRaw).toBeGreaterThan(0n);
+  });
 });

--- a/tests/swap/route.test.ts
+++ b/tests/swap/route.test.ts
@@ -1,11 +1,10 @@
 import { type Hex, toHex } from 'viem';
-import { describe, expect, it, vi } from 'vitest';
-import { type Chain, SUPPORTED_CHAINS, type VSCClient } from '../../src/commons';
+import { describe, expect, it } from 'vitest';
+import { type Chain, SUPPORTED_CHAINS } from '../../src/commons';
 import type { FlatBalance } from '../../src/swap/data';
 import {
   hasDestinationChainSourceSwapOutput,
   requiresSafeAccount,
-  resolveDestinationExecution,
   toAggregatorInputsWithSwapAddresses,
 } from '../../src/swap/route';
 import {
@@ -47,108 +46,10 @@ describe('requiresSafeAccount', () => {
   });
 });
 
-describe('resolveDestinationExecution', () => {
-  it('uses the deterministic Safe account on HyperEVM when a destination swap is required', async () => {
-    const vscClient = {
-      vscGetSafeAccountAddress: vi.fn().mockResolvedValue({
-        address: '0x3333333333333333333333333333333333333333',
-        factoryAddress: '0x4444444444444444444444444444444444444444',
-      }),
-    } as Partial<VSCClient> as VSCClient;
-
-    const result = await resolveDestinationExecution({
-      chain: {
-        ...baseChain,
-        id: SUPPORTED_CHAINS.HYPEREVM,
-        name: 'HyperEVM',
-        pectraUpgradeSupport: false,
-      },
-      eoaAddress: '0x1111111111111111111111111111111111111111',
-      ephemeralAddress: '0x2222222222222222222222222222222222222222',
-      needsDestinationExecution: true,
-      vscClient,
-    });
-
-    expect(vscClient.vscGetSafeAccountAddress).toHaveBeenCalledWith(
-      SUPPORTED_CHAINS.HYPEREVM,
-      '0x2222222222222222222222222222222222222222'
-    );
-    expect(result).toEqual({
-      address: '0x3333333333333333333333333333333333333333',
-      entryPoint: null,
-      factoryAddress: '0x4444444444444444444444444444444444444444',
-      mode: 'safe_account',
-    });
-  });
-
-  it('keeps the ephemeral executor on 7702 destination paths', async () => {
-    const vscClient = {
-      vscGetSafeAccountAddress: vi.fn(),
-    } as Partial<VSCClient> as VSCClient;
-
-    const result = await resolveDestinationExecution({
-      chain: baseChain,
-      eoaAddress: '0x1111111111111111111111111111111111111111',
-      ephemeralAddress: '0x2222222222222222222222222222222222222222',
-      needsDestinationExecution: true,
-      vscClient,
-    });
-
-    expect(vscClient.vscGetSafeAccountAddress).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      address: '0x2222222222222222222222222222222222222222',
-      entryPoint: null,
-      mode: '7702',
-    });
-  });
-
-  it('keeps direct-to-eoa destination transfers off the smart-account path when no destination swap is needed', async () => {
-    const vscClient = {
-      vscGetSafeAccountAddress: vi.fn(),
-    } as Partial<VSCClient> as VSCClient;
-
-    const result = await resolveDestinationExecution({
-      chain: {
-        ...baseChain,
-        id: SUPPORTED_CHAINS.HYPEREVM,
-        name: 'HyperEVM',
-        pectraUpgradeSupport: false,
-      },
-      eoaAddress: '0x1111111111111111111111111111111111111111',
-      ephemeralAddress: '0x2222222222222222222222222222222222222222',
-      needsDestinationExecution: false,
-      vscClient,
-    });
-
-    expect(vscClient.vscGetSafeAccountAddress).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      address: '0x1111111111111111111111111111111111111111',
-      entryPoint: null,
-      mode: 'direct_eoa',
-    });
-  });
-
-  it('routes no-destination-execution transfers directly to the EOA on 7702 chains as well', async () => {
-    const vscClient = {
-      vscGetSafeAccountAddress: vi.fn(),
-    } as Partial<VSCClient> as VSCClient;
-
-    const result = await resolveDestinationExecution({
-      chain: baseChain,
-      eoaAddress: '0x1111111111111111111111111111111111111111',
-      ephemeralAddress: '0x2222222222222222222222222222222222222222',
-      needsDestinationExecution: false,
-      vscClient,
-    });
-
-    expect(vscClient.vscGetSafeAccountAddress).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      address: '0x1111111111111111111111111111111111111111',
-      entryPoint: null,
-      mode: 'direct_eoa',
-    });
-  });
-});
+// Per-chain Safe-vs-7702 selection is covered by tests/swap/sourceExecution.test.ts
+// (which now targets the combined `resolveChainExecutions` helper). The dst-specific
+// `direct_eoa` downgrade is exercised end-to-end by the integration scenarios below
+// (`assertNoDestinationCalls`, the `combined` flag tests, etc.).
 
 describe('toAggregatorInputsWithSwapAddresses', () => {
   it('populates both takerAddress and receiverAddress with the execution address per source chain', () => {

--- a/tests/swap/route.test.ts
+++ b/tests/swap/route.test.ts
@@ -588,10 +588,10 @@ describe('Combined-swap destination input buffer', () => {
     expect(buyQuote!.inputAmount).toBe(99_500_000n);
   });
 
-  it('does NOT apply combined buffer when combined=false (bridge case)', async () => {
-    // Base NONCOT 100 → bridge → Arbitrum: dst input is sourceOutput minus bridge fee.
-    // The combined buffer must NOT be applied here. We assert the input is not the
-    // 99.5% multiple that the combined path would produce.
+  it('applies EXACT_IN srcBuffer (0.5%, capped at $1) when combined=false (bridge case)', async () => {
+    // Base NONCOT 100 → bridge → Arbitrum: source produces 100 USDC, mock bridge fee = 0,
+    // srcBuffer = min(100 * 0.005, $1) = 0.5 → dst aggregator input = 99.5 USDC. The
+    // under-sized dst input keeps the dst swap funded if a source leg re-quotes lower.
     const { aggregator } = await runDetermineSwapRoute({
       input: exactInInput({
         from: [{ chainId: SUPPORTED_CHAINS.BASE, tokenAddress: NONCOT_BASE }],
@@ -609,9 +609,32 @@ describe('Combined-swap destination input buffer', () => {
     });
     const buyQuote = findDstExactInBuyQuote(destinationCalls);
     expect(buyQuote).toBeDefined();
-    // Whatever the bridge-fee math produces, it must not coincidentally equal the combined
-    // buffer's 99_500_000n. (If feeStore mock returns zero fee the input would be 100_000_000n.)
-    expect(buyQuote!.inputAmount).not.toBe(99_500_000n);
+    // 100 USDC - 0.5 USDC (srcBuffer) = 99.5 USDC
+    expect(buyQuote!.inputAmount).toBe(99_500_000n);
+  });
+
+  it('caps EXACT_IN srcBuffer at $1 for large source amounts', async () => {
+    // Base NONCOT 500 → bridge → Arbitrum: 0.5% would be $2.50 but the cap is $1, so
+    // srcBuffer = $1 → dst aggregator input = 499 USDC.
+    const { aggregator } = await runDetermineSwapRoute({
+      input: exactInInput({
+        from: [{ chainId: SUPPORTED_CHAINS.BASE, tokenAddress: NONCOT_BASE }],
+        toChainId: SUPPORTED_CHAINS.ARBITRUM,
+        toTokenAddress: NONCOT_ARBITRUM,
+      }),
+      preloadedBalances: [makeBalance(SUPPORTED_CHAINS.BASE, NONCOT_BASE, '500')],
+      oraclePrices,
+    });
+
+    const { destinationCalls } = partitionCalls(aggregator.calls, {
+      destChainId: SUPPORTED_CHAINS.ARBITRUM,
+      destToken: NONCOT_ARBITRUM,
+      cotPerChain: COT_PER_CHAIN,
+    });
+    const buyQuote = findDstExactInBuyQuote(destinationCalls);
+    expect(buyQuote).toBeDefined();
+    // 500 USDC - $1 (srcBuffer cap) = 499 USDC
+    expect(buyQuote!.inputAmount).toBe(499_000_000n);
   });
 });
 

--- a/tests/swap/sourceExecution.test.ts
+++ b/tests/swap/sourceExecution.test.ts
@@ -1,71 +1,122 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { Chain, VSCClient } from '../../src/commons';
-import { SUPPORTED_CHAINS } from '../../src/commons';
-import { resolveSourceExecution } from '../../src/swap/route';
+import { type ChainListType, SUPPORTED_CHAINS, type VSCClient } from '../../src/commons';
+import { resolveChainExecutions } from '../../src/swap/route';
+import { SAFE_PROXY_FACTORY } from '../../src/swap/safe.constants';
+import { predictSafeAccountAddress } from '../../src/swap/safetx';
 
-const baseChain = {
-  blockExplorers: { default: { name: 'Explorer', url: 'https://example.com' } },
-  custom: { icon: '', knownTokens: [] },
-  id: SUPPORTED_CHAINS.ETHEREUM,
-  name: 'Ethereum',
-  ankrName: 'eth',
-  nativeCurrency: { decimals: 18, name: 'Ether', symbol: 'ETH' },
-  pectraUpgradeSupport: true,
-  rpcUrls: { default: { http: [], webSocket: [] } },
-  swapSupported: true,
-  universe: 1,
-} as Chain;
+const EPHEMERAL = '0x2222222222222222222222222222222222222222' as const;
 
-describe('resolveSourceExecution', () => {
-  it('uses the ephemeral execution account for Pectra chains without calling VSC', async () => {
+const makeChainList = (
+  chains: Array<{ id: number; pectraUpgradeSupport: boolean }>
+): ChainListType =>
+  ({
+    getChainByID: (id: number) => {
+      const found = chains.find((c) => c.id === id);
+      if (!found) return undefined;
+      return {
+        id: found.id,
+        pectraUpgradeSupport: found.pectraUpgradeSupport,
+        swapSupported: true,
+      } as never;
+    },
+  }) as unknown as ChainListType;
+
+describe('resolveChainExecutions', () => {
+  it('returns 7702 wrapper synchronously for pectra chains and does not call VSC', async () => {
     const vscClient = {
       vscGetSafeAccountAddress: vi.fn(),
     } as Partial<VSCClient> as VSCClient;
 
-    const result = await resolveSourceExecution({
-      chain: baseChain,
-      eoaAddress: '0x1111111111111111111111111111111111111111',
-      ephemeralAddress: '0x2222222222222222222222222222222222222222',
+    const { executions, verification } = resolveChainExecutions({
+      chainIds: [SUPPORTED_CHAINS.ETHEREUM],
+      ephemeralAddress: EPHEMERAL,
+      chainList: makeChainList([{ id: SUPPORTED_CHAINS.ETHEREUM, pectraUpgradeSupport: true }]),
       vscClient,
     });
 
-    expect(vscClient.vscGetSafeAccountAddress).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      address: '0x2222222222222222222222222222222222222222',
+    expect(executions[SUPPORTED_CHAINS.ETHEREUM]).toEqual({
+      address: EPHEMERAL,
       entryPoint: null,
       mode: '7702',
     });
+    expect(vscClient.vscGetSafeAccountAddress).not.toHaveBeenCalled();
+    await expect(verification).resolves.toBeUndefined();
   });
 
-  it('uses the deterministic Safe account for non-Pectra swap chains', async () => {
+  it('uses the locally-predicted Safe address for non-pectra chains and verifies via VSC', async () => {
+    const expected = predictSafeAccountAddress(EPHEMERAL);
     const vscClient = {
       vscGetSafeAccountAddress: vi.fn().mockResolvedValue({
-        address: '0x3333333333333333333333333333333333333333',
-        factoryAddress: '0x4444444444444444444444444444444444444444',
+        address: expected,
+        factoryAddress: SAFE_PROXY_FACTORY,
+        exists: false,
       }),
     } as Partial<VSCClient> as VSCClient;
 
-    const result = await resolveSourceExecution({
-      chain: {
-        ...baseChain,
-        id: SUPPORTED_CHAINS.HYPEREVM,
-        name: 'HyperEVM',
-        pectraUpgradeSupport: false,
-      },
-      eoaAddress: '0x1111111111111111111111111111111111111111',
-      ephemeralAddress: '0x2222222222222222222222222222222222222222',
+    const { executions, verification } = resolveChainExecutions({
+      chainIds: [SUPPORTED_CHAINS.HYPEREVM],
+      ephemeralAddress: EPHEMERAL,
+      chainList: makeChainList([{ id: SUPPORTED_CHAINS.HYPEREVM, pectraUpgradeSupport: false }]),
       vscClient,
     });
 
-    expect(vscClient.vscGetSafeAccountAddress).toHaveBeenCalledWith(
-      SUPPORTED_CHAINS.HYPEREVM,
-      '0x2222222222222222222222222222222222222222'
-    );
-    expect(result).toEqual({
-      address: '0x3333333333333333333333333333333333333333',
+    // Returned synchronously without awaiting VSC.
+    expect(executions[SUPPORTED_CHAINS.HYPEREVM]).toEqual({
+      address: expected,
       entryPoint: null,
-      factoryAddress: '0x4444444444444444444444444444444444444444',
+      factoryAddress: SAFE_PROXY_FACTORY,
       mode: 'safe_account',
     });
+    expect(vscClient.vscGetSafeAccountAddress).toHaveBeenCalledWith(
+      SUPPORTED_CHAINS.HYPEREVM,
+      EPHEMERAL
+    );
+    await expect(verification).resolves.toBeUndefined();
+  });
+
+  it('throws on the verification promise if the server reports a different Safe address', async () => {
+    const vscClient = {
+      vscGetSafeAccountAddress: vi.fn().mockResolvedValue({
+        address: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+        factoryAddress: SAFE_PROXY_FACTORY,
+        exists: true,
+      }),
+    } as Partial<VSCClient> as VSCClient;
+
+    const { verification } = resolveChainExecutions({
+      chainIds: [SUPPORTED_CHAINS.HYPEREVM],
+      ephemeralAddress: EPHEMERAL,
+      chainList: makeChainList([{ id: SUPPORTED_CHAINS.HYPEREVM, pectraUpgradeSupport: false }]),
+      vscClient,
+    });
+
+    await expect(verification).rejects.toThrow(/Safe address mismatch/);
+  });
+
+  it('deduplicates repeated chain ids and only calls VSC once per non-pectra chain', () => {
+    const vscClient = {
+      vscGetSafeAccountAddress: vi.fn().mockResolvedValue({
+        address: predictSafeAccountAddress(EPHEMERAL),
+        factoryAddress: SAFE_PROXY_FACTORY,
+        exists: true,
+      }),
+    } as Partial<VSCClient> as VSCClient;
+
+    resolveChainExecutions({
+      chainIds: [
+        SUPPORTED_CHAINS.HYPEREVM,
+        SUPPORTED_CHAINS.HYPEREVM,
+        SUPPORTED_CHAINS.ETHEREUM,
+        SUPPORTED_CHAINS.HYPEREVM,
+      ],
+      ephemeralAddress: EPHEMERAL,
+      chainList: makeChainList([
+        { id: SUPPORTED_CHAINS.HYPEREVM, pectraUpgradeSupport: false },
+        { id: SUPPORTED_CHAINS.ETHEREUM, pectraUpgradeSupport: true },
+      ]),
+      vscClient,
+    });
+
+    expect(vscClient.vscGetSafeAccountAddress).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
- fix: fix and verify buffer usage
- fix: handling empty balance fields from swap balances API
- fix: refresh using same initial data for faster quote refresh
- fix: reduce quoting calls by using usd value as a initial check for source selection
- fix: better logging of failed calls for easier debugging
- fix: exact in buffer usage check and update
- fix: update balances & buffer calculation to provide more accurate quote
- fix: use actual quote numbers for intent to have more accurate values for impact calculation
- fix: decimal precision increase to prevent rounding issue with higher decimals
- fix: safe native reserve increase for eoa sent txs
- fix: combined handler updated invariant