### PR TITLE
build: externalize declared dependencies from SDK bundles

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { isBuiltin } from 'node:module';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
@@ -8,24 +10,17 @@ import dts from 'rollup-plugin-dts';
 
 const shouldMinify = process.env.NODE_ENV !== 'development';
 const shouldGenerateSourceMaps = false;
+const packageJson = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
 
 // Polyfill `globalThis.process` so the SDK can run in non-Node environments
 // (browsers, edge runtimes) without crashing on `process.env`/`process.nextTick`.
 const processPolyfillIntro =
   'if(typeof globalThis.process==="undefined"){globalThis.process={env:{},version:"",nextTick:function(cb){Promise.resolve().then(cb)},stderr:{isTTY:false},stdout:{isTTY:false},pid:0,versions:{node:""}}}';
 
-const external = [
-  /^viem/,
-  'decimal.js',
-  'es-toolkit',
-  'posthog-js',
-  'zod',
-  'axios',
-  '@opentelemetry/api-logs',
-  '@opentelemetry/exporter-logs-otlp-http',
-  '@opentelemetry/resources',
-  '@opentelemetry/sdk-logs',
-];
+const dependencyIds = Object.keys(packageJson.dependencies ?? {});
+const external = (id) =>
+  isBuiltin(id) ||
+  dependencyIds.some((dependency) => id === dependency || id.startsWith(`${dependency}/`));
 
 const baseConfig = {
   input: 'src/index.ts',

--- a/tests/tooling/rollup-config.test.mjs
+++ b/tests/tooling/rollup-config.test.mjs
@@ -1,0 +1,43 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import rollupConfigs from '../../rollup.config.mjs';
+
+const packageJson = JSON.parse(
+  await readFile(new URL('../../package.json', import.meta.url), 'utf8')
+);
+
+describe('Rollup dependency externalization', () => {
+  it('uses one external predicate for JavaScript and declaration builds', () => {
+    const predicates = rollupConfigs.map((config) => config.external);
+
+    for (const predicate of predicates) {
+      expect(typeof predicate).toBe('function');
+    }
+    expect(new Set(predicates).size).toBe(1);
+  });
+
+  it('externalizes every declared dependency and its subpaths', () => {
+    const external = rollupConfigs[0].external;
+
+    expect(typeof external).toBe('function');
+    if (typeof external !== 'function') return;
+
+    for (const dependency of Object.keys(packageJson.dependencies)) {
+      expect(external(dependency)).toBe(true);
+      expect(external(`${dependency}/subpath`)).toBe(true);
+    }
+  });
+
+  it('preserves Node built-ins without matching dependency prefix collisions', () => {
+    const external = rollupConfigs[0].external;
+
+    expect(typeof external).toBe('function');
+    if (typeof external !== 'function') return;
+
+    expect(external('crypto')).toBe(true);
+    expect(external('node:crypto')).toBe(true);
+    expect(external('@avail-project/nexus-types-extra')).toBe(false);
+    expect(external('axios-retry')).toBe(false);
+    expect(external('./domain')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Rollup's manually maintained external list omitted `@avail-project/nexus-types`. Imports through `@avail-project/nexus-types/rff` were therefore bundled together with Mayan, Solana, and other transitive runtime code.

This derives Rollup externals from `package.json#dependencies`, including dependency subpaths, substantially reducing the published SDK bundles without changing the public API or package entrypoints.

| Entry | Before | After |
|---|---:|---:|
| `index.esm.js` | ~605 KB / 165 KB gzip | 338.8 KB / 85.8 KB gzip |
| `utils.esm.js` | ~266 KB / 81 KB gzip | 29.5 KB / 9.4 KB gzip |

## Changes

- `rollup.config.mjs`: derive externals from declared dependencies instead of maintaining a manual list.
- Match both package roots and subpaths, e.g. `@avail-project/nexus-types/rff`.
- Preserve Node built-ins as external.
- Reuse the same predicate across JavaScript and declaration builds.
- Add focused tests covering dependencies, subpaths, built-ins, and package-prefix collisions.
- No `package.json`, export-map, module-format, or output-filename changes.

## Testing

- [x] `npm run lint` — passes with two pre-existing warnings
- [x] `npm run typecheck`
- [x] `npm test`
- [x] Focused Rollup configuration tests: 3 passed
- [x] Built and measured both ESM entries

## Risk / Impact

- No public API or SDK behavior change.
- Declared runtime dependencies are now resolved from the consumer installation instead of being embedded in the SDK output.
- This reduces the size of the published SDK artifacts; final application bundle size still depends on the consumer bundler and imported SDK functionality.