### PR TITLE
swap: deduct native gas reserve in preflight source selection

### DIFF
--- a/src/services/balances.ts
+++ b/src/services/balances.ts
@@ -157,7 +157,7 @@ export const getBalancesForSwap = async (input: {
 // Scope: chains the user actually holds positive native (EADDRESS) balance on.
 // Anything else doesn't need a fee estimate — drops the typical fanout from
 // every-swap-supported-chain to 0-2 chains.
-const deductSwapNativeReserveFees = async (
+export const deductSwapNativeReserveFees = async (
   chainList: ChainListType,
   balances: FlatBalance[]
 ): Promise<FlatBalance[]> => {
@@ -189,6 +189,13 @@ const deductSwapNativeReserveFees = async (
     if (!fee) return b;
     const amount = new Decimal(b.amount);
     const remaining = amount.sub(fee);
+    // Actual amount removed from this native balance — the reserve fee, or the whole balance
+    // when the fee exceeds it.
+    const deducted = amount.sub(Decimal.max(remaining, 0));
+    logger.debug('swap-native-reserve-deducted', {
+      chainId: b.chainID,
+      deductedNativeAmount: `${deducted.toString()} ${b.symbol}`,
+    });
     if (remaining.lte(0)) {
       return { ...b, amount: '0', value: 0 };
     }

--- a/src/swap/balance/swap-balances.ts
+++ b/src/swap/balance/swap-balances.ts
@@ -1,64 +1,31 @@
 import type { Hex } from 'viem';
-import type { FlatBalance, Source } from '../types';
+import type { FlatBalance } from '../types';
 import { sortSourcesByPriority } from './sort';
 
 // ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-type GetBalancesInput = {
-  /** Pre-fetched balances (from Ankr or unified balance) */
-  balances: FlatBalance[];
-  /** Destination chain ID for priority sorting */
-  dstChainId: number;
-  /** Destination token address for priority sorting */
-  dstTokenAddress: Hex;
-  /** Only include these sources (whitelist) */
-  allowedSources?: Source[];
-  /** Exclude these sources (blacklist) */
-  removeSources?: Source[];
-};
-
-// ---------------------------------------------------------------------------
-// getBalancesForSwap
+// selectSwapSources
 // ---------------------------------------------------------------------------
 
 /**
- * Filters and sorts balances for swap routing.
+ * Selects source balances for swap routing:
  *
- * 1. Filter out zero/negative balances
- * 2. Apply allowedSources whitelist (if provided)
- * 3. Apply removeSources blacklist (if provided)
- * 4. Sort by 11-level priority system
+ * 1. Drop zero/negative balances (natives whose reserve is fully consumed land here as '0')
+ * 2. Sort by the 11-level source priority system
+ *
+ * The native gas reserve is deducted upstream (in `buildSwapPreflight`) before these are
+ * selected, so the router never sizes a swap against gas it needs to execute.
  */
-export const getBalancesForSwap = async (input: GetBalancesInput): Promise<FlatBalance[]> => {
-  const { balances, dstChainId, dstTokenAddress, allowedSources, removeSources } = input;
-
-  let filtered = balances.filter((b) => {
+export const selectSwapSources = (
+  balances: FlatBalance[],
+  dstChainId: number,
+  dstTokenAddress: Hex
+): FlatBalance[] => {
+  const filtered = balances.filter((b) => {
     const s = b.amount;
     if (s === '0' || s === '0.' || s.startsWith('-')) return false;
     // Check at least one non-zero digit exists
     return /[1-9]/.test(s);
   });
 
-  // Whitelist filter
-  if (allowedSources && allowedSources.length > 0) {
-    const allowSet = new Set(
-      allowedSources.map((s) => `${s.chainId}:${s.tokenAddress.toLowerCase()}`)
-    );
-    filtered = filtered.filter((b) => allowSet.has(`${b.chainID}:${b.tokenAddress.toLowerCase()}`));
-  }
-
-  // Blacklist filter
-  if (removeSources && removeSources.length > 0) {
-    const removeSet = new Set(
-      removeSources.map((s) => `${s.chainId}:${s.tokenAddress.toLowerCase()}`)
-    );
-    filtered = filtered.filter(
-      (b) => !removeSet.has(`${b.chainID}:${b.tokenAddress.toLowerCase()}`)
-    );
-  }
-
-  // Sort by priority
   return sortSourcesByPriority(filtered, dstChainId, dstTokenAddress);
 };

--- a/src/swap/preflight.ts
+++ b/src/swap/preflight.ts
@@ -4,8 +4,9 @@ import { type ChainListType, getLogger, type TokenInfo } from '../domain';
 import { isNativeAddress } from '../services/addresses';
 import { fetchErc20TokenMetadata } from '../services/token-metadata';
 import type { MiddlewareSwapPreflightClient } from '../transport';
+import { deductSwapNativeReserveFees } from '../services/balances';
 import { createAggregators } from './aggregators';
-import { getBalancesForSwap } from './balance/swap-balances';
+import { selectSwapSources } from './balance/swap-balances';
 import { type CurrencyID, resolveSwapSettlement } from './cot';
 import type {
   BridgeQuoteResponse,
@@ -153,11 +154,16 @@ export const buildSwapPreflight = async (
     quotePromise,
   ]);
 
-  const balances = await getBalancesForSwap({
-    balances: rawBalances,
-    dstChainId: input.data.toChainId,
-    dstTokenAddress: input.data.toTokenAddress,
-  });
+  // Reserve a representative gas amount out of native balances before source selection, so the
+  // router never sizes a swap against native it needs to execute. Applied here — the single swap
+  // source-sizing chokepoint — regardless of whether balances were preloaded (composite flow
+  // passes raw, keeping actual values for its own destination-gas shortfall) or freshly fetched.
+  const reserved = await deductSwapNativeReserveFees(options.chainList, rawBalances);
+  const balances = selectSwapSources(
+    reserved,
+    input.data.toChainId,
+    input.data.toTokenAddress
+  );
 
   const candidateChainIds = getCandidateChainIds(input, balances);
   const walletPathHints = new Map<number, WalletPath>(

--- a/src/swap/swap.md
+++ b/src/swap/swap.md
@@ -143,8 +143,9 @@ swap(input = {mode: EXACT_OUT, data:{toChainId:Base, toTokenAddress:WETH, toAmou
   pf = buildSwapPreflight(input, {chainList, cotCurrencyId, eoaAddress, middlewareClient})
     aggregators      = createAggregators(mw)               # → [LiFi, Bebop, Fibrous, 0x, Mystic, Relay]
     publicClientList = createPublicClientList(chainList)
-    balances         = getBalancesForSwap(                 # preloaded? then skip getSwapBalances
-                         preloaded ?? getSwapBalances(eoa))      # → positive-only, same-chain-first
+    raw              = preloaded ?? getSwapBalances(eoa)   # composite passes raw (keeps actuals for shortfall)
+    reserved         = deductSwapNativeReserveFees(chainList, raw)   # reserve native gas out of source sizing
+    balances         = selectSwapSources(reserved, toChainId, toToken)   # → positive-only, same-chain-first
     dstTokenInfo     = native(toToken) ? chain.nativeCurrency
                                        : fetchErc20TokenMetadata(toToken)     # → WETH/18
     quoteTok = resolveBridgeQuoteToken(input)          # the token the router will BRIDGE: the dst token
@@ -797,10 +798,11 @@ for `runMayanEphemeralBridge`'s **wait‑for‑mine‑then‑RFF ordering** and 
 gap. Mayan routing/intent/selection stay covered by `route-mayan.test.ts`, `bridge-intent.test.ts`,
 `auto-select-mayan-min.test.ts`, and `route.test.ts`'s provider‑parity block.
 
-Remaining sharp edge (by design, not a missing test): **two functions named `getBalancesForSwap`**
-— `src/swap/balance/swap-balances` (pure filter/sort of a provided `FlatBalance[]`) vs.
-`src/services/balances` (address‑driven fetch, used by the flow & cleanup). Mocked separately;
-don't conflate them. A rename is a deliberate API change, left for a separate pass.
+Source selection is `selectSwapSources` (`src/swap/balance/swap-balances`, pure filter/sort of a
+provided `FlatBalance[]`); the address‑driven fetch + display shaping is `getBalancesForSwap`
+(`src/services/balances`). The native gas reserve is deducted once, at the preflight source‑sizing
+chokepoint (`deductSwapNativeReserveFees`), so the composite flow keeps raw balances for its
+destination‑gas shortfall while the router still sizes against reserve‑adjusted balances.
 
 ---
 

--- a/tests/services/swap-preflight.test.ts
+++ b/tests/services/swap-preflight.test.ts
@@ -24,7 +24,14 @@ vi.mock('../../src/swap/aggregators', () => ({
 }));
 
 vi.mock('../../src/swap/balance/swap-balances', () => ({
-  getBalancesForSwap: vi.fn(),
+  selectSwapSources: vi.fn(),
+}));
+
+vi.mock('../../src/services/balances', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/services/balances')>()),
+  // Passthrough: preflight's reserve deduction is exercised in preflight-native-reserve.test.ts;
+  // here it must not alter balances or hit RPC so these assertions stay focused on preflight wiring.
+  deductSwapNativeReserveFees: vi.fn(async (_chainList, balances) => balances),
 }));
 
 vi.mock('../../src/services/token-metadata', () => ({
@@ -36,7 +43,7 @@ vi.mock('../../src/services/token-metadata', () => ({
 }));
 
 import { createAggregators } from '../../src/swap/aggregators';
-import { getBalancesForSwap } from '../../src/swap/balance/swap-balances';
+import { selectSwapSources } from '../../src/swap/balance/swap-balances';
 import { buildSwapPreflight } from '../../src/swap/preflight';
 import { fetchErc20TokenMetadata } from '../../src/services/token-metadata';
 import { EADDRESS } from '../../src/swap/constants';
@@ -165,7 +172,7 @@ const sortedBalances = [
 describe('buildSwapPreflight', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(getBalancesForSwap).mockResolvedValue(sortedBalances);
+    vi.mocked(selectSwapSources).mockReturnValue(sortedBalances);
   });
 
   it('loads oracle prices and balances in parallel before sorting balances', async () => {
@@ -193,14 +200,14 @@ describe('buildSwapPreflight', () => {
 
     expect(middlewareClient.getSwapBalances).toHaveBeenCalledTimes(1);
     expect(middlewareClient.getOraclePrices).toHaveBeenCalledTimes(1);
-    expect(getBalancesForSwap).not.toHaveBeenCalled();
+    expect(selectSwapSources).not.toHaveBeenCalled();
 
     resolveOraclePrices!([]);
     resolveBalances!([]);
 
     await preflightPromise;
 
-    expect(getBalancesForSwap).toHaveBeenCalledTimes(1);
+    expect(selectSwapSources).toHaveBeenCalledTimes(1);
   });
 
   it('reuses preloaded balances instead of refetching swap balances', async () => {
@@ -227,11 +234,7 @@ describe('buildSwapPreflight', () => {
     });
 
     expect(middlewareClient.getSwapBalances).not.toHaveBeenCalled();
-    expect(getBalancesForSwap).toHaveBeenCalledWith({
-      balances: rawBalances,
-      dstChainId: OP_CHAIN,
-      dstTokenAddress: WETH,
-    });
+    expect(selectSwapSources).toHaveBeenCalledWith(rawBalances, OP_CHAIN, WETH);
   });
 
   it('builds wallet path hints from each chain\'s 7702 support', async () => {

--- a/tests/swap/balance/precision.test.ts
+++ b/tests/swap/balance/precision.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { parseUnits } from 'viem';
-import { getBalancesForSwap } from '../../../src/swap/balance/swap-balances';
+import { selectSwapSources } from '../../../src/swap/balance/swap-balances';
 import type { FlatBalance } from '../../../src/swap/types';
 
+const DST_CHAIN = 42161;
+const DST_TOKEN = '0xaf88d065e77c8cc2239327c5edb3a432268e5831' as const;
+
 describe('balance precision safety', () => {
-  it('getBalancesForSwap does not lose precision filtering large balances', async () => {
+  it('selectSwapSources does not lose precision filtering large balances', () => {
     // This amount exceeds Number.MAX_SAFE_INTEGER when converted
     const largeBalance: FlatBalance = {
       amount: '999999999999999.999999',
@@ -17,18 +19,14 @@ describe('balance precision safety', () => {
       name: 'USDC',
     };
 
-    const result = await getBalancesForSwap({
-      balances: [largeBalance],
-      dstChainId: 42161,
-      dstTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
-    });
+    const result = selectSwapSources([largeBalance], DST_CHAIN, DST_TOKEN);
 
     expect(result).toHaveLength(1);
     // The amount string must survive unchanged — no Number() truncation
     expect(result[0].amount).toBe('999999999999999.999999');
   });
 
-  it('getBalancesForSwap filters out zero-amount strings without Number()', async () => {
+  it('selectSwapSources filters out zero-amount strings without Number()', () => {
     const zeroBalance: FlatBalance = {
       amount: '0',
       chainID: 1,
@@ -40,16 +38,12 @@ describe('balance precision safety', () => {
       name: 'USDC',
     };
 
-    const result = await getBalancesForSwap({
-      balances: [zeroBalance],
-      dstChainId: 42161,
-      dstTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
-    });
+    const result = selectSwapSources([zeroBalance], DST_CHAIN, DST_TOKEN);
 
     expect(result).toHaveLength(0);
   });
 
-  it('getBalancesForSwap keeps small positive amounts', async () => {
+  it('selectSwapSources keeps small positive amounts', () => {
     const tinyBalance: FlatBalance = {
       amount: '0.000001',
       chainID: 1,
@@ -61,11 +55,7 @@ describe('balance precision safety', () => {
       name: 'USDC',
     };
 
-    const result = await getBalancesForSwap({
-      balances: [tinyBalance],
-      dstChainId: 42161,
-      dstTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
-    });
+    const result = selectSwapSources([tinyBalance], DST_CHAIN, DST_TOKEN);
 
     expect(result).toHaveLength(1);
   });

--- a/tests/swap/balance/swap-balances.test.ts
+++ b/tests/swap/balance/swap-balances.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
-import { getBalancesForSwap } from '../../../src/swap/balance/swap-balances';
+import { describe, expect, it } from 'vitest';
+import { selectSwapSources } from '../../../src/swap/balance/swap-balances';
 import type { FlatBalance } from '../../../src/swap/types';
 
 const ETH_ADDR = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' as const;
 const USDC_ARB = '0xaf88d065e77c8cc2239327c5edb3a432268e5831' as const;
 const WETH_ARB = '0x82af49447d8a07e3bd95bd0d56f35241523fbab1' as const;
+const OUTPUT_TOKEN = '0x00000000000000000000000000000000000000ff' as const;
 
 const makeBalance = (
   chainID: number,
@@ -24,19 +25,15 @@ const makeBalance = (
   name: symbol,
 });
 
-describe('getBalancesForSwap', () => {
+describe('selectSwapSources', () => {
   const defaultBalances: FlatBalance[] = [
     makeBalance(42161, USDC_ARB, 'USDC', '100', 100, 6),
     makeBalance(42161, WETH_ARB, 'WETH', '0.5', 1000),
     makeBalance(42161, ETH_ADDR, 'ETH', '1.0', 2000),
   ];
 
-  it('returns filtered + sorted balances', async () => {
-    const result = await getBalancesForSwap({
-      balances: defaultBalances,
-      dstChainId: 8453,
-      dstTokenAddress: '0xOutputToken' as `0x${string}`,
-    });
+  it('returns filtered + sorted balances', () => {
+    const result = selectSwapSources(defaultBalances, 8453, OUTPUT_TOKEN);
 
     expect(result.length).toBeGreaterThan(0);
     // All balances have positive amounts
@@ -45,55 +42,21 @@ describe('getBalancesForSwap', () => {
     }
   });
 
-  it('filters by allowedSources when provided', async () => {
-    const result = await getBalancesForSwap({
-      balances: defaultBalances,
-      dstChainId: 8453,
-      dstTokenAddress: '0xOutputToken' as `0x${string}`,
-      allowedSources: [{ chainId: 42161, tokenAddress: USDC_ARB }],
-    });
-
-    expect(result).toHaveLength(1);
-    expect(result[0].symbol).toBe('USDC');
-  });
-
-  it('removes by removeSources when provided', async () => {
-    const result = await getBalancesForSwap({
-      balances: defaultBalances,
-      dstChainId: 8453,
-      dstTokenAddress: '0xOutputToken' as `0x${string}`,
-      removeSources: [{ chainId: 42161, tokenAddress: USDC_ARB }],
-    });
-
-    // USDC should be removed
-    const hasUSDC = result.some((b) => b.symbol === 'USDC');
-    expect(hasUSDC).toBe(false);
-    expect(result.length).toBe(2);
-  });
-
-  it('returns empty when all balances are zero', async () => {
+  it('returns empty when all balances are zero', () => {
     const zeroBalances = [makeBalance(42161, USDC_ARB, 'USDC', '0', 0, 6)];
 
-    const result = await getBalancesForSwap({
-      balances: zeroBalances,
-      dstChainId: 8453,
-      dstTokenAddress: '0xOutputToken' as `0x${string}`,
-    });
+    const result = selectSwapSources(zeroBalances, 8453, OUTPUT_TOKEN);
 
     expect(result).toHaveLength(0);
   });
 
-  it('sorts by priority (same chain first)', async () => {
+  it('sorts by priority (same chain first)', () => {
     const balances = [
       makeBalance(42161, WETH_ARB, 'WETH', '1', 1000),
       makeBalance(8453, USDC_ARB, 'USDC', '50', 50, 6),
     ];
 
-    const result = await getBalancesForSwap({
-      balances,
-      dstChainId: 8453,
-      dstTokenAddress: '0xOutputToken' as `0x${string}`,
-    });
+    const result = selectSwapSources(balances, 8453, OUTPUT_TOKEN);
 
     // Same chain (8453) should come first
     expect(result[0].chainID).toBe(8453);

--- a/tests/swap/max.test.ts
+++ b/tests/swap/max.test.ts
@@ -11,7 +11,7 @@ vi.mock('../../src/swap/aggregators', () => ({
 }));
 
 vi.mock('../../src/swap/balance/swap-balances', () => ({
-  getBalancesForSwap: vi.fn().mockResolvedValue([]),
+  selectSwapSources: vi.fn().mockReturnValue([]),
 }));
 
 vi.mock('../../src/swap/preflight', () => ({

--- a/tests/swap/preflight-native-reserve.test.ts
+++ b/tests/swap/preflight-native-reserve.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Hex } from 'viem';
+import { buildSwapPreflight } from '../../src/swap/preflight';
+import { EADDRESS } from '../../src/swap/constants';
+import { CurrencyID } from '../../src/swap/cot';
+import { SwapMode, type FlatBalance } from '../../src/swap/types';
+import type { MiddlewareSwapPreflightClient } from '../../src/transport';
+import { ARB_CHAIN, WETH, makeDstTokenInfo, makeSwapChainList } from '../helpers/swap';
+
+// 0.01 ETH representative reserve fee — deducted from native balances by the swap source path.
+vi.mock('../../src/services/swap-native-reserve-fee', () => ({
+  estimateRepresentativeSwapNativeReserveFee: vi.fn().mockResolvedValue(10_000_000_000_000_000n),
+  DEFAULT_SWAP_NATIVE_RESERVE_GAS: 1_500_000n,
+}));
+
+const EOA = '0xaaaa000000000000000000000000000000000001' as Hex;
+
+const makeMiddleware = (
+  balances: FlatBalance[] = []
+): MiddlewareSwapPreflightClient =>
+  ({
+    getSwapBalances: vi.fn().mockResolvedValue(balances),
+    getOraclePrices: vi.fn().mockResolvedValue([]),
+    getQuote: vi.fn().mockResolvedValue(null),
+  }) as unknown as MiddlewareSwapPreflightClient;
+
+const nativeEth = (amount: string): FlatBalance => ({
+  amount,
+  chainID: ARB_CHAIN,
+  decimals: 18,
+  symbol: 'ETH',
+  tokenAddress: EADDRESS,
+  value: 3000,
+  logo: '',
+  name: 'Ether',
+});
+
+const exactInInput = {
+  mode: SwapMode.EXACT_IN as const,
+  data: { from: [], toChainId: ARB_CHAIN, toTokenAddress: WETH },
+};
+
+describe('buildSwapPreflight native gas reserve', () => {
+  it('deducts the native reserve from preloaded balances before routing', async () => {
+    const preflight = await buildSwapPreflight(exactInInput, {
+      chainList: makeSwapChainList(),
+      cotCurrencyId: CurrencyID.USDC,
+      eoaAddress: EOA,
+      middlewareClient: makeMiddleware(),
+      preloadedBalances: [nativeEth('1')],
+      preloadedDstTokenInfo: makeDstTokenInfo(),
+    });
+
+    const eth = preflight.balances.find((b) => b.symbol === 'ETH');
+    expect(eth).toBeDefined();
+    expect(Number(eth!.amount)).toBeCloseTo(0.99, 6); // 1 - 0.01 reserve
+  });
+
+  it('deducts the native reserve from freshly fetched balances (no preload)', async () => {
+    const preflight = await buildSwapPreflight(exactInInput, {
+      chainList: makeSwapChainList(),
+      cotCurrencyId: CurrencyID.USDC,
+      eoaAddress: EOA,
+      middlewareClient: makeMiddleware([nativeEth('1')]),
+      preloadedDstTokenInfo: makeDstTokenInfo(),
+    });
+
+    const eth = preflight.balances.find((b) => b.symbol === 'ETH');
+    expect(eth).toBeDefined();
+    expect(Number(eth!.amount)).toBeCloseTo(0.99, 6); // 1 - 0.01 reserve
+  });
+});

--- a/tests/swap/swap.test.ts
+++ b/tests/swap/swap.test.ts
@@ -31,6 +31,7 @@ vi.mock('../../src/swap/execution/failure-cleanup', async (importOriginal) => ({
 
 vi.mock('../../src/services/balances', () => ({
   getBalancesForSwap: vi.fn().mockResolvedValue([]),
+  deductSwapNativeReserveFees: vi.fn(async (_chainList, balances) => balances),
 }));
 
 vi.mock('../../src/services/sbc', () => ({


### PR DESCRIPTION
## Summary

The native gas reserve was only applied on the display balance path (`client.getBalancesForSwap()`), never on the swap execution path — so the router could size a swap against native tokens the source chain still needs for gas, violating the "never consume 100% of native if gas is needed" invariant. This applies the reserve once, at the swap preflight source-sizing chokepoint, covering both standalone `swap()` and the composite `swapAndExecute` flow.

## Changes
- `src/swap/preflight.ts`: deduct the native gas reserve (`deductSwapNativeReserveFees`) from balances before source selection — applied to `preloaded ?? fetched`, so the composite flow (which hands preflight raw preloaded balances) gets the reserve too.
- `src/services/balances.ts`: export `deductSwapNativeReserveFees` (was module-private); add a per-chain `debug` log of the human-readable amount deducted — `swap-native-reserve-deducted { chainId, deductedNativeAmount: "0.0005 ETH" }`.
- `src/swap/balance/swap-balances.ts`: rename `getBalancesForSwap` → `selectSwapSources` and drop the dead `allowedSources` / `removeSources` params (now a pure sync filter+sort).
- Composite `swapAndExecute` and the display-path `getBalancesForSwap` are intentionally untouched, so `computeShortfall` keeps reading actual (un-reserved) destination-gas balances and never asks the user to fund gas they already hold.
- `src/swap/swap.md`: updated to reflect the rename and the single reserve chokepoint.
- Tests: added `tests/swap/preflight-native-reserve.test.ts` (preloaded + fetched paths); migrated `swap-balances`, `precision`, `swap-preflight`, `max`, and `swap` tests for the rename plus a reserve passthrough mock.

## Testing
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

## Risk / Impact
- Behavior change: swaps now size against reserve-adjusted native source balances, so a swap that previously spent 100% of a native source now correctly leaves gas — this can lower the max swappable amount from a native source or push borderline cases to require bridging. Intended.
- Adds a per-native-chain reserve RPC (gas estimate) to the swap preflight hot path; it overlaps the existing preflight `Promise.all` and is already paid on the display path.
- Destination-gas shortfall accounting is unchanged (still raw balances), so no new false gas-funding requests.
- No public API change: `client.getBalancesForSwap()` signature and the display shape are unchanged; the renamed function is swap-internal.