### PR TITLE
docs: document displayed intent freshness for interactive approvals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1124,59 +1124,66 @@ The `intent` object passed to `onIntent` is the pricing preview shown in the app
 
 | Operation | Freshness guidance |
 |-----------|--------------------|
-| `swapWithExactIn()`, `swapWithExactOut()`, `swapAndExecute()` when a swap is required | Most underlying swap quotes are valid for roughly 30 seconds. Refresh every 20 seconds to leave time for sequential route construction and user approval. |
-| `bridge()`, `bridgeAndTransfer()`, `bridgeAndExecute()` when a bridge is required | Bridge quote deadlines vary by provider. Refresh every 15 seconds while the approval UI is open. |
+| `swapWithExactIn()`, `swapWithExactOut()`, `swapAndExecute()` when a swap is required | Most underlying swap quotes are valid for roughly 30 seconds. After each refresh completes, wait 20 seconds before starting the next one. |
+| `bridge()`, `bridgeAndTransfer()`, `bridgeAndExecute()` when a bridge is required | Bridge quote deadlines vary by provider. After each refresh completes, wait 15 seconds before starting the next one. |
 
 These are conservative UI-refresh cadences, not guaranteed protocol expiry values. This guidance applies only while displaying the pre-approval intent from `onIntent`; an already signed or submitted intent has separate expiry semantics. The SDK's execution-time requoting is also separate from keeping the confirmation UI current.
 
 Call `refresh()` without arguments to rebuild using the current source selection, or pass sources to change the selection. Always render the returned intent, avoid overlapping refresh calls, and stop refreshing before `allow()` or `deny()`. If a refresh is in flight, disable confirmation until it settles so `allow()` cannot race an older preview.
 
-```typescript
-const keepIntentFresh = <T>(
-  initialIntent: T,
-  refresh: () => Promise<T>,
-  everyMs: number,
-  render: (intent: T) => void,
-  reportError: (error: unknown) => void
-) => {
-  let stopped = false;
-  let timer: ReturnType<typeof setTimeout> | undefined;
+Use an async timeout rather than `setInterval`. The next timeout must be scheduled only after `refresh()` settles: if refreshing takes 5–10 seconds, a 20-second async timeout waits the full 20 seconds after completion instead of starting the next refresh only 10–15 seconds later.
 
-  const schedule = () => {
-    timer = setTimeout(async () => {
-      try {
-        const refreshedIntent = await refresh();
-        if (!stopped) render(refreshedIntent);
-      } catch (error) {
-        if (!stopped) reportError(error);
-      } finally {
-        if (!stopped) schedule();
-      }
-    }, everyMs);
+```typescript
+type ClearAsyncInterval = () => void;
+
+function setAsyncInterval(
+  cb: () => Promise<void>,
+  interval: number,
+  onError: (error: unknown) => void
+): ClearAsyncInterval {
+  let active = true;
+  let timer: ReturnType<typeof setTimeout>;
+
+  const tick = async () => {
+    if (!active) return;
+
+    try {
+      await cb();
+    } catch (error) {
+      onError(error);
+    } finally {
+      if (active) timer = setTimeout(tick, interval);
+    }
   };
 
-  render(initialIntent);
-  schedule();
+  timer = setTimeout(tick, interval);
 
   return () => {
-    stopped = true;
-    if (timer !== undefined) clearTimeout(timer);
+    active = false;
+    clearTimeout(timer);
   };
-};
+}
 
 await client.swapWithExactOut(input, {
   hooks: {
     onIntent: ({ intent, refresh, allow, deny }) => {
-      const stopRefreshing = keepIntentFresh(
-        intent,
-        () => refresh(),
-        20_000,
-        renderSwapIntent,
-        showIntentRefreshError
-      );
+      let refreshing = false;
+      renderSwapIntent(intent);
+
+      const stopRefreshing = setAsyncInterval(async () => {
+        refreshing = true;
+        setIntentRefreshing(true); // disable Confirm in the UI
+        try {
+          renderSwapIntent(await refresh());
+        } finally {
+          refreshing = false;
+          setIntentRefreshing(false);
+        }
+      }, 20_000, showIntentRefreshError);
 
       showIntentActions({
         confirm: () => {
+          if (refreshing) return;
           stopRefreshing();
           allow();
         },
@@ -1232,7 +1239,7 @@ type OnIntentHookData = {
 };
 ```
 
-> **Interactive approval:** refresh the bridge intent displayed in the confirmation UI every 15 seconds, render the intent returned by `refresh()`, and stop the refresh loop before calling `allow()` or `deny()`. See [Displayed Intent Freshness](#displayed-intent-freshness).
+> **Interactive approval:** after refreshing the bridge intent displayed in the confirmation UI, wait 15 seconds before starting the next refresh. Render the intent returned by `refresh()` and stop the async timeout before calling `allow()` or `deny()`. See [Displayed Intent Freshness](#displayed-intent-freshness).
 
 **BridgeIntent Structure:**
 
@@ -1408,7 +1415,7 @@ type OnIntentHookData = {
 };
 ```
 
-> **Interactive approval:** most swap quotes are valid for roughly 30 seconds. Refresh the swap intent displayed in the confirmation UI every 20 seconds so sequential routing and user approval do not consume the entire quote lifetime. See [Displayed Intent Freshness](#displayed-intent-freshness).
+> **Interactive approval:** most swap quotes are valid for roughly 30 seconds. After refreshing the swap intent displayed in the confirmation UI, wait 20 seconds before starting the next refresh. Use an async timeout so sequential routing does not shorten that wait. See [Displayed Intent Freshness](#displayed-intent-freshness).
 
 ### Composite Intent Hooks (Bridge + Execute / Swap + Execute)
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Built for backends, CLIs, and custom UI integrations.
   - [Swap Operations](#swap-operations)
   - [Intent Management](#intent-management)
 - [Hooks & Callbacks](#hooks--callbacks)
+  - [Displayed Intent Freshness](#displayed-intent-freshness)
   - [Intent Hook](#intent-hook)
   - [Allowance Hook](#allowance-hook)
   - [Swap Intent Hook](#swap-intent-hook)
@@ -1117,6 +1118,80 @@ type IntentRecord = {
 
 Hooks are essential for building interactive UIs. They allow users to review and approve operations before execution.
 
+### Displayed Intent Freshness
+
+The `intent` object passed to `onIntent` is the pricing preview shown in the app's confirmation UI. If that UI waits for interactive confirmation, keep this displayed intent fresh until the user approves or denies it.
+
+| Operation | Freshness guidance |
+|-----------|--------------------|
+| `swapWithExactIn()`, `swapWithExactOut()`, `swapAndExecute()` when a swap is required | Most underlying swap quotes are valid for roughly 30 seconds. Refresh every 20 seconds to leave time for sequential route construction and user approval. |
+| `bridge()`, `bridgeAndTransfer()`, `bridgeAndExecute()` when a bridge is required | Bridge quote deadlines vary by provider. Refresh every 15 seconds while the approval UI is open. |
+
+These are conservative UI-refresh cadences, not guaranteed protocol expiry values. This guidance applies only while displaying the pre-approval intent from `onIntent`; an already signed or submitted intent has separate expiry semantics. The SDK's execution-time requoting is also separate from keeping the confirmation UI current.
+
+Call `refresh()` without arguments to rebuild using the current source selection, or pass sources to change the selection. Always render the returned intent, avoid overlapping refresh calls, and stop refreshing before `allow()` or `deny()`. If a refresh is in flight, disable confirmation until it settles so `allow()` cannot race an older preview.
+
+```typescript
+const keepIntentFresh = <T>(
+  initialIntent: T,
+  refresh: () => Promise<T>,
+  everyMs: number,
+  render: (intent: T) => void,
+  reportError: (error: unknown) => void
+) => {
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const schedule = () => {
+    timer = setTimeout(async () => {
+      try {
+        const refreshedIntent = await refresh();
+        if (!stopped) render(refreshedIntent);
+      } catch (error) {
+        if (!stopped) reportError(error);
+      } finally {
+        if (!stopped) schedule();
+      }
+    }, everyMs);
+  };
+
+  render(initialIntent);
+  schedule();
+
+  return () => {
+    stopped = true;
+    if (timer !== undefined) clearTimeout(timer);
+  };
+};
+
+await client.swapWithExactOut(input, {
+  hooks: {
+    onIntent: ({ intent, refresh, allow, deny }) => {
+      const stopRefreshing = keepIntentFresh(
+        intent,
+        () => refresh(),
+        20_000,
+        renderSwapIntent,
+        showIntentRefreshError
+      );
+
+      showIntentActions({
+        confirm: () => {
+          stopRefreshing();
+          allow();
+        },
+        cancel: () => {
+          stopRefreshing();
+          deny();
+        },
+      });
+    },
+  },
+});
+```
+
+Use `15_000` instead for an interactive bridge intent. Immediate auto-approval (`onIntent: ({ allow }) => allow()`) does not need a refresh loop. Composite operations expose the same `refresh()` callback through their top-level `onIntent` hook.
+
 ### Intent Hook
 
 Called when the SDK needs user approval for a bridge/transfer intent. Passed via `options.hooks.onIntent` for bridge operations.
@@ -1157,7 +1232,7 @@ type OnIntentHookData = {
 };
 ```
 
-> **Keeping quotes fresh.** Fees and amounts drift while a confirmation modal is open. A common pattern is to stash the hook handle and poll `refresh()` on an interval (e.g. every 20s) to re-quote, re-rendering the intent each time, until the user calls `allow()` / `deny()`. `refresh()` returns the updated intent (the same shape passed to the hook). The same applies to the swap and composite intent hooks.
+> **Interactive approval:** refresh the bridge intent displayed in the confirmation UI every 15 seconds, render the intent returned by `refresh()`, and stop the refresh loop before calling `allow()` or `deny()`. See [Displayed Intent Freshness](#displayed-intent-freshness).
 
 **BridgeIntent Structure:**
 
@@ -1333,9 +1408,13 @@ type OnIntentHookData = {
 };
 ```
 
+> **Interactive approval:** most swap quotes are valid for roughly 30 seconds. Refresh the swap intent displayed in the confirmation UI every 20 seconds so sequential routing and user approval do not consume the entire quote lifetime. See [Displayed Intent Freshness](#displayed-intent-freshness).
+
 ### Composite Intent Hooks (Bridge + Execute / Swap + Execute)
 
 `bridgeAndExecute()` and `swapAndExecute()` use a top-level `onIntent` hook (not nested under `hooks`). The intent data is a composite type that includes the execution requirement, available balances, and whether a bridge/swap is actually needed.
+
+When the composite intent reports `bridgeRequired: true` or `swapRequired: true`, keep it fresh with the corresponding 15-second bridge or 20-second swap cadence until approval.
 
 #### Bridge and Execute Intent
 

--- a/skills/nexus-core/SKILL.md
+++ b/skills/nexus-core/SKILL.md
@@ -117,6 +117,8 @@ const result = await client.bridge(
 // Returns: BridgeResult { intentExplorerUrl, sourceTxs, intent }
 ```
 
+If `onIntent` opens an interactive confirmation UI instead of calling `allow()` immediately, refresh the bridge intent shown to the user every 15 seconds until approval. See [Displayed Intent Freshness](#displayed-intent-freshness-required-for-interactive-approval).
+
 ### Transfer (Bridge + Send)
 
 Bridge tokens and send to a different recipient.
@@ -247,6 +249,8 @@ const exactOutResult = await client.swapWithExactOut(
 // Returns: SwapResult { sourceSwaps, intentExplorerUrl, destinationSwap }
 ```
 
+Most swap quotes are valid for roughly 30 seconds. If `onIntent` displays an intent while waiting for user confirmation, call `refresh()` every 20 seconds, render the returned intent, and stop refreshing before `allow()` or `deny()`. See [Displayed Intent Freshness](#displayed-intent-freshness-required-for-interactive-approval).
+
 **Calculate Maximum Swappable** — populate a "Max" button before calling `swapWithExactIn`:
 
 ```ts
@@ -354,11 +358,59 @@ client.convertTokenReadableAmountToBigInt('1.5', 'USDC', 8453); // bigint
 
 Hooks are passed via the `options` parameter of each operation. If omitted, the SDK **auto-approves** (intents allowed, allowances set to `'min'`).
 
+### Displayed Intent Freshness (Required for Interactive Approval)
+
+The `intent` object passed to `onIntent` is the live pricing preview shown to the user before approval. Do not leave that displayed intent unchanged while waiting for a user to approve a modal. This is separate from the expiry of an already signed/submitted intent and from SDK execution-time requoting:
+
+- Swap and swap-backed composite intents: most quotes are valid for roughly 30 seconds; refresh every 20 seconds to preserve time for sequential route construction and approval.
+- Bridge and bridge-backed composite intents: provider deadlines vary; refresh every 15 seconds.
+- Render the intent returned by `refresh()`, prevent overlapping refresh calls, and stop the timer before `allow()` or `deny()`.
+- Disable confirmation while `refresh()` is running so approval cannot race an older preview.
+- Immediate auto-approval does not need a refresh timer.
+
+```ts
+onIntent: ({ intent, refresh, allow, deny }) => {
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const scheduleRefresh = () => {
+    timer = setTimeout(async () => {
+      try {
+        const refreshedIntent = await refresh();
+        if (!stopped) renderIntent(refreshedIntent);
+      } catch (error) {
+        if (!stopped) showIntentRefreshError(error);
+      } finally {
+        if (!stopped) scheduleRefresh();
+      }
+    }, 20_000); // use 15_000 for bridge
+  };
+
+  renderIntent(intent);
+  scheduleRefresh();
+
+  showIntentActions({
+    confirm: () => {
+      stopped = true;
+      if (timer !== undefined) clearTimeout(timer);
+      allow();
+    },
+    cancel: () => {
+      stopped = true;
+      if (timer !== undefined) clearTimeout(timer);
+      deny();
+    },
+  });
+};
+```
+
+Call `refresh()` without arguments to keep the current sources, or pass a new source list to re-route. `bridgeAndExecute()` and `swapAndExecute()` expose this callback through their top-level `onIntent` hook.
+
 ### Intent Hook
 
 ```ts
 hooks: {
-  onIntent: ({ intent, allow, deny, refresh }) => {
+  onIntent: async ({ intent, allow, deny, refresh }) => {
     // inspect intent details
     console.log(intent.selectedSources, intent.destination);
 
@@ -697,12 +749,13 @@ const src = token.logo || getFallbackTokenLogoDataUri(token.symbol); // size def
 
 1. **Amounts are always `bigint` in raw token units** — use `parseUnits('100', 6)` for 100 USDC, not `100`.
 2. **Bridge uses token symbols, swap uses contract addresses.** `bridge`/`bridgeAndTransfer`/`bridgeAndExecute` take `toTokenSymbol: 'USDC'` and `tokenApproval.toTokenSymbol`. `swapWithExactIn`/`swapWithExactOut`/`swapAndExecute` take `toTokenAddress: '0x...'` and `tokenApproval.toTokenAddress`.
-3. **Composite hooks are top-level** — `bridgeAndExecute` and `swapAndExecute` use `options.onIntent`, not `options.hooks.onIntent`.
-4. **`bridgeAndExecute().execute` omits `toChainId`.** `BridgeAndExecuteParams.execute` is `Omit<ExecuteParams, 'toChainId'>`; setting it is a type error. The destination chain is inherited from the top-level `toChainId`.
-5. **Default auto-approval** — if no hooks are provided, intents are allowed and allowances use `'min'`. When you do provide an `onAllowance` hook, the array passed to `allow()` must have the same length as `sources` (otherwise the SDK throws `INVALID_VALUES_ALLOWANCE_HOOK`); the safest pattern is `allow(sources.map(() => 'min'))`.
-6. **`initialize()` and `setEVMProvider()` are independent.** `initialize()` is required before any chain-dependent method; `setEVMProvider()` only attaches a wallet and can be called in any order.
-7. **Create a new client on account change.** `setEVMProvider()` short-circuits when called with the same provider instance, so it cannot be reused to swap accounts. Rebuild with `createNexusClient()` and re-run both setup steps.
-8. **Bridge skip optimization** — `bridgeAndExecute` and `swapAndExecute` may skip the bridge/swap if the destination chain already has enough funds; always branch on `result.bridgeSkipped` / `result.swapSkipped` before reading `result.bridgeResult` / `result.swapResult`.
+3. **Displayed intent previews are short-lived** — when `onIntent` shows an intent while waiting for interactive approval, refresh swaps every 20 seconds and bridges every 15 seconds, render the returned intent, and stop refreshing before `allow()` or `deny()`. Immediate auto-approval does not need a timer.
+4. **Composite hooks are top-level** — `bridgeAndExecute` and `swapAndExecute` use `options.onIntent`, not `options.hooks.onIntent`.
+5. **`bridgeAndExecute().execute` omits `toChainId`.** `BridgeAndExecuteParams.execute` is `Omit<ExecuteParams, 'toChainId'>`; setting it is a type error. The destination chain is inherited from the top-level `toChainId`.
+6. **Default auto-approval** — if no hooks are provided, intents are allowed and allowances use `'min'`. When you do provide an `onAllowance` hook, the array passed to `allow()` must have the same length as `sources` (otherwise the SDK throws `INVALID_VALUES_ALLOWANCE_HOOK`); the safest pattern is `allow(sources.map(() => 'min'))`.
+7. **`initialize()` and `setEVMProvider()` are independent.** `initialize()` is required before any chain-dependent method; `setEVMProvider()` only attaches a wallet and can be called in any order.
+8. **Create a new client on account change.** `setEVMProvider()` short-circuits when called with the same provider instance, so it cannot be reused to swap accounts. Rebuild with `createNexusClient()` and re-run both setup steps.
+9. **Bridge skip optimization** — `bridgeAndExecute` and `swapAndExecute` may skip the bridge/swap if the destination chain already has enough funds; always branch on `result.bridgeSkipped` / `result.swapSkipped` before reading `result.bridgeResult` / `result.swapResult`.
 
 ---
 

--- a/skills/nexus-core/SKILL.md
+++ b/skills/nexus-core/SKILL.md
@@ -117,7 +117,7 @@ const result = await client.bridge(
 // Returns: BridgeResult { intentExplorerUrl, sourceTxs, intent }
 ```
 
-If `onIntent` opens an interactive confirmation UI instead of calling `allow()` immediately, refresh the bridge intent shown to the user every 15 seconds until approval. See [Displayed Intent Freshness](#displayed-intent-freshness-required-for-interactive-approval).
+If `onIntent` opens an interactive confirmation UI instead of calling `allow()` immediately, use an async timeout that waits 15 seconds after each bridge refresh completes before starting the next one. See [Displayed Intent Freshness](#displayed-intent-freshness-required-for-interactive-approval).
 
 ### Transfer (Bridge + Send)
 
@@ -249,7 +249,7 @@ const exactOutResult = await client.swapWithExactOut(
 // Returns: SwapResult { sourceSwaps, intentExplorerUrl, destinationSwap }
 ```
 
-Most swap quotes are valid for roughly 30 seconds. If `onIntent` displays an intent while waiting for user confirmation, call `refresh()` every 20 seconds, render the returned intent, and stop refreshing before `allow()` or `deny()`. See [Displayed Intent Freshness](#displayed-intent-freshness-required-for-interactive-approval).
+Most swap quotes are valid for roughly 30 seconds. If `onIntent` displays an intent while waiting for user confirmation, use an async timeout that waits 20 seconds after each `refresh()` completes, render the returned intent, and stop refreshing before `allow()` or `deny()`. See [Displayed Intent Freshness](#displayed-intent-freshness-required-for-interactive-approval).
 
 **Calculate Maximum Swappable** — populate a "Max" button before calling `swapWithExactIn`:
 
@@ -362,11 +362,13 @@ Hooks are passed via the `options` parameter of each operation. If omitted, the 
 
 The `intent` object passed to `onIntent` is the live pricing preview shown to the user before approval. Do not leave that displayed intent unchanged while waiting for a user to approve a modal. This is separate from the expiry of an already signed/submitted intent and from SDK execution-time requoting:
 
-- Swap and swap-backed composite intents: most quotes are valid for roughly 30 seconds; refresh every 20 seconds to preserve time for sequential route construction and approval.
-- Bridge and bridge-backed composite intents: provider deadlines vary; refresh every 15 seconds.
+- Swap and swap-backed composite intents: most quotes are valid for roughly 30 seconds; wait 20 seconds after each refresh completes before starting the next one.
+- Bridge and bridge-backed composite intents: provider deadlines vary; wait 15 seconds after each refresh completes before starting the next one.
 - Render the intent returned by `refresh()`, prevent overlapping refresh calls, and stop the timer before `allow()` or `deny()`.
 - Disable confirmation while `refresh()` is running so approval cannot race an older preview.
 - Immediate auto-approval does not need a refresh timer.
+
+Use a recursive async timeout, not `setInterval`. Schedule the next timeout in `finally` after `refresh()` settles, matching `example/browser`: a refresh that takes 5–10 seconds still gets the full configured delay before the next refresh starts.
 
 ```ts
 onIntent: ({ intent, refresh, allow, deny }) => {
@@ -749,7 +751,7 @@ const src = token.logo || getFallbackTokenLogoDataUri(token.symbol); // size def
 
 1. **Amounts are always `bigint` in raw token units** — use `parseUnits('100', 6)` for 100 USDC, not `100`.
 2. **Bridge uses token symbols, swap uses contract addresses.** `bridge`/`bridgeAndTransfer`/`bridgeAndExecute` take `toTokenSymbol: 'USDC'` and `tokenApproval.toTokenSymbol`. `swapWithExactIn`/`swapWithExactOut`/`swapAndExecute` take `toTokenAddress: '0x...'` and `tokenApproval.toTokenAddress`.
-3. **Displayed intent previews are short-lived** — when `onIntent` shows an intent while waiting for interactive approval, refresh swaps every 20 seconds and bridges every 15 seconds, render the returned intent, and stop refreshing before `allow()` or `deny()`. Immediate auto-approval does not need a timer.
+3. **Displayed intent previews are short-lived** — when `onIntent` shows an intent while waiting for interactive approval, use recursive async timeouts that wait 20 seconds after swap refreshes and 15 seconds after bridge refreshes, render the returned intent, and stop refreshing before `allow()` or `deny()`. Do not use `setInterval`; immediate auto-approval does not need a timer.
 4. **Composite hooks are top-level** — `bridgeAndExecute` and `swapAndExecute` use `options.onIntent`, not `options.hooks.onIntent`.
 5. **`bridgeAndExecute().execute` omits `toChainId`.** `BridgeAndExecuteParams.execute` is `Omit<ExecuteParams, 'toChainId'>`; setting it is a type error. The destination chain is inherited from the top-level `toChainId`.
 6. **Default auto-approval** — if no hooks are provided, intents are allowed and allowances use `'min'`. When you do provide an `onAllowance` hook, the array passed to `allow()` must have the same length as `sources` (otherwise the SDK throws `INVALID_VALUES_ALLOWANCE_HOOK`); the safest pattern is `allow(sources.map(() => 'min'))`.


### PR DESCRIPTION
## Summary
Document how integrations should keep the pre-approval intent shown to users fresh while an interactive confirmation UI remains open.

## Changes
- Explain that the `intent` passed to `onIntent` is a live pricing preview, separate from signed intent expiry and execution-time requoting.
- Recommend refreshing displayed swap intents every 20 seconds because most underlying quotes are valid for roughly 30 seconds and routing may contain sequential quote stages.
- Recommend refreshing displayed bridge intents every 15 seconds because provider quote deadlines vary.
- Add a copyable refresh-loop example that renders each refreshed intent, avoids overlapping requests, and stops before approval or denial.
- Clarify that immediate auto-approval does not require a refresh loop.
- Add the guidance to both the SDK README and the Nexus integration skill.

## Testing
- Documentation-only change; no runtime tests required.

## Risk / Impact
- Documentation and integration guidance only; no SDK API or runtime behavior changes.
- Refresh intervals are conservative UI recommendations, not guaranteed protocol expiry values.