### PR TITLE
docs: clarify swapAndExecute/bridgeAndExecute are orchestrated, not atomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ console.log('Bridge complete:', result.intentExplorerUrl);
 - **Cross-chain swaps** — Execute EXACT_IN and EXACT_OUT swaps between any supported networks via LiFi, Bebop, and Fibrous aggregators
 - **Unified balances** — Aggregate user assets and balances across all connected chains
 - **Contract execution** — Call smart contracts with automatic bridging or swap funding logic
-- **Composite operations** — Bridge + Execute or Swap + Execute atomically
+- **Composite operations** — Bridge + Execute or Swap + Execute, orchestrated as two sequenced operations (funding, then execution) — not a single atomic transaction
 - **Transaction simulation** — Estimate gas, fees, and required approvals before sending
 - **Real-time progress** — Typed event system for plan previews, step-by-step progress, and status updates
 - **Complete testnet coverage** — Full multi-chain test environment
@@ -606,7 +606,12 @@ type ExecuteSimulation = {
 
 #### `bridgeAndExecute(params, options?)`
 
-Bridge tokens to a destination chain and execute a contract call. Automatically detects if sufficient funds already exist on the destination and skips the bridge when possible.
+Orchestrates **two distinct operations in sequence — not a single atomic transaction**:
+
+1. **Bridge (conditional)** — funds the shortfall on the destination chain. Automatically skipped when the destination already holds enough of the token (`result.bridgeSkipped === true`).
+2. **Execute + approval (execute always, approval optional)** — the contract call, preceded by an optional token approval, is **always** sent from the user's connected wallet on the destination chain.
+
+Because the two steps run one after the other, they succeed or fail independently. This is **not** atomic: if the execute fails after a bridge, the bridged funds remain in the user's wallet on the destination chain (they are not rolled back).
 
 ```typescript
 const result = await client.bridgeAndExecute(
@@ -952,7 +957,12 @@ type BridgeMaxResult = {
 
 #### `swapAndExecute(params, options?)`
 
-Swap tokens to a destination chain and execute a contract call atomically. Automatically skips the swap if sufficient funds already exist on the destination.
+Orchestrates **two distinct operations in sequence — not a single atomic transaction**:
+
+1. **Swap (conditional)** — funds the shortfall on the destination chain. Automatically skipped when the destination already holds enough of the token (`result.swapSkipped === true`).
+2. **Execute + approval (execute always, approval optional)** — the contract call, preceded by an optional token approval, is **always** sent from the user's connected wallet on the destination chain.
+
+Because the two steps run one after the other, they succeed or fail independently. This is **not** atomic: if the execute fails after a swap, the swapped funds remain in the user's wallet on the destination chain (they are not rolled back).
 
 ```typescript
 const result = await client.swapAndExecute(

--- a/skills/nexus-core/SKILL.md
+++ b/skills/nexus-core/SKILL.md
@@ -167,7 +167,7 @@ const result = await client.execute(
 
 ### Bridge + Execute (Composite)
 
-Bridge tokens then execute a contract call on the destination chain.
+**Two operations orchestrated in sequence, NOT one atomic transaction:** (1) a bridge that funds the shortfall on the destination chain — skipped when the destination already holds enough (`bridgeSkipped: true`); then (2) the execute (plus an optional token approval), which **always** runs from the user's connected wallet on the destination chain. The two steps succeed/fail independently — a failed execute does not roll back the bridge; the bridged funds stay in the user's wallet on the destination chain.
 
 ```ts
 const result = await client.bridgeAndExecute(
@@ -273,6 +273,8 @@ const max = await client.calculateMaxForBridge({
 ```
 
 ### Swap + Execute (Composite)
+
+**Two operations orchestrated in sequence, NOT one atomic transaction:** (1) a swap that funds the shortfall on the destination chain — skipped when the destination already holds enough (`swapSkipped: true`); then (2) the execute (plus an optional token approval), which **always** runs from the user's connected wallet on the destination chain. The two steps succeed/fail independently — a failed execute does not roll back the swap; the swapped funds stay in the user's wallet on the destination chain.
 
 ```ts
 const result = await client.swapAndExecute(

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -85,6 +85,18 @@ export type NexusClient = {
   listIntents: (params?: ListIntentsParams) => Promise<ListIntentsResult>;
   execute: (params: ExecuteParams, options?: OnEventParam) => Promise<ExecuteResult>;
   simulateExecute: (params: ExecuteParams) => Promise<ExecuteSimulation>;
+  /**
+   * Orchestrates two distinct operations in sequence — NOT a single atomic transaction:
+   *
+   * 1. Bridge (conditional) — funds the shortfall on the destination chain. Skipped when the
+   *    destination already holds enough of the token (`result.bridgeSkipped === true`).
+   * 2. Execute + approval (execute always, approval optional) — the contract call, preceded by
+   *    an optional token approval, is always sent from the user's connected wallet on the
+   *    destination chain.
+   *
+   * The steps succeed or fail independently: a failed execute does not roll back the bridge —
+   * the bridged funds remain in the user's wallet on the destination chain.
+   */
   bridgeAndExecute: (
     params: BridgeAndExecuteParams,
     options?: BridgeAndExecuteOptions
@@ -102,6 +114,18 @@ export type NexusClient = {
     input: SwapExactOutParams,
     options?: SwapOperationOptions
   ) => Promise<SwapResult>;
+  /**
+   * Orchestrates two distinct operations in sequence — NOT a single atomic transaction:
+   *
+   * 1. Swap (conditional) — funds the shortfall on the destination chain. Skipped when the
+   *    destination already holds enough of the token (`result.swapSkipped === true`).
+   * 2. Execute + approval (execute always, approval optional) — the contract call, preceded by
+   *    an optional token approval, is always sent from the user's connected wallet on the
+   *    destination chain.
+   *
+   * The steps succeed or fail independently: a failed execute does not roll back the swap —
+   * the swapped funds remain in the user's wallet on the destination chain.
+   */
   swapAndExecute: (
     input: SwapAndExecuteParams,
     options?: SwapAndExecuteOptions


### PR DESCRIPTION
## Summary

Clarifies in docs and JSDoc that `bridgeAndExecute` and `swapAndExecute` are **two operations orchestrated in sequence, not a single atomic transaction**. The previous wording ("Bridge + Execute … atomically", "execute a contract call atomically") misled an LLM building a swap+execute app into treating the composite as one all-or-nothing on-chain call. This is a documentation/comment-only change — no public API, type, or runtime behavior changes.

## Changes

- README: reworded the "Composite operations" feature bullet from "…atomically" to "orchestrated as two sequenced operations (funding, then execution) — not a single atomic transaction".
- README: rewrote the `bridgeAndExecute` and `swapAndExecute` descriptions as an explicit two-step sequence — (1) bridge/swap funds the shortfall on the destination, skipped when it already holds enough (`bridgeSkipped`/`swapSkipped`); (2) execute always + approval optional, always sent from the user's connected wallet — plus a note that the steps succeed/fail independently and a failed execute is not rolled back.
- skills/nexus-core/SKILL.md: added the same "two orchestrated operations, NOT one atomic transaction" framing to the Bridge + Execute and Swap + Execute sections.
- src/core/types.ts: added JSDoc to `bridgeAndExecute` and `swapAndExecute` on the `NexusClient` type so the orchestrated-not-atomic explanation shows on IDE hover / typedoc.
- Left the unrelated EIP-5792 `atomic batch` references (`wallet_sendCalls` capability, error codes) untouched — that is a different, correctly-named concept.

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] Verified claims against flow code: both flows deliver to `deps.evm.address` (user EOA) and send execute + approval via `deps.evm.walletClient` (user wallet).

## Risk / Impact

Very low. Documentation and JSDoc only; no changes to exported types, signatures, or runtime behavior. `src/core/types.ts` edit is a comment block on the existing `NexusClient` members.