### PR TITLE
swap: add mystic and relay aggregator, combine slippage bps used across

### DIFF
--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -54,7 +54,14 @@ export type UserActionService = 'wallet' | 'hook';
 export type SimulationService = 'rpc';
 export type ExecutionService = 'wallet' | 'rpc';
 export type BackendService = 'middleware';
-export type ExternalServiceService = 'lifi' | 'bebop' | 'fibrous' | 'zerox' | 'coinbase';
+export type ExternalServiceService =
+  | 'lifi'
+  | 'bebop'
+  | 'fibrous'
+  | 'zerox'
+  | 'mystic'
+  | 'relay'
+  | 'coinbase';
 export type InternalService = never;
 
 /**

--- a/src/swap/aggregators/constants.ts
+++ b/src/swap/aggregators/constants.ts
@@ -1,0 +1,7 @@
+// Common target slippage for every aggregator quote. Defined once in basis points and converted to
+// each aggregator's native unit at the call site, so all adapters floor the output at the same
+// tolerance and their quotes stay comparable in aggregateAggregators.
+export const SLIPPAGE_BPS = 25; // 0.25%
+export const SLIPPAGE_BPS_STRING = String(SLIPPAGE_BPS); // '25' — 0x `slippageBps`, Relay `slippageTolerance`
+export const SLIPPAGE_FRACTION = (SLIPPAGE_BPS / 10_000).toString(); // '0.0025' — LiFi `slippage`
+export const SLIPPAGE_PERCENT = (SLIPPAGE_BPS / 100).toString(); // '0.25' — Fibrous `slippage`

--- a/src/swap/aggregators/fibrous.ts
+++ b/src/swap/aggregators/fibrous.ts
@@ -1,5 +1,6 @@
 import Decimal from 'decimal.js';
 import { encodeFunctionData, getAddress, type Hex, toHex, zeroAddress } from 'viem';
+import { SLIPPAGE_PERCENT } from './constants';
 import type { Aggregator, Quote, QuoteRequest } from './types';
 import { QuoteType } from './types';
 
@@ -10,7 +11,6 @@ const CHAIN_NAME_MAP: Record<number, string> = {
 };
 
 const DEFAULT_EXCLUDE_PROTOCOLS = '3';
-const DEFAULT_SLIPPAGE = '0.5';
 
 export type FibrousAggregatorOptions = {
   excludeProtocols?: string;
@@ -43,7 +43,7 @@ export class FibrousAggregator implements Aggregator {
         amount: req.inputAmount.toString(),
         tokenInAddress: req.inputToken,
         tokenOutAddress: req.outputToken,
-        slippage: DEFAULT_SLIPPAGE,
+        slippage: SLIPPAGE_PERCENT,
         destination: req.recipientAddress,
         excludeProtocols: this.excludeProtocols,
       };

--- a/src/swap/aggregators/index.ts
+++ b/src/swap/aggregators/index.ts
@@ -8,6 +8,8 @@ import { EADDRESS } from '../constants';
 import { BebopAggregator } from './bebop';
 import { FibrousAggregator } from './fibrous';
 import { LiFiAggregator } from './lifi';
+import { MysticAggregator } from './mystic';
+import { RelayAggregator } from './relay';
 import type { Aggregator, Quote, QuoteRequest } from './types';
 import { ZeroExAggregator } from './zerox';
 
@@ -21,6 +23,8 @@ export const aggregatorService = (aggregator: Aggregator): ExternalServiceServic
   if (aggregator instanceof BebopAggregator) return 'bebop';
   if (aggregator instanceof FibrousAggregator) return 'fibrous';
   if (aggregator instanceof ZeroExAggregator) return 'zerox';
+  if (aggregator instanceof MysticAggregator) return 'mystic';
+  if (aggregator instanceof RelayAggregator) return 'relay';
   if (aggregator instanceof LiFiAggregator) return 'lifi';
   return 'lifi';
 };
@@ -34,6 +38,8 @@ export const createAggregators = (mw: MiddlewareAggregatorQuoteClient): Aggregat
   new BebopAggregator(mw.getBebopQuote),
   new FibrousAggregator(mw.getFibrousQuote),
   new ZeroExAggregator(mw.getZeroExQuote),
+  new MysticAggregator(mw.postMystic),
+  new RelayAggregator(mw.getRelayQuote),
 ];
 
 // ---------------------------------------------------------------------------
@@ -163,7 +169,8 @@ const backfillFromSiblings = (
   reqIdx: number,
   selfIdx: number
 ): Quote | null => {
-  const needsDecimals = aggregator instanceof ZeroExAggregator;
+  const needsDecimals =
+    aggregator instanceof ZeroExAggregator || aggregator instanceof MysticAggregator;
   for (const side of ['input', 'output'] as const) {
     const leg = quote[side];
     if (needsDecimals) {
@@ -203,6 +210,8 @@ const siblingField = (
 export { BebopAggregator } from './bebop';
 export { FibrousAggregator } from './fibrous';
 export { LiFiAggregator } from './lifi';
+export { MysticAggregator } from './mystic';
+export { RelayAggregator } from './relay';
 // Re-exports
 export type { Aggregator, Holding, Quote, QuoteRequest, QuoteResponse } from './types';
 export { QuoteSeriousness, QuoteType } from './types';

--- a/src/swap/aggregators/lifi.ts
+++ b/src/swap/aggregators/lifi.ts
@@ -1,6 +1,7 @@
 import Decimal from 'decimal.js';
 import type { Hex } from 'viem';
 import { divDecimals } from '../../services/math';
+import { SLIPPAGE_FRACTION } from './constants';
 import type { Aggregator, Quote, QuoteRequest } from './types';
 import { QuoteType } from './types';
 
@@ -60,7 +61,7 @@ export class LiFiAggregator implements Aggregator {
         fromAddress: req.userAddress,
         toAddress,
         denyExchanges: denyExchangesFor(req.chainId),
-        slippage: '0.01',
+        slippage: SLIPPAGE_FRACTION,
         skipSimulation: true,
       };
 

--- a/src/swap/aggregators/mystic.ts
+++ b/src/swap/aggregators/mystic.ts
@@ -1,0 +1,127 @@
+import { type Hex, toHex, zeroAddress } from 'viem';
+import { SLIPPAGE_BPS } from './constants';
+import type { Aggregator, Quote, QuoteRequest } from './types';
+import { QuoteSeriousness, QuoteType } from './types';
+
+// Chains Mystic Router serves in this SDK. Citrea-only for now (co-located with Fibrous); add
+// Mystic's other chains (Flare 14, Plume 98866, …) here once validated.
+const ALLOWED_CHAINS = new Set<number>([
+  4114, // Citrea
+]);
+
+/**
+ * Mystic Router is a two-step API: POST /v1/swap/quote returns ranked routes (amounts only, no token
+ * metadata), then POST /v1/swap/build turns the chosen route into an unsigned tx. Like 0x it reports
+ * no decimals/symbol/USD price, so those are left as placeholders for aggregateAggregators to
+ * backfill from a sibling quote. EXACT_IN only — the quote endpoint takes `sellAmount`, not a buy
+ * target.
+ */
+export class MysticAggregator implements Aggregator {
+  // One POST proxy to the Mystic router; the adapter supplies the versioned path per endpoint.
+  private readonly post: (path: string, body: Record<string, unknown>) => Promise<unknown>;
+
+  constructor(post: (path: string, body: Record<string, unknown>) => Promise<unknown>) {
+    this.post = post;
+  }
+
+  async getQuotes(requests: QuoteRequest[]): Promise<(Quote | null)[]> {
+    return Promise.all(requests.map((req) => this.fetchQuote(req)));
+  }
+
+  private async fetchQuote(req: QuoteRequest): Promise<Quote | null> {
+    if (req.type !== QuoteType.EXACT_IN) return null; // quote endpoint is sellAmount-only
+    if (!ALLOWED_CHAINS.has(req.chainId)) return null;
+
+    try {
+      const quoteBody: Record<string, unknown> = {
+        chainId: req.chainId, // number, per Mystic's JSON schema
+        sellToken: req.inputToken,
+        buyToken: req.outputToken,
+        sellAmount: req.inputAmount.toString(), // integer string, smallest unit
+        taker: req.userAddress,
+        recipient: req.recipientAddress,
+        slippageBps: SLIPPAGE_BPS,
+      };
+
+      const quoteData = (await this.post('v1/swap/quote', quoteBody)) as MysticQuoteResponse;
+      const best = quoteData.quotes?.[0]; // ranked by output, best first
+      if (!best) return null;
+
+      const inputAmountRaw = BigInt(best.sellAmount);
+      const outputAmountRaw = BigInt(best.minBuyAmount); // slippage-protected floor, like 0x
+
+      // Price surveys only compare amounts and are always re-quoted SERIOUS before execution
+      // (swap/execution/source-swaps.ts), so skip the build call: it simulates on-chain, which is
+      // wasteful per survey candidate and would drop otherwise-valid price data when the taker
+      // can't execute yet.
+      if (req.seriousness !== QuoteSeriousness.SERIOUS) {
+        return {
+          input: placeholderSide(req.inputToken, inputAmountRaw),
+          output: placeholderSide(req.outputToken, outputAmountRaw),
+          txData: SURVEY_TX_PLACEHOLDER,
+        };
+      }
+
+      const buildBody: Record<string, unknown> = {
+        quoteSetId: quoteData.quoteSetId,
+        quoteId: best.quoteId,
+        userAddress: req.userAddress,
+        recipient: req.recipientAddress,
+      };
+      const build = (await this.post('v1/swap/build', buildBody)) as MysticBuildResponse;
+      if (!build.txRequest) return null;
+
+      return {
+        input: placeholderSide(req.inputToken, inputAmountRaw),
+        output: placeholderSide(req.outputToken, outputAmountRaw),
+        txData: {
+          approvalAddress: build.approval?.spender ?? zeroAddress, // null for native sells
+          tx: {
+            to: build.txRequest.to,
+            data: build.txRequest.data,
+            value: toHex(BigInt(build.txRequest.value)), // Mystic returns decimal wei; Quote wants hex
+          },
+        },
+      };
+    } catch {
+      return null;
+    }
+  }
+}
+
+// amount/decimals/symbol/value are placeholders — Mystic reports amounts + tx only (no token
+// metadata), so aggregateAggregators backfills them from a sibling quote. Mirrors the 0x adapter.
+const placeholderSide = (contractAddress: Hex, amountRaw: bigint): Quote['input'] => ({
+  contractAddress,
+  amountRaw,
+  amount: '0',
+  decimals: 0,
+  value: 0,
+  symbol: '',
+});
+
+// Survey quotes are indicative (amounts only) and never executed, so txData is a placeholder built
+// without the (simulating) build call.
+const SURVEY_TX_PLACEHOLDER: Quote['txData'] = {
+  approvalAddress: zeroAddress,
+  tx: { to: zeroAddress, data: '0x', value: '0x0' },
+};
+
+// ---------------------------------------------------------------------------
+// Mystic response types (internal) — only the fields the adapter reads
+// ---------------------------------------------------------------------------
+
+type MysticQuoteResponse = {
+  quoteSetId: string;
+  quotes?: Array<{
+    quoteId: string;
+    sellAmount: string;
+    buyAmount: string;
+    minBuyAmount: string;
+  }>;
+};
+
+type MysticBuildResponse = {
+  txRequest?: { to: Hex; data: Hex; value: string };
+  approval: { token: Hex; spender: Hex; amount: string } | null;
+};

--- a/src/swap/aggregators/relay.ts
+++ b/src/swap/aggregators/relay.ts
@@ -1,0 +1,148 @@
+import Decimal from 'decimal.js';
+import { decodeFunctionData, type Hex, parseAbi, toHex, zeroAddress } from 'viem';
+import { ZERO_ADDRESS } from '../../domain/constants/addresses';
+import { isNativeAddress } from '../../services/addresses';
+import { divDecimals } from '../../services/math';
+import { SLIPPAGE_BPS_STRING } from './constants';
+import type { Aggregator, Quote, QuoteRequest } from './types';
+import { QuoteType } from './types';
+
+const ERC20_APPROVE_ABI = parseAbi(['function approve(address spender, uint256 value)']);
+
+// Relay `/quote/v2` used as a SAME-CHAIN swap: originChainId == destinationChainId. Native is the
+// ZERO address on Relay (its default currency), whereas the SDK hands adapters EADDRESS — so map
+// native → zero on the request and keep the SDK-canonical token on the returned quote.
+const relayCurrency = (token: Hex): Hex => (isNativeAddress(token) ? ZERO_ADDRESS : token);
+
+export class RelayAggregator implements Aggregator {
+  private readonly getQuote: (params: Record<string, string>) => Promise<unknown>;
+
+  constructor(getQuote: (params: Record<string, string>) => Promise<unknown>) {
+    this.getQuote = getQuote;
+  }
+
+  async getQuotes(requests: QuoteRequest[]): Promise<(Quote | null)[]> {
+    return Promise.all(requests.map((req) => this.fetchQuote(req)));
+  }
+
+  private async fetchQuote(req: QuoteRequest): Promise<Quote | null> {
+    try {
+      const isExactOut = req.type === QuoteType.EXACT_OUT;
+      const chainId = req.chainId.toString();
+      const amountRaw =
+        isExactOut && 'outputAmount' in req
+          ? req.outputAmount
+          : 'inputAmount' in req
+            ? req.inputAmount
+            : 0n;
+
+      const params: Record<string, string> = {
+        user: req.userAddress,
+        recipient: req.recipientAddress,
+        originChainId: chainId,
+        destinationChainId: chainId, // same-chain swap
+        originCurrency: relayCurrency(req.inputToken),
+        destinationCurrency: relayCurrency(req.outputToken),
+        amount: amountRaw.toString(),
+        tradeType: isExactOut ? 'EXACT_OUTPUT' : 'EXACT_INPUT',
+        slippageTolerance: SLIPPAGE_BPS_STRING,
+      };
+
+      const data = (await this.getQuote(params)) as RelayResponse;
+      return parseResponse(data, req, isExactOut);
+    } catch {
+      return null;
+    }
+  }
+}
+
+const parseResponse = (
+  data: RelayResponse,
+  req: QuoteRequest,
+  isExactOut: boolean
+): Quote | null => {
+  // Same-chain swaps return an `approve` step (ERC-20) then a `swap` step. The SDK runs its own
+  // approval, so we only read the `swap` transaction and the approve step's spender — the signature
+  // (Permit2 / EIP-3009 authorize*) steps are irrelevant here.
+  const tx = data.steps?.find((s) => s.id === 'swap' && s.kind === 'transaction')?.items?.[0]?.data;
+  if (!tx?.to) return null;
+
+  const currencyIn = data.details?.currencyIn;
+  const currencyOut = data.details?.currencyOut;
+  if (!currencyIn || !currencyOut) return null;
+
+  // EXACT_IN floors the output at the slippage-protected `minimumAmount`; EXACT_OUT delivers the
+  // exact requested output. The input is Relay's quoted `amount` either way.
+  const inputAmountRaw = BigInt(currencyIn.amount);
+  const outputAmountRaw = BigInt(isExactOut ? currencyOut.amount : currencyOut.minimumAmount);
+
+  return {
+    input: buildSide(currencyIn, req.inputToken, inputAmountRaw),
+    output: buildSide(currencyOut, req.outputToken, outputAmountRaw),
+    txData: {
+      approvalAddress: resolveApprovalAddress(data, req.inputToken, tx.to as Hex),
+      tx: {
+        to: tx.to as Hex,
+        data: tx.data as Hex,
+        value: tx.value ? toHex(BigInt(tx.value)) : '0x0',
+      },
+    },
+  };
+};
+
+// Native needs no approval. Otherwise use the spender Relay's `approve` step encodes (the step's `to`
+// is the token; the spender lives in its `approve(spender,value)` calldata), falling back to the swap
+// contract when there is no approve step or the calldata can't be decoded.
+const resolveApprovalAddress = (data: RelayResponse, inputToken: Hex, swapTo: Hex): Hex => {
+  if (isNativeAddress(inputToken)) return zeroAddress;
+  const approveData = data.steps?.find((s) => s.id === 'approve')?.items?.[0]?.data?.data;
+  if (approveData) {
+    try {
+      const { args } = decodeFunctionData({ abi: ERC20_APPROVE_ABI, data: approveData as Hex });
+      return args[0] as Hex;
+    } catch {
+      // fall through to the swap contract
+    }
+  }
+  return swapTo;
+};
+
+// Relay reports amountUsd for the whole leg; derive a per-token priceUsd so `value` tracks the
+// slippage-protected amount (parity with the LiFi adapter's value = amount × priceUsd).
+const buildSide = (
+  detail: RelayCurrencyDetail,
+  tokenAddress: Hex,
+  amountRaw: bigint
+): Quote['input'] => {
+  const { currency } = detail;
+  const amount = divDecimals(amountRaw, currency.decimals).toFixed();
+  const formatted = Number(detail.amountFormatted);
+  const priceUsd = formatted > 0 ? Number(detail.amountUsd) / formatted : 0;
+  return {
+    contractAddress: tokenAddress, // SDK-canonical token (EADDRESS for native), not Relay's zero
+    amount,
+    amountRaw,
+    decimals: currency.decimals,
+    value: new Decimal(amount).mul(priceUsd).toNumber(),
+    priceUsd,
+    symbol: currency.symbol,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Relay response types (internal — only the fields the adapter reads)
+// ---------------------------------------------------------------------------
+
+type RelayTxData = { to?: string; data?: string; value?: string };
+type RelayStep = { id: string; kind: string; items?: { data?: RelayTxData }[] };
+type RelayCurrencyDetail = {
+  currency: { address: string; symbol: string; decimals: number };
+  amount: string;
+  amountFormatted: string;
+  amountUsd: string;
+  minimumAmount: string;
+};
+type RelayResponse = {
+  steps?: RelayStep[];
+  details?: { currencyIn?: RelayCurrencyDetail; currencyOut?: RelayCurrencyDetail };
+};

--- a/src/swap/aggregators/zerox.ts
+++ b/src/swap/aggregators/zerox.ts
@@ -1,4 +1,5 @@
 import { type Hex, zeroAddress } from 'viem';
+import { SLIPPAGE_BPS_STRING } from './constants';
 import type { Aggregator, Quote, QuoteRequest } from './types';
 import { QuoteType } from './types';
 
@@ -41,7 +42,7 @@ export class ZeroExAggregator implements Aggregator {
         buyToken: req.outputToken,
         taker: req.userAddress,
         recipient: req.recipientAddress,
-        slippageBps: '100', // 1%, matches the LiFi adapter's slippage
+        slippageBps: SLIPPAGE_BPS_STRING,
       };
       if (isExactOut && 'outputAmount' in req) {
         params.buyAmount = req.outputAmount.toString();

--- a/src/transport/middleware.ts
+++ b/src/transport/middleware.ts
@@ -74,6 +74,11 @@ export type MiddlewareClient = {
   getBebopQuote: (params: Record<string, string>) => Promise<unknown>;
   getFibrousQuote: (params: Record<string, string>) => Promise<unknown>;
   getZeroExQuote: (params: Record<string, string>) => Promise<unknown>;
+  // Mystic is a multi-endpoint POST/JSON API (quote → build); one proxy, the aggregator supplies the
+  // versioned path. Bodies carry mixed types (numeric chainId/slippageBps + string amounts) rather
+  // than the string-only GET query maps above.
+  postMystic: (path: string, body: Record<string, unknown>) => Promise<unknown>;
+  getRelayQuote: (params: Record<string, string>) => Promise<unknown>;
   getSwapBalances: (address: Hex) => Promise<FlatBalance[]>;
   getQuote: (request: QuoteRequest) => Promise<QuoteResponse>;
   getMayanQuotes: (request: MayanQuoteRequest) => Promise<MayanQuoteResponse>;
@@ -96,7 +101,12 @@ export type MiddlewareMayanQuoteClient = Pick<MiddlewareClient, 'getMayanQuotes'
 export type MiddlewareBridgeProviderClient = Pick<MiddlewareClient, 'getBridgeProvider'>;
 export type MiddlewareAggregatorQuoteClient = Pick<
   MiddlewareClient,
-  'getLiFiQuote' | 'getBebopQuote' | 'getFibrousQuote' | 'getZeroExQuote'
+  | 'getLiFiQuote'
+  | 'getBebopQuote'
+  | 'getFibrousQuote'
+  | 'getZeroExQuote'
+  | 'postMystic'
+  | 'getRelayQuote'
 >;
 export type MiddlewareRffClient = Pick<MiddlewareClient, 'getRFF'>;
 export type MiddlewareRffStatusClient = Pick<MiddlewareClient, 'getRFFStatus'>;
@@ -946,6 +956,25 @@ export const createMiddlewareClient = (
     return response.data;
   };
 
+  // Mystic's `/mystic/*` proxy forwards method + body to router.mysticfinance.xyz, so endpoints are
+  // POSTs with a JSON body (not GET query params like the aggregators above). One proxy for all
+  // Mystic endpoints — the aggregator passes the versioned path (e.g. 'v1/swap/quote').
+  const postMystic = async (path: string, body: Record<string, unknown>): Promise<unknown> => {
+    const response = await client.post(`/api/v1/proxy/mystic/${path}`, body);
+    return response.data;
+  };
+
+  // Relay is a POST /quote/v2 with a JSON body (chain ids as numbers), unlike the GET aggregators.
+  const getRelayQuote = async (params: Record<string, string>): Promise<unknown> => {
+    const { originChainId, destinationChainId, ...rest } = params;
+    const response = await client.post('/api/v1/proxy/relay/quote/v2', {
+      ...rest,
+      originChainId: Number(originChainId),
+      destinationChainId: Number(destinationChainId),
+    });
+    return response.data;
+  };
+
   const getSwapBalances = async (address: Hex): Promise<FlatBalance[]> => {
     try {
       const response = await client.get<BalancesByChain>(`/api/v1/swap-balance/EVM/${address}`);
@@ -1085,6 +1114,8 @@ export const createMiddlewareClient = (
     getBebopQuote,
     getFibrousQuote,
     getZeroExQuote,
+    postMystic,
+    getRelayQuote,
     getSwapBalances,
     getQuote,
     getMayanQuotes,

--- a/tests/swap/aggregators/aggregate.test.ts
+++ b/tests/swap/aggregators/aggregate.test.ts
@@ -286,15 +286,37 @@ describe('aggregateAggregators — native token normalization', () => {
 });
 
 describe('createAggregators', () => {
-  it('returns LiFi, Bebop, Fibrous, and 0x aggregators when given a MiddlewareClient', () => {
+  it('returns LiFi, Bebop, Fibrous, 0x, Mystic, and Relay aggregators when given a MiddlewareClient', () => {
     const mockMiddlewareClient = {
       getLiFiQuote: vi.fn(),
       getBebopQuote: vi.fn(),
       getFibrousQuote: vi.fn(),
       getZeroExQuote: vi.fn(),
+      postMystic: vi.fn(),
+      getRelayQuote: vi.fn(),
     } as any;
     const aggs = createAggregators(mockMiddlewareClient);
-    expect(aggs).toHaveLength(4);
+    expect(aggs).toHaveLength(6);
+  });
+
+  it('wires Relay aggregator to mw.getRelayQuote', async () => {
+    const getRelayQuote = vi.fn().mockResolvedValue({});
+    const mw = {
+      getLiFiQuote: vi.fn(),
+      getBebopQuote: vi.fn(),
+      getFibrousQuote: vi.fn(),
+      getZeroExQuote: vi.fn(),
+      postMystic: vi.fn(),
+      getRelayQuote,
+    } as any;
+
+    const aggs = createAggregators(mw);
+    const relay = aggs[5];
+    await relay.getQuotes([makeRequest()]);
+
+    expect(getRelayQuote).toHaveBeenCalledTimes(1);
+    expect(mw.getLiFiQuote).not.toHaveBeenCalled();
+    expect(mw.getZeroExQuote).not.toHaveBeenCalled();
   });
 
   it('wires 0x aggregator to mw.getZeroExQuote', async () => {

--- a/tests/swap/aggregators/fibrous.test.ts
+++ b/tests/swap/aggregators/fibrous.test.ts
@@ -130,7 +130,7 @@ describe('FibrousAggregator', () => {
     expect(params.amount).toBe('1000000');
     expect(params.tokenInAddress).toBe(INPUT_TOKEN);
     expect(params.tokenOutAddress).toBe(OUTPUT_TOKEN);
-    expect(params.slippage).toBe('0.5');
+    expect(params.slippage).toBe('0.25');
   });
 
   it('returns null for EXACT_OUT without calling getQuote (Fibrous is EXACT_IN only)', async () => {

--- a/tests/swap/aggregators/lifi.test.ts
+++ b/tests/swap/aggregators/lifi.test.ts
@@ -164,12 +164,13 @@ describe('LiFiAggregator', () => {
     expect(getQuoteFn.mock.calls[0]).toHaveLength(2);
   });
 
-  it('includes denyExchanges and skipSimulation in params', async () => {
+  it('includes denyExchanges, skipSimulation, and slippage in params', async () => {
     await agg.getQuotes([makeRequest()]);
 
     const [params] = getQuoteFn.mock.calls[0];
     expect(params.denyExchanges).toBe('openocean');
     expect(params.skipSimulation).toBe(true);
+    expect(params.slippage).toBe('0.0025'); // 25 bps as a fraction
   });
 
   it('denies HyperEVM-specific exchanges in addition to openocean on chain 999', async () => {

--- a/tests/swap/aggregators/mystic.test.ts
+++ b/tests/swap/aggregators/mystic.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MysticAggregator } from '../../../src/swap/aggregators/mystic';
+import { QuoteSeriousness, QuoteType, type QuoteRequest } from '../../../src/swap/aggregators/types';
+
+type ExactInQuoteRequest = Extract<QuoteRequest, { type: QuoteType.EXACT_IN }>;
+
+const INPUT = '0x0000000000000000000000000000000000000a11' as `0x${string}`;
+const OUTPUT = '0x0000000000000000000000000000000000000b22' as `0x${string}`;
+const SPENDER = '0x00000000000000000000000000000000005e11de' as `0x${string}`;
+const ROUTER = '0x00000000000000000000000000000000009007e2' as `0x${string}`;
+
+const makeRequest = (overrides: Partial<ExactInQuoteRequest> = {}): ExactInQuoteRequest => ({
+  userAddress: '0x1111111111111111111111111111111111111111',
+  recipientAddress: '0x2222222222222222222222222222222222222222',
+  chainId: 4114, // Citrea
+  inputToken: INPUT,
+  outputToken: OUTPUT,
+  seriousness: QuoteSeriousness.SERIOUS,
+  type: QuoteType.EXACT_IN,
+  inputAmount: 1000000n,
+  ...overrides,
+});
+
+const quoteResponse = () => ({
+  quoteSetId: 'qs_1',
+  quotes: [
+    { quoteId: 'uniswap-v3::qs_1', sellAmount: '1000000', buyAmount: '990000', minBuyAmount: '985000' },
+  ],
+});
+
+const buildResponse = () => ({
+  txRequest: { to: ROUTER, data: '0xabcdef', value: '0' }, // Mystic returns decimal wei
+  approval: { token: INPUT, spender: SPENDER, amount: '1000000' },
+});
+
+describe('MysticAggregator', () => {
+  let agg: MysticAggregator;
+  // One proxy for every Mystic endpoint; dispatch the mock response by path.
+  let postFn: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    postFn = vi.fn(async (path: string) =>
+      path === 'v1/swap/build' ? buildResponse() : quoteResponse()
+    );
+    agg = new MysticAggregator(
+      postFn as unknown as (path: string, body: Record<string, unknown>) => Promise<unknown>
+    );
+  });
+
+  it('maps an EXACT_IN SERIOUS quote: sellAmount in, minBuyAmount out, tx from build', async () => {
+    const [quote] = await agg.getQuotes([makeRequest()]);
+
+    expect(quote).not.toBeNull();
+    expect(quote!.input.amountRaw).toBe(1000000n); // sellAmount
+    expect(quote!.output.amountRaw).toBe(985000n); // minBuyAmount, NOT buyAmount
+    expect(quote!.txData.approvalAddress).toBe(SPENDER);
+    expect(quote!.txData.tx.to).toBe(ROUTER);
+    expect(quote!.txData.tx.data).toBe('0xabcdef');
+    expect(quote!.txData.tx.value).toBe('0x0'); // decimal "0" -> hex
+  });
+
+  it('reports no token metadata (decimals 0, priceUsd undefined) — enrichment fills from a sibling', async () => {
+    const [quote] = await agg.getQuotes([makeRequest()]);
+
+    expect(quote!.input.decimals).toBe(0);
+    expect(quote!.output.priceUsd).toBeUndefined();
+    expect(quote!.input.value).toBe(0);
+  });
+
+  it('sends the quote then the build with quoteSetId + quoteId', async () => {
+    await agg.getQuotes([makeRequest()]);
+
+    const [quotePath, quoteBody] = postFn.mock.calls[0];
+    expect(quotePath).toBe('v1/swap/quote');
+    expect(quoteBody.chainId).toBe(4114); // number, per Mystic's JSON schema
+    expect(quoteBody.sellToken).toBe(INPUT);
+    expect(quoteBody.buyToken).toBe(OUTPUT);
+    expect(quoteBody.sellAmount).toBe('1000000');
+    expect(quoteBody.taker).toBe('0x1111111111111111111111111111111111111111');
+
+    const [buildPath, buildBody] = postFn.mock.calls[1];
+    expect(buildPath).toBe('v1/swap/build');
+    expect(buildBody.quoteSetId).toBe('qs_1');
+    expect(buildBody.quoteId).toBe('uniswap-v3::qs_1');
+  });
+
+  it('skips the (simulating) build call on a price survey', async () => {
+    const [quote] = await agg.getQuotes([makeRequest({ seriousness: QuoteSeriousness.PRICE_SURVEY })]);
+
+    expect(quote!.output.amountRaw).toBe(985000n);
+    expect(postFn).toHaveBeenCalledTimes(1); // quote only — build (which simulates) is skipped
+    expect(postFn).not.toHaveBeenCalledWith('v1/swap/build', expect.anything());
+  });
+
+  it('uses zeroAddress approval for native sells (build.approval null)', async () => {
+    postFn.mockImplementation(async (path: string) =>
+      path === 'v1/swap/build' ? { ...buildResponse(), approval: null } : quoteResponse()
+    );
+
+    const [quote] = await agg.getQuotes([makeRequest()]);
+
+    expect(quote!.txData.approvalAddress).toBe('0x0000000000000000000000000000000000000000');
+  });
+
+  it('returns null for EXACT_OUT (quote endpoint is sellAmount-only)', async () => {
+    const exactOut: QuoteRequest = {
+      userAddress: '0x1111111111111111111111111111111111111111',
+      recipientAddress: '0x2222222222222222222222222222222222222222',
+      chainId: 4114,
+      inputToken: INPUT,
+      outputToken: OUTPUT,
+      seriousness: QuoteSeriousness.SERIOUS,
+      type: QuoteType.EXACT_OUT,
+      outputAmount: 500000n,
+    };
+
+    const [quote] = await agg.getQuotes([exactOut]);
+
+    expect(quote).toBeNull();
+    expect(postFn).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits unsupported chains without firing a request', async () => {
+    const [quote] = await agg.getQuotes([makeRequest({ chainId: 1 })]); // Ethereum, not enabled yet
+
+    expect(quote).toBeNull();
+    expect(postFn).not.toHaveBeenCalled();
+  });
+
+  it('returns null when there are no quotes', async () => {
+    postFn.mockResolvedValueOnce({ quoteSetId: 'qs_1', quotes: [] });
+
+    const [quote] = await agg.getQuotes([makeRequest()]);
+
+    expect(quote).toBeNull();
+    expect(postFn).toHaveBeenCalledTimes(1); // build not reached
+  });
+
+  it('returns null when getQuote throws', async () => {
+    postFn.mockRejectedValueOnce(new Error('404 INSUFFICIENT_LIQUIDITY'));
+
+    const [quote] = await agg.getQuotes([makeRequest()]);
+
+    expect(quote).toBeNull();
+  });
+});

--- a/tests/swap/aggregators/relay.test.ts
+++ b/tests/swap/aggregators/relay.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { encodeFunctionData, parseAbi, zeroAddress } from 'viem';
+import { RelayAggregator } from '../../../src/swap/aggregators/relay';
+import { QuoteSeriousness, QuoteType, type QuoteRequest } from '../../../src/swap/aggregators/types';
+import { EADDRESS, ZERO_ADDRESS } from '../../../src/domain/constants/addresses';
+
+type ExactInQuoteRequest = Extract<QuoteRequest, { type: QuoteType.EXACT_IN }>;
+
+const INPUT = '0xaaaa000000000000000000000000000000000001' as const;
+const OUTPUT = '0xbbbb000000000000000000000000000000000002' as const;
+const TAKER = '0x1111111111111111111111111111111111111111' as const;
+const RECIPIENT = '0x2222222222222222222222222222222222222222' as const;
+const ROUTER = '0xdddd000000000000000000000000000000000004' as const;
+// Distinct from ROUTER so the assertion proves the approvalAddress comes from the approve step's
+// calldata spender, not the swap tx `to`.
+const SPENDER = '0xcccc000000000000000000000000000000000003' as const;
+const APPROVE_CALLDATA = encodeFunctionData({
+  abi: parseAbi(['function approve(address spender, uint256 value)']),
+  functionName: 'approve',
+  args: [SPENDER, 1_000_000n],
+});
+
+const makeRequest = (overrides: Partial<ExactInQuoteRequest> = {}): QuoteRequest => ({
+  type: QuoteType.EXACT_IN,
+  seriousness: QuoteSeriousness.SERIOUS,
+  chainId: 42161,
+  inputToken: INPUT,
+  outputToken: OUTPUT,
+  userAddress: TAKER,
+  recipientAddress: RECIPIENT,
+  inputAmount: 1_000_000n,
+  ...overrides,
+});
+
+// Raw Relay /quote/v2 response — only the fields the adapter reads. Two steps (approve + swap) and
+// the details block with slippage-protected `minimumAmount` alongside the expected `amount`.
+const makeResponse = () => ({
+  steps: [
+    {
+      id: 'approve',
+      kind: 'transaction',
+      items: [{ status: 'incomplete', data: { to: INPUT, data: APPROVE_CALLDATA, value: '0', chainId: 42161 } }],
+    },
+    {
+      id: 'swap',
+      kind: 'transaction',
+      items: [{ status: 'incomplete', data: { to: ROUTER, data: '0xswapdata', value: '0', chainId: 42161 } }],
+    },
+  ],
+  details: {
+    currencyIn: {
+      currency: { chainId: 42161, address: INPUT, symbol: 'USDC', name: 'USD Coin', decimals: 6 },
+      amount: '1000000',
+      amountFormatted: '1',
+      amountUsd: '1',
+      minimumAmount: '1000000',
+    },
+    currencyOut: {
+      currency: { chainId: 42161, address: OUTPUT, symbol: 'WETH', name: 'Wrapped Ether', decimals: 18 },
+      amount: '400000000000000',
+      amountFormatted: '0.0004',
+      amountUsd: '1.2',
+      minimumAmount: '399000000000000',
+    },
+  },
+});
+
+const asProxy = (fn: unknown) => fn as (params: Record<string, string>) => Promise<unknown>;
+
+describe('RelayAggregator', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sends same-chain EXACT_INPUT params at 25 bps slippage', async () => {
+    const getQuote = vi.fn().mockResolvedValue(makeResponse());
+    await new RelayAggregator(asProxy(getQuote)).getQuotes([makeRequest()]);
+
+    const [params] = getQuote.mock.calls[0];
+    expect(params.user).toBe(TAKER);
+    expect(params.recipient).toBe(RECIPIENT);
+    expect(params.originChainId).toBe('42161');
+    expect(params.destinationChainId).toBe('42161'); // same-chain swap
+    expect(params.originCurrency).toBe(INPUT);
+    expect(params.destinationCurrency).toBe(OUTPUT);
+    expect(params.amount).toBe('1000000');
+    expect(params.tradeType).toBe('EXACT_INPUT');
+    expect(params.slippageTolerance).toBe('25');
+  });
+
+  it('maps EXACT_IN → slippage-protected output (currencyOut.minimumAmount), swap step tx', async () => {
+    const getQuote = vi.fn().mockResolvedValue(makeResponse());
+    const [quote] = await new RelayAggregator(asProxy(getQuote)).getQuotes([makeRequest()]);
+
+    expect(quote!.input.amountRaw).toBe(1000000n);
+    expect(quote!.input.decimals).toBe(6);
+    expect(quote!.input.symbol).toBe('USDC');
+    expect(quote!.output.amountRaw).toBe(399000000000000n); // minimumAmount, NOT the expected amount
+    expect(quote!.output.decimals).toBe(18);
+    expect(quote!.output.symbol).toBe('WETH');
+    // tx comes from the 'swap' step, never 'approve'.
+    expect(quote!.txData.tx.to).toBe(ROUTER);
+    expect(quote!.txData.tx.data).toBe('0xswapdata');
+    expect(quote!.txData.tx.value).toBe('0x0');
+    // approvalAddress is the spender the approve step encodes, not the swap tx `to`
+    // (decodeFunctionData returns it checksummed; addresses compare case-insensitively).
+    expect(quote!.txData.approvalAddress.toLowerCase()).toBe(SPENDER);
+  });
+
+  it('EXACT_OUT: delivers the exact requested output (currencyOut.amount), EXACT_OUTPUT trade type', async () => {
+    const getQuote = vi.fn().mockResolvedValue(makeResponse());
+    const req: QuoteRequest = {
+      type: QuoteType.EXACT_OUT,
+      seriousness: QuoteSeriousness.SERIOUS,
+      chainId: 42161,
+      inputToken: INPUT,
+      outputToken: OUTPUT,
+      userAddress: TAKER,
+      recipientAddress: RECIPIENT,
+      outputAmount: 400000000000000n,
+    };
+    const [quote] = await new RelayAggregator(asProxy(getQuote)).getQuotes([req]);
+
+    const [params] = getQuote.mock.calls[0];
+    expect(params.tradeType).toBe('EXACT_OUTPUT');
+    expect(params.amount).toBe('400000000000000');
+    expect(quote!.output.amountRaw).toBe(400000000000000n); // exact requested, NOT the minimum floor
+    expect(quote!.input.amountRaw).toBe(1000000n);
+  });
+
+  it('native input: originCurrency = ZERO_ADDRESS, approvalAddress = zero, quote keeps EADDRESS', async () => {
+    const res = makeResponse();
+    res.steps[1].items[0].data.value = '1000000000000000000'; // native rides the swap tx value
+    const getQuote = vi.fn().mockResolvedValue(res);
+    const [quote] = await new RelayAggregator(asProxy(getQuote)).getQuotes([
+      makeRequest({ inputToken: EADDRESS }),
+    ]);
+
+    const [params] = getQuote.mock.calls[0];
+    expect(params.originCurrency).toBe(ZERO_ADDRESS); // Relay's native sentinel is the zero address
+    expect(quote!.input.contractAddress).toBe(EADDRESS); // SDK-canonical native preserved on the quote
+    expect(quote!.txData.approvalAddress).toBe(zeroAddress); // native input needs no approval
+    expect(quote!.txData.tx.value).toBe('0xde0b6b3a7640000'); // 1e18, decimal string → hex
+  });
+
+  it('returns null when the proxy throws', async () => {
+    const getQuote = vi.fn().mockRejectedValue(new Error('boom'));
+    const [quote] = await new RelayAggregator(asProxy(getQuote)).getQuotes([makeRequest()]);
+    expect(quote).toBeNull();
+  });
+
+  it('returns null when no executable (non-approve) step is present', async () => {
+    const res = makeResponse();
+    res.steps = [res.steps[0]]; // only the approve step, nothing to execute
+    const getQuote = vi.fn().mockResolvedValue(res);
+    const [quote] = await new RelayAggregator(asProxy(getQuote)).getQuotes([makeRequest()]);
+    expect(quote).toBeNull();
+  });
+});

--- a/tests/swap/aggregators/zerox.test.ts
+++ b/tests/swap/aggregators/zerox.test.ts
@@ -91,7 +91,7 @@ describe('ZeroExAggregator', () => {
     expect(params.buyToken).toBe(OUTPUT);
     expect(params.taker).toBe('0x1111111111111111111111111111111111111111');
     expect(params.recipient).toBe('0x2222222222222222222222222222222222222222');
-    expect(params.slippageBps).toBe('100');
+    expect(params.slippageBps).toBe('25');
     expect(params.sellAmount).toBe('1000000');
     expect(params.buyAmount).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

Adds two new swap aggregator adapters — Mystic Router and Relay — and centralizes slippage tolerance into a single shared constant so every adapter floors output at the same tolerance and their quotes stay comparable in `aggregateAggregators`.

## Changes

- Add `MysticAggregator` (`src/swap/aggregators/mystic.ts`): two-step POST API (`/v1/swap/quote` → `/v1/swap/build`), EXACT_IN only, Citrea-only for now; reports no decimals/symbol/USD (like 0x) so those are backfilled from a sibling quote — hence it's added to the `needsDecimals` path.
- Add `RelayAggregator` (`src/swap/aggregators/relay.ts`): `POST /quote/v2` used as a same-chain swap (`originChainId == destinationChainId`), maps SDK-canonical native (EADDRESS) → Relay's zero-address currency on the request and keeps the canonical token on the returned quote.
- Add `src/swap/aggregators/constants.ts`: define `SLIPPAGE_BPS = 25` (0.25%) once and export the per-aggregator unit conversions — `SLIPPAGE_BPS_STRING` ('25', for 0x/Relay), `SLIPPAGE_FRACTION` ('0.0025', for LiFi), `SLIPPAGE_PERCENT` ('0.25', for Fibrous).
- Point existing adapters at the shared constant: Fibrous (was 0.5%), LiFi (was 1%), and 0x (was 1%) now all use 0.25%.
- Register both aggregators in `src/swap/aggregators/index.ts`: construct them in the default list, map instances to their string ids in `aggregatorId`, extend the `needsDecimals` check for Mystic, and re-export the classes.
- Add transport middleware clients (`src/transport/middleware.ts`): `postMystic` (one JSON POST proxy to `/api/v1/proxy/mystic/{path}`, adapter supplies the versioned path) and `getRelayQuote` (`POST /api/v1/proxy/relay/quote/v2`, coerces chain ids to numbers); both added to `MiddlewareSwapClient`.
- Extend `ExternalServiceService` in `src/domain/errors.ts` with `'mystic'` and `'relay'` so their failures classify correctly.
- Tests: new `tests/swap/aggregators/mystic.test.ts` and `relay.test.ts`; update `aggregate.test.ts` and the Fibrous/LiFi/0x adapter tests for the shared slippage value.

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

## Risk / Impact

- Behavior change: slippage tolerance is now uniformly 0.25% across all adapters, down from 0.5% (Fibrous) and 1% (LiFi, 0x). Tighter tolerance floors output higher and keeps cross-aggregator quotes comparable, but may raise revert/no-quote rates on volatile or thin pairs — the previous looser tolerances would have succeeded where 0.25% now fails.
- New aggregators are additive: Mystic is gated to Citrea (chain 4114) and EXACT_IN only; Relay runs same-chain only. Failures in either are isolated per-adapter and classified as external-service errors, so they don't break the aggregate flow.
- No public API surface change (`src/index.ts` / `src/utils.ts` / `NexusClient` signatures untouched); new middleware clients are internal.