### PR TITLE
swap: use expected outputs for Exact In previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,6 +763,15 @@ const result = await client.swapWithExactIn(
 | `toChainId` | `number` | Yes | Destination chain |
 | `toTokenAddress` | `Hex` | Yes | Output token address |
 
+For Exact In, the approval-time `SwapIntent.destination.amount` and `.value` are the route's
+**expected output**, not its slippage-protected minimum. Expected source-swap output sizes the
+bridge, expected bridge delivery sizes the destination swap, and the destination quote's expected
+output reaches the existing intent fields. Executable calldata, approvals, aggregator selection,
+and retry guards still use protected quote amounts. At execution the SDK must read the COT that
+actually reached the destination wrapper and resize the destination swap before its first dispatch;
+the read/resize has three attempts total, then the swap fails with destination-step context and runs
+the normal stranded-COT cleanup.
+
 #### `swapWithExactOut(input, options?)`
 
 Swap tokens specifying the exact output amount desired.
@@ -850,7 +859,7 @@ type Swap = {
 
 #### `calculateMaxForSwap(input)`
 
-Calculate the maximum amount that can be swapped to a destination token across all available sources. Useful for populating a "Max" button before calling `swapWithExactIn`.
+Calculate the maximum amount that can be swapped to a destination token across all available sources. Useful for populating a "Max" button before calling `swapWithExactIn`. Max calculation deliberately uses protected minimum outputs at every stage (with the existing safety haircut), while reusing the normal quote sequence without extra quote requests.
 
 ```typescript
 const max = await client.calculateMaxForSwap({
@@ -1384,8 +1393,8 @@ await client.swapWithExactOut(input, {
 ```typescript
 type SwapIntent = {
   destination: {
-    amount: string;          // human-readable decimal amount
-    value?: string;          // optional USD value
+    amount: string;          // Exact In: expected output; Exact Out: requested output
+    value?: string;          // Exact In: expected output USD value when available
     chain: { id: number; logo: string; name: string };
     token: { contractAddress: Hex; decimals: number; symbol: string };
     gas: {

--- a/README.md
+++ b/README.md
@@ -770,7 +770,8 @@ output reaches the existing intent fields. Executable calldata, approvals, aggre
 and retry guards still use protected quote amounts. At execution the SDK must read the COT that
 actually reached the destination wrapper and resize the destination swap before its first dispatch;
 the read/resize has three attempts total, then the swap fails with destination-step context and runs
-the normal stranded-COT cleanup.
+the normal stranded-COT cleanup. The resized quote must consume the complete measured COT balance;
+an under-consuming quote is rejected rather than returning settlement-token dust to the user.
 
 #### `swapWithExactOut(input, options?)`
 

--- a/src/flows/swap.ts
+++ b/src/flows/swap.ts
@@ -54,7 +54,8 @@ const createRouteOptions = (
     | 'forceMayan'
     | 'timing'
   >,
-  preflight: SwapPreflight
+  preflight: SwapPreflight,
+  input: SwapData
 ): RouteOptions => ({
   aggregators: preflight.aggregators,
   bridgeQuoteResponse: preflight.bridgeQuoteResponse,
@@ -76,6 +77,7 @@ const createRouteOptions = (
   ),
   forceMayan: context.forceMayan,
   timing: context.timing,
+  ...(input.mode === SwapMode.EXACT_IN ? { exactInAmountBasis: 'expected' as const } : {}),
 });
 
 export type SwapPreviewState = {
@@ -102,7 +104,10 @@ export const buildSwapPreviewState = async (
   input: SwapData,
   context: SwapPreviewContext
 ): Promise<SwapPreviewState> => {
-  const route = await determineSwapRoute(input, createRouteOptions(context, context.preflight));
+  const route = await determineSwapRoute(
+    input,
+    createRouteOptions(context, context.preflight, input)
+  );
   return createSwapPreviewStateFromRoute(route, input, context.chainList);
 };
 
@@ -217,7 +222,8 @@ const runSwapFlow = async (
           forceMayan: deps.forceMayan,
           timing: deps.timing,
         },
-        preflight
+        preflight,
+        input
       )
     )
   );

--- a/src/services/mayan.ts
+++ b/src/services/mayan.ts
@@ -33,6 +33,37 @@ export type MayanLegQuote = {
   minReceived: Decimal;
 };
 
+const validExpectedMayanOutput = (candidate: Decimal, minimum: Decimal): boolean =>
+  candidate.isFinite() && candidate.gt(0) && candidate.gte(minimum);
+
+/** Select Mayan's normalized expected or protected delivery in human destination-token units. */
+export const selectMayanQuoteOutput = (
+  quote: MayanQuote,
+  destinationDecimals: number,
+  basis: 'expected' | 'minimum'
+): Decimal => {
+  const minimum = new Decimal(quote.minReceived.toString());
+  if (basis === 'minimum') return minimum;
+
+  try {
+    const expectedBaseUnits = new Decimal(quote.expectedAmountOutBaseUnits).div(
+      new Decimal(10).pow(destinationDecimals)
+    );
+    if (validExpectedMayanOutput(expectedBaseUnits, minimum)) return expectedBaseUnits;
+  } catch {
+    // Fall through to Mayan's human expected amount.
+  }
+
+  try {
+    const expectedHuman = new Decimal(quote.expectedAmountOut.toString());
+    if (validExpectedMayanOutput(expectedHuman, minimum)) return expectedHuman;
+  } catch {
+    // Fall through to the protected delivery.
+  }
+
+  return minimum;
+};
+
 /**
  * Shared Mayan quote plumbing: builds the `getMayanQuotes` request from a list of legs,
  * validates the response is index-aligned with the request (length + per-leg

--- a/src/swap/aggregators/bebop.ts
+++ b/src/swap/aggregators/bebop.ts
@@ -4,6 +4,7 @@ import { logger } from '../../domain/utils';
 import { divDecimals } from '../../services/math';
 import type { Aggregator, Quote, QuoteRequest } from './types';
 import { QuoteType } from './types';
+import { normalizeExpectedOutput } from './expected-output';
 
 type BebopApi = 'aggregation' | 'rfq';
 
@@ -138,6 +139,16 @@ export class BebopAggregator implements Aggregator {
       inputToken.decimals
     );
 
+    const output: Quote['output'] = {
+      contractAddress: buyToken,
+      amount: outputAmountInDecimal,
+      amountRaw: BigInt(outputToken.minimumAmount),
+      decimals: outputToken.decimals,
+      value: Decimal.mul(outputAmountInDecimal, outputToken.priceUsd ?? 0).toNumber(),
+      priceUsd: outputToken.priceUsd,
+      symbol: outputToken.symbol,
+    };
+
     return {
       expiry: quote.expiry,
       input: {
@@ -149,15 +160,8 @@ export class BebopAggregator implements Aggregator {
         priceUsd: inputToken.priceUsd,
         symbol: inputToken.symbol,
       },
-      output: {
-        contractAddress: buyToken,
-        amount: outputAmountInDecimal,
-        amountRaw: BigInt(outputToken.minimumAmount),
-        decimals: outputToken.decimals,
-        value: Decimal.mul(outputAmountInDecimal, outputToken.priceUsd ?? 0).toNumber(),
-        priceUsd: outputToken.priceUsd,
-        symbol: outputToken.symbol,
-      },
+      output,
+      expectedOutput: normalizeExpectedOutput(outputToken.amount, output),
       txData: {
         approvalAddress: quote.approvalTarget,
         tx: {
@@ -181,6 +185,7 @@ type BebopQuoteData = {
       decimals: number;
       priceUsd?: number;
       symbol: string;
+      amount?: string;
       minimumAmount: string;
     }
   >;

--- a/src/swap/aggregators/expected-output.ts
+++ b/src/swap/aggregators/expected-output.ts
@@ -1,0 +1,50 @@
+import Decimal from 'decimal.js';
+import { divDecimals } from '../../services/math';
+import type { Quote } from './types';
+
+/**
+ * Normalize an aggregator's unprotected output estimate without weakening its executable floor.
+ * Missing, malformed, non-positive, or below-floor estimates collapse to `quote.output`.
+ */
+export const normalizeExpectedOutput = (
+  expectedAmountRaw: unknown,
+  protectedOutput: Quote['output']
+): Quote['expectedOutput'] => {
+  let amountRaw = protectedOutput.amountRaw;
+  try {
+    const candidate = BigInt(expectedAmountRaw as string | number | bigint);
+    if (candidate > 0n && candidate >= protectedOutput.amountRaw) {
+      amountRaw = candidate;
+    }
+  } catch {
+    // Fall back to the executable protected output.
+  }
+
+  if (amountRaw === protectedOutput.amountRaw) {
+    return {
+      amountRaw,
+      amount: protectedOutput.amount,
+      value: protectedOutput.value,
+    };
+  }
+
+  const amount = divDecimals(amountRaw, protectedOutput.decimals).toFixed();
+  const protectedAmount = new Decimal(protectedOutput.amount);
+  const priceUsd =
+    protectedOutput.priceUsd ??
+    (protectedAmount.gt(0) ? new Decimal(protectedOutput.value).div(protectedAmount).toNumber() : 0);
+
+  return {
+    amountRaw,
+    amount,
+    value: new Decimal(amount).mul(priceUsd).toNumber(),
+  };
+};
+
+/** Recalculate metadata-dependent expected human/USD values after 0x/Mystic enrichment. */
+export const refreshExpectedOutput = (quote: Quote): Quote => {
+  if (quote.expectedOutput) {
+    quote.expectedOutput = normalizeExpectedOutput(quote.expectedOutput.amountRaw, quote.output);
+  }
+  return quote;
+};

--- a/src/swap/aggregators/expected-output.ts
+++ b/src/swap/aggregators/expected-output.ts
@@ -43,6 +43,8 @@ export const normalizeExpectedOutput = (
 
 /** Recalculate metadata-dependent expected human/USD values after 0x/Mystic enrichment. */
 export const refreshExpectedOutput = (quote: Quote): Quote => {
+  // Normalized SDK quotes require expectedOutput. This guard only tolerates malformed runtime
+  // objects from untyped/custom integrations; it does not make the normalized field optional.
   if (quote.expectedOutput) {
     quote.expectedOutput = normalizeExpectedOutput(quote.expectedOutput.amountRaw, quote.output);
   }

--- a/src/swap/aggregators/fibrous.ts
+++ b/src/swap/aggregators/fibrous.ts
@@ -3,6 +3,7 @@ import { encodeFunctionData, getAddress, type Hex, toHex, zeroAddress } from 'vi
 import { SLIPPAGE_BPS, SLIPPAGE_PERCENT } from './constants';
 import type { Aggregator, Quote, QuoteRequest } from './types';
 import { QuoteSeriousness, QuoteType } from './types';
+import { normalizeExpectedOutput } from './expected-output';
 
 const CHAIN_NAME_MAP: Record<number, string> = {
   // 999: 'hyperevm', // Causing issue
@@ -89,6 +90,15 @@ export class FibrousAggregator implements Aggregator {
     const routerAddress = getAddress(data.router_address);
     const isNativeInput = data.calldata.route.swap_type === 0;
 
+    const output: Quote['output'] = {
+      contractAddress: req.outputToken,
+      amount: outputAmount,
+      amountRaw: outputAmountRaw,
+      decimals: outputDecimals,
+      value: Decimal.mul(outputAmount, data.route.outputToken.price ?? 0).toNumber(),
+      symbol: data.route.outputToken.symbol ?? data.route.outputToken.name,
+    };
+
     return {
       input: {
         contractAddress: req.inputToken,
@@ -98,14 +108,8 @@ export class FibrousAggregator implements Aggregator {
         value: Decimal.mul(inputAmount, data.route.inputToken.price ?? 0).toNumber(),
         symbol: data.route.inputToken.symbol ?? data.route.inputToken.name,
       },
-      output: {
-        contractAddress: req.outputToken,
-        amount: outputAmount,
-        amountRaw: outputAmountRaw,
-        decimals: outputDecimals,
-        value: Decimal.mul(outputAmount, data.route.outputToken.price ?? 0).toNumber(),
-        symbol: data.route.outputToken.symbol ?? data.route.outputToken.name,
-      },
+      output,
+      expectedOutput: normalizeExpectedOutput(data.calldata.route.amount_out, output),
       txData: {
         approvalAddress: isNativeInput ? zeroAddress : routerAddress,
         tx: {
@@ -153,6 +157,15 @@ export class FibrousAggregator implements Aggregator {
       .div(Decimal.pow(10, data.outputToken.decimals))
       .toFixed(data.outputToken.decimals);
 
+    const output: Quote['output'] = {
+      contractAddress: req.outputToken,
+      amount: outputAmount,
+      amountRaw: outputAmountRaw,
+      decimals: data.outputToken.decimals,
+      value: Decimal.mul(outputAmount, data.outputToken.price ?? 0).toNumber(),
+      symbol: data.outputToken.symbol ?? data.outputToken.name,
+    };
+
     return {
       input: {
         contractAddress: req.inputToken,
@@ -162,14 +175,8 @@ export class FibrousAggregator implements Aggregator {
         value: Decimal.mul(inputAmount, data.inputToken.price ?? 0).toNumber(),
         symbol: data.inputToken.symbol ?? data.inputToken.name,
       },
-      output: {
-        contractAddress: req.outputToken,
-        amount: outputAmount,
-        amountRaw: outputAmountRaw,
-        decimals: data.outputToken.decimals,
-        value: Decimal.mul(outputAmount, data.outputToken.price ?? 0).toNumber(),
-        symbol: data.outputToken.symbol ?? data.outputToken.name,
-      },
+      output,
+      expectedOutput: normalizeExpectedOutput(data.outputAmount, output),
       txData: SURVEY_TX_PLACEHOLDER,
     };
   }

--- a/src/swap/aggregators/index.ts
+++ b/src/swap/aggregators/index.ts
@@ -5,6 +5,7 @@ import { isNativeAddress } from '../../services/addresses';
 import { divDecimals } from '../../services/math';
 import type { MiddlewareAggregatorQuoteClient } from '../../transport';
 import { EADDRESS } from '../constants';
+import { refreshExpectedOutput } from './expected-output';
 import { BebopAggregator } from './bebop';
 import { FibrousAggregator } from './fibrous';
 import { LiFiAggregator } from './lifi';
@@ -305,7 +306,7 @@ const backfillFromSiblings = (
         leg.value = new Decimal(leg.amount).mul(priceUsd).toNumber();
     }
   }
-  return quote;
+  return refreshExpectedOutput(quote);
 };
 
 // First non-nullish value of `field` on `side` among the sibling results (skips the winner itself,
@@ -363,7 +364,7 @@ const enrichWinner = async (
       leg.value = 0;
     }
   }
-  return quote;
+  return refreshExpectedOutput(quote);
 };
 
 export { BebopAggregator } from './bebop';

--- a/src/swap/aggregators/lifi.ts
+++ b/src/swap/aggregators/lifi.ts
@@ -4,6 +4,7 @@ import { divDecimals } from '../../services/math';
 import { SLIPPAGE_FRACTION } from './constants';
 import type { Aggregator, Quote, QuoteRequest, TokenInfo, TokenInfoProvider } from './types';
 import { QuoteType } from './types';
+import { normalizeExpectedOutput } from './expected-output';
 
 // LiFi exchanges to deny. openocean over-quotes everywhere; on HyperEVM (999)
 // fly/hyperflow/liquidswap share one on-chain entry and over-quote native HYPE->USDC by
@@ -115,6 +116,16 @@ export class LiFiAggregator implements Aggregator, TokenInfoProvider {
     const inputAmount = divDecimals(inputAmountRaw, action.fromToken.decimals).toFixed();
     const outputAmount = divDecimals(outputAmountRaw, action.toToken.decimals).toFixed();
 
+    const output: Quote['output'] = {
+      contractAddress: action.toToken.address as Hex,
+      amount: outputAmount,
+      amountRaw: outputAmountRaw,
+      decimals: action.toToken.decimals,
+      value: Decimal.mul(outputAmount, action.toToken.priceUSD).toNumber(),
+      priceUsd: Number(action.toToken.priceUSD),
+      symbol: action.toToken.symbol,
+    };
+
     return {
       input: {
         contractAddress: action.fromToken.address as Hex,
@@ -126,15 +137,8 @@ export class LiFiAggregator implements Aggregator, TokenInfoProvider {
         priceUsd: Number(action.fromToken.priceUSD),
         symbol: action.fromToken.symbol,
       },
-      output: {
-        contractAddress: action.toToken.address as Hex,
-        amount: outputAmount,
-        amountRaw: outputAmountRaw,
-        decimals: action.toToken.decimals,
-        value: Decimal.mul(outputAmount, action.toToken.priceUSD).toNumber(),
-        priceUsd: Number(action.toToken.priceUSD),
-        symbol: action.toToken.symbol,
-      },
+      output,
+      expectedOutput: normalizeExpectedOutput(estimate.toAmount, output),
       txData: {
         approvalAddress: estimate.approvalAddress as Hex,
         tx: {

--- a/src/swap/aggregators/mystic.ts
+++ b/src/swap/aggregators/mystic.ts
@@ -2,6 +2,7 @@ import { type Hex, toHex, zeroAddress } from 'viem';
 import { SLIPPAGE_BPS } from './constants';
 import type { Aggregator, Quote, QuoteRequest, TokenInfo, TokenInfoProvider } from './types';
 import { QuoteSeriousness, QuoteType } from './types';
+import { normalizeExpectedOutput } from './expected-output';
 
 // Chains Mystic Router serves in this SDK. Citrea-only for now (co-located with Fibrous); add
 // Mystic's other chains (Flare 14, Plume 98866, …) here once validated.
@@ -71,6 +72,7 @@ export class MysticAggregator implements Aggregator, TokenInfoProvider {
 
       const inputAmountRaw = BigInt(best.sellAmount);
       const outputAmountRaw = BigInt(best.minBuyAmount); // slippage-protected floor, like 0x
+      const output = placeholderSide(req.outputToken, outputAmountRaw);
 
       // Price surveys are only used as indicative convergence seeds and never enter execution, so
       // skip the build call: it simulates on-chain, which is wasteful per seed and would drop
@@ -78,7 +80,8 @@ export class MysticAggregator implements Aggregator, TokenInfoProvider {
       if (req.seriousness !== QuoteSeriousness.SERIOUS) {
         return {
           input: placeholderSide(req.inputToken, inputAmountRaw),
-          output: placeholderSide(req.outputToken, outputAmountRaw),
+          output,
+          expectedOutput: normalizeExpectedOutput(best.buyAmount, output),
           txData: SURVEY_TX_PLACEHOLDER,
         };
       }
@@ -94,7 +97,8 @@ export class MysticAggregator implements Aggregator, TokenInfoProvider {
 
       return {
         input: placeholderSide(req.inputToken, inputAmountRaw),
-        output: placeholderSide(req.outputToken, outputAmountRaw),
+        output,
+        expectedOutput: normalizeExpectedOutput(best.buyAmount, output),
         txData: {
           approvalAddress: build.approval?.spender ?? zeroAddress, // null for native sells
           tx: {

--- a/src/swap/aggregators/relay.ts
+++ b/src/swap/aggregators/relay.ts
@@ -6,6 +6,7 @@ import { divDecimals } from '../../services/math';
 import { SLIPPAGE_BPS_STRING } from './constants';
 import type { Aggregator, Quote, QuoteRequest } from './types';
 import { QuoteType } from './types';
+import { normalizeExpectedOutput } from './expected-output';
 
 const ERC20_APPROVE_ABI = parseAbi(['function approve(address spender, uint256 value)']);
 
@@ -98,9 +99,11 @@ const parseResponse = (
   const inputAmountRaw = BigInt(currencyIn.amount);
   const outputAmountRaw = BigInt(isExactOut ? currencyOut.amount : currencyOut.minimumAmount);
 
+  const output = buildSide(currencyOut, req.outputToken, outputAmountRaw);
   return {
     input: buildSide(currencyIn, req.inputToken, inputAmountRaw),
-    output: buildSide(currencyOut, req.outputToken, outputAmountRaw),
+    output,
+    expectedOutput: normalizeExpectedOutput(currencyOut.amount, output),
     txData: {
       approvalAddress: resolveApprovalAddress(data, req.inputToken, tx.to as Hex),
       tx: {
@@ -138,8 +141,8 @@ const buildSide = (
 ): Quote['input'] => {
   const { currency } = detail;
   const amount = divDecimals(amountRaw, currency.decimals).toFixed();
-  const formatted = Number(detail.amountFormatted);
-  const priceUsd = formatted > 0 ? Number(detail.amountUsd) / formatted : 0;
+  const formatted = new Decimal(detail.amountFormatted);
+  const priceUsd = formatted.gt(0) ? new Decimal(detail.amountUsd).div(formatted).toNumber() : 0;
   return {
     contractAddress: tokenAddress, // SDK-canonical token (EADDRESS for native), not Relay's zero
     amount,

--- a/src/swap/aggregators/types.ts
+++ b/src/swap/aggregators/types.ts
@@ -39,6 +39,13 @@ export type Quote = {
     priceUsd?: number; // see input.priceUsd
     symbol: string;
   };
+  // Unprotected output estimate used only for Exact In preview economics and forward sizing.
+  // `output` remains the executable slippage-protected minimum for selection, calldata, and guards.
+  expectedOutput: {
+    amountRaw: bigint;
+    amount: string;
+    value: number;
+  };
   txData: {
     approvalAddress: Hex;
     tx: { to: Hex; data: Hex; value: Hex };

--- a/src/swap/aggregators/zerox.ts
+++ b/src/swap/aggregators/zerox.ts
@@ -2,6 +2,7 @@ import { type Hex, zeroAddress } from 'viem';
 import { SLIPPAGE_BPS_STRING } from './constants';
 import type { Aggregator, Quote, QuoteRequest } from './types';
 import { QuoteSeriousness, QuoteType } from './types';
+import { normalizeExpectedOutput } from './expected-output';
 
 // Chains 0x's Swap API serves. Best-effort mainnet set; outside it we return null without a
 // round-trip (mirrors LiFi's ALLOWED_CHAINS). Confirm/expand against
@@ -91,9 +92,11 @@ const parseResponse = (
   const inputAmountRaw = BigInt(isExactOut ? data.maxSellAmount : data.sellAmount);
   const outputAmountRaw = BigInt(isExactOut ? data.buyAmount : data.minBuyAmount);
 
+  const output = placeholderSide(req.outputToken, outputAmountRaw);
   return {
     input: placeholderSide(req.inputToken, inputAmountRaw),
-    output: placeholderSide(req.outputToken, outputAmountRaw),
+    output,
+    expectedOutput: normalizeExpectedOutput(data.buyAmount, output),
     // /quote carries the executable tx; /price (survey) carries none, so use a placeholder that is
     // never executed because surveys are restricted to indicative convergence seeds.
     txData: data.transaction

--- a/src/swap/amount-basis.ts
+++ b/src/swap/amount-basis.ts
@@ -11,4 +11,6 @@ export const selectExactInQuoteOutput = (
   quote: Quote,
   basis: ExactInAmountBasis
 ): Quote['output'] | Quote['expectedOutput'] =>
+  // Normalized SDK quotes require expectedOutput. Keep the runtime check only for untyped custom
+  // aggregators or stale JavaScript objects crossing the boundary; it does not weaken Quote's type.
   basis === 'expected' && quote.expectedOutput ? quote.expectedOutput : quote.output;

--- a/src/swap/amount-basis.ts
+++ b/src/swap/amount-basis.ts
@@ -1,0 +1,14 @@
+import type { Quote } from './aggregators/types';
+
+export type ExactInAmountBasis = 'expected' | 'minimum';
+
+export const resolveExactInAmountBasis = (
+  basis: ExactInAmountBasis | undefined
+): ExactInAmountBasis => basis ?? 'minimum';
+
+/** Select the one forward-sizing/display amount while leaving executable quote fields untouched. */
+export const selectExactInQuoteOutput = (
+  quote: Quote,
+  basis: ExactInAmountBasis
+): Quote['output'] | Quote['expectedOutput'] =>
+  basis === 'expected' && quote.expectedOutput ? quote.expectedOutput : quote.output;

--- a/src/swap/bridge-intent.ts
+++ b/src/swap/bridge-intent.ts
@@ -10,6 +10,7 @@ import {
 import { Universe } from '../domain/chain-abstraction';
 import { Errors } from '../domain/errors';
 import { mulDecimals } from '../services/math';
+import { computeNexusBridgeFees } from './routing/bridge';
 import type { BridgeAsset, SwapRoute } from './types';
 
 const logger = getLogger();
@@ -74,12 +75,19 @@ export const createSwapBridgeIntent = (params: {
     (sum, asset) => sum.plus(asset.eoaBalance).plus(asset.ephemeralBalance),
     new Decimal(0)
   );
+  const effectiveFees =
+    bridge.provider === 'nexus' && bridge.nexusFeeModel
+      ? computeNexusBridgeFees({
+          nexusFeeModel: bridge.nexusFeeModel,
+          grossBridged: totalBridgedAmount,
+        }).estimatedFees
+      : bridge.estimatedFees;
   // Gas-swap COT (`bridge.amounts.gasInCot`) is still bridged — it funds the dst gas swap.
   // Bridge solver no longer delivers separate native gas; intent.destination.nativeAmount=0.
   const executionTokenAmount = totalBridgedAmount
-    .minus(bridge.estimatedFees.collection)
-    .minus(bridge.estimatedFees.fulfilment)
-    .minus(bridge.estimatedFees.protocol);
+    .minus(effectiveFees.collection)
+    .minus(effectiveFees.fulfilment)
+    .minus(effectiveFees.protocol);
   if (executionTokenAmount.isNegative()) {
     throw new Error('Bridge token amount cannot be negative after fee deduction');
   }
@@ -169,11 +177,11 @@ export const createSwapBridgeIntent = (params: {
       universe: Universe.ETHEREUM,
     },
     fees: {
-      caGas: bridge.estimatedFees.caGas.toString(),
-      deposit: bridge.estimatedFees.collection.toString(),
-      fulfillment: bridge.estimatedFees.fulfilment.toString(),
-      protocol: bridge.estimatedFees.protocol.toString(),
-      solver: bridge.estimatedFees.solver.toString(),
+      caGas: effectiveFees.caGas.toString(),
+      deposit: effectiveFees.collection.toString(),
+      fulfillment: effectiveFees.fulfilment.toString(),
+      protocol: effectiveFees.protocol.toString(),
+      solver: effectiveFees.solver.toString(),
     },
     recipientAddress: recipient,
   };

--- a/src/swap/constants.ts
+++ b/src/swap/constants.ts
@@ -39,13 +39,6 @@ export const DST_BUFFER_PCT = 0.1;
 export const DST_BUFFER_MAX_USD = 2;
 export const SRC_BUFFER_PCT = 0.02;
 export const SRC_BUFFER_MAX_USD = 1;
-// EXACT_IN dst reclaim: when the destination swap is re-sized from the COT that actually landed
-// at the wrapper, shave this off as a safety margin (raw rounding + the swap's own input-side
-// behaviour) so the sized input can never exceed the on-chain balance.
-// ponytail: fixed 1bp margin — real-world calibration knob, not a derived constant. Too small →
-// occasional insufficient-balance reverts; too large → yield left on the table. Upgrade path:
-// derive from the quote's own slippage + a dust floor.
-export const DST_RECLAIM_DEDUCTION_PCT = 0.0001;
 export const MAX_SWAP_HAIRCUT_PCT = 0.03;
 export const MAX_SWAP_HAIRCUT_MIN_USDC = 3;
 export const GAS_TO_COT_BUFFER = 1.02;

--- a/src/swap/execution/bridge.ts
+++ b/src/swap/execution/bridge.ts
@@ -4,6 +4,7 @@ import {
   toMayanDepositRequest,
   VAULT_ABI_MAYAN,
 } from '@avail-project/nexus-types/rff';
+import Decimal from 'decimal.js';
 import { encodeFunctionData, erc20Abi, type Hex, type PublicClient, parseSignature } from 'viem';
 import type { PrivateKeyAccount } from 'viem/accounts';
 import { ERC20PermitABI } from '../../abi/erc20';
@@ -847,8 +848,30 @@ export const refreshMayanQuotesForExecution = async (
     })),
     destination: { chainId: bridge.chainID, tokenAddress: bridge.tokenAddress },
   });
+  const grossBridged = bridgedAssets.reduce(
+    (sum, asset) => sum.plus(asset.eoaBalance).plus(asset.ephemeralBalance),
+    new Decimal(0)
+  );
+  const protectedDelivered = quotes.reduce(
+    (sum, quote) => sum.plus(new Decimal(quote.quote.minReceived.toString())),
+    new Decimal(0)
+  );
+  const haircut = Decimal.max(grossBridged.minus(protectedDelivered), new Decimal(0));
   return {
     ...bridge,
+    amount: grossBridged,
+    amounts: {
+      tokenAmount: Decimal.max(protectedDelivered.minus(bridge.amounts.gasInCot), new Decimal(0)),
+      gasInCot: bridge.amounts.gasInCot,
+      totalAmount: grossBridged,
+    },
+    estimatedFees: {
+      collection: new Decimal(0),
+      fulfilment: new Decimal(0),
+      caGas: new Decimal(0),
+      protocol: haircut,
+      solver: new Decimal(0),
+    },
     mayanQuotesBySource: new Map(
       quotes.map((quote) => [`${quote.chainId}:${quote.tokenAddress.toLowerCase()}`, quote.quote])
     ),

--- a/src/swap/execution/destination-swap.ts
+++ b/src/swap/execution/destination-swap.ts
@@ -288,66 +288,41 @@ export const executeDestinationSwap = async (
     walletPath: wrapper,
   });
 
-  // Read the COT at the dst wrapper once. Execution just measures and hands the balance to the route's
-  // getDstSwap — each mode's closure decides what to do with it (EXACT_IN grows the input toward it,
-  // EXACT_OUT lifts its max-input budget to it). Includes the in-batch direct dst COT (eoaToEphemeral),
-  // which rides the swap batch and isn't at the wrapper yet. Best-effort: a failed read passes 0 (→ the
-  // route-time quote) and the leftover falls back to the Sweeper.
-  let wrapperCotBalance: bigint | null = null;
-  try {
+  const readWrapperCotBalance = async (): Promise<bigint> => {
     const cotAddress =
       currentSwap.tokenSwap?.quote.input.contractAddress ??
       currentSwap.gasSwap?.quote.input.contractAddress;
-    if (cotAddress) {
-      const holderAddress =
-        wrapper === 'safe'
-          ? predictSafeAccountAddress(ctx.ephemeralWallet.address).address
-          : ctx.ephemeralWallet.address;
-      const balance = await withTimingSpan(
-        ctx.timing,
-        'flow.swap.execute.destination.read_balance',
-        async () =>
-          readSettlementBalanceRaw({
-            chainId: destination.chainId,
-            tokenAddress: cotAddress,
-            holderAddress,
-            publicClientList: ctx.publicClientList,
-          }),
-        { tags: { mode, wallet_path: wrapper } }
-      );
-      wrapperCotBalance = balance + (destination.eoaToEphemeral?.amount ?? 0n);
+    if (!cotAddress) {
+      throw new Error('Destination settlement token is unavailable');
     }
-  } catch (error) {
-    logger.debug('swap.execute.destination.balance_read.skipped', {
-      chainId: destination.chainId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-
-  // EXACT_IN re-sizes the dst input to the COT that ACTUALLY landed, in BOTH directions: grow on
-  // positive slippage (swallow the surplus into more output), shrink when a down-drifted source
-  // delivered less (there's no source buffer guaranteeing balanceOf ≥ the route estimate). getDstSwap
-  // applies the reclaim deduction, so the swap always pulls ≤ the balance — a leftover survives for
-  // the refund transfer and it can never underflow. EXACT_OUT keeps the output fixed — it tries the
-  // existing quote first and only re-prices (at the lifted budget) on a retry/expiry below.
-  if (mode === SwapMode.EXACT_IN && wrapperCotBalance !== null && currentSwap.tokenSwap) {
-    try {
-      const resized = await withTimingSpan(
-        ctx.timing,
-        'flow.swap.execute.destination.resize_or_requote',
-        async () => destination.getDstSwap(wrapperCotBalance),
-        { tags: { mode, wallet_path: wrapper, attempt: 0 } }
-      );
-      if (resized?.tokenSwap) {
-        currentSwap = resized;
-        logger.debug('swap.execute.destination.resize.completed', {
+    const holderAddress =
+      wrapper === 'safe'
+        ? predictSafeAccountAddress(ctx.ephemeralWallet.address).address
+        : ctx.ephemeralWallet.address;
+    const balance = await withTimingSpan(
+      ctx.timing,
+      'flow.swap.execute.destination.read_balance',
+      async () =>
+        readSettlementBalanceRaw({
           chainId: destination.chainId,
-          actualBalanceRaw: wrapperCotBalance.toString(),
-          inputAmountRaw: resized.tokenSwap.quote.input.amountRaw.toString(),
-        });
-      }
+          tokenAddress: cotAddress,
+          holderAddress,
+          publicClientList: ctx.publicClientList,
+        }),
+      { tags: { mode, wallet_path: wrapper } }
+    );
+    return balance + (destination.eoaToEphemeral?.amount ?? 0n);
+  };
+
+  // EXACT_OUT keeps its best-effort read: it can safely execute the protected fixed-output quote
+  // without measuring surplus. EXACT_IN must measure and resize before dispatch, so its read lives
+  // inside the retry loop below and a read failure consumes an attempt.
+  let wrapperCotBalance: bigint | null = null;
+  if (mode === SwapMode.EXACT_OUT) {
+    try {
+      wrapperCotBalance = await readWrapperCotBalance();
     } catch (error) {
-      logger.debug('swap.execute.destination.resize.skipped', {
+      logger.debug('swap.execute.destination.balance_read.skipped', {
         chainId: destination.chainId,
         error: error instanceof Error ? error.message : String(error),
       });
@@ -364,10 +339,46 @@ export const executeDestinationSwap = async (
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
+      if (mode === SwapMode.EXACT_IN) {
+        wrapperCotBalance ??= await readWrapperCotBalance();
+        const resized = await withTimingSpan(
+          ctx.timing,
+          'flow.swap.execute.destination.resize_or_requote',
+          async () => destination.getDstSwap(wrapperCotBalance as bigint),
+          { tags: { mode, wallet_path: wrapper, attempt } }
+        );
+        const hasEveryRequiredLeg =
+          resized != null &&
+          (!requiresTokenSwap || Boolean(resized.tokenSwap)) &&
+          (!requiresGasSwap || Boolean(resized.gasSwap));
+        if (!resized || (!resized.tokenSwap && !resized.gasSwap) || !hasEveryRequiredLeg) {
+          const previousAggregator =
+            currentSwap.tokenSwap?.aggregator ?? currentSwap.gasSwap?.aggregator;
+          throw new ExternalServiceError(
+            ERROR_CODES.EXTERNAL_DESTINATION_SWAP_QUOTE_FAILED,
+            'Quote failed: Failed to resize destination swap.',
+            {
+              context: {
+                service: previousAggregator ? aggregatorService(previousAggregator) : 'lifi',
+                stepId: createDestinationSwapStepId(destination.chainId),
+                stepType: 'destination_swap',
+                chainId: destination.chainId,
+              },
+            }
+          );
+        }
+        currentSwap = resized;
+        logger.debug('swap.execute.destination.resize.completed', {
+          chainId: destination.chainId,
+          actualBalanceRaw: wrapperCotBalance.toString(),
+          inputAmountRaw: resized.tokenSwap?.quote.input.amountRaw.toString(),
+        });
+      }
+
       // Try the current quote first; only requote on a forced retry or an expired quote. The requote
       // re-prices against the actual balance (EXACT_OUT lifts its budget to it; an EXACT_IN retry
       // re-grows).
-      if (attempt > 0 || isQuoteExpired(currentSwap)) {
+      if (mode === SwapMode.EXACT_OUT && (attempt > 0 || isQuoteExpired(currentSwap))) {
         const requoted = await withTimingSpan(
           ctx.timing,
           'flow.swap.execute.destination.resize_or_requote',

--- a/src/swap/execution/destination-swap.ts
+++ b/src/swap/execution/destination-swap.ts
@@ -137,11 +137,10 @@ const buildDestinationCalls = async (
     calls.push(parsedGasSwap.swap);
   }
 
-  // Leftover COT input → ONE direct transfer back to the EOA: `B − consumed` (EXACT_IN grew the input
-  // so this is ~nothing; EXACT_OUT leaves the real surplus). Both modes use the same transfer; getDstSwap
-  // already applied any margin (EXACT_IN's grow deduction), and the swap pulls ≤ its quoted input so the
-  // leftover is guaranteed available. Only when the balance read failed do we fall back to the blind
-  // Sweeper (size unknown).
+  // Leftover COT input → ONE direct transfer back to the EOA: `B − consumed`. Exact In execution
+  // requires its resized quote to consume the complete measured balance, so only Exact Out should
+  // produce a positive surplus here. When the Exact Out balance read failed, fall back to the blind
+  // Sweeper because the surplus size is unknown.
   if (wrapperCotBalance !== null) {
     const cotAddress =
       currentSwap.tokenSwap?.quote.input.contractAddress ??
@@ -340,18 +339,30 @@ export const executeDestinationSwap = async (
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
       if (mode === SwapMode.EXACT_IN) {
-        wrapperCotBalance ??= await readWrapperCotBalance();
+        if (wrapperCotBalance === null) {
+          wrapperCotBalance = await readWrapperCotBalance();
+        }
+        const actualCotBalance = wrapperCotBalance;
         const resized = await withTimingSpan(
           ctx.timing,
           'flow.swap.execute.destination.resize_or_requote',
-          async () => destination.getDstSwap(wrapperCotBalance as bigint),
+          async () => destination.getDstSwap(actualCotBalance),
           { tags: { mode, wallet_path: wrapper, attempt } }
         );
         const hasEveryRequiredLeg =
           resized != null &&
           (!requiresTokenSwap || Boolean(resized.tokenSwap)) &&
           (!requiresGasSwap || Boolean(resized.gasSwap));
-        if (!resized || (!resized.tokenSwap && !resized.gasSwap) || !hasEveryRequiredLeg) {
+        const resizedInputRaw =
+          (resized?.tokenSwap?.quote.input.amountRaw ?? 0n) +
+          (resized?.gasSwap?.quote.input.amountRaw ?? 0n);
+        const consumesFullBalance = resizedInputRaw === actualCotBalance;
+        if (
+          !resized ||
+          (!resized.tokenSwap && !resized.gasSwap) ||
+          !hasEveryRequiredLeg ||
+          !consumesFullBalance
+        ) {
           const previousAggregator =
             currentSwap.tokenSwap?.aggregator ?? currentSwap.gasSwap?.aggregator;
           throw new ExternalServiceError(
@@ -370,7 +381,7 @@ export const executeDestinationSwap = async (
         currentSwap = resized;
         logger.debug('swap.execute.destination.resize.completed', {
           chainId: destination.chainId,
-          actualBalanceRaw: wrapperCotBalance.toString(),
+          actualBalanceRaw: actualCotBalance.toString(),
           inputAmountRaw: resized.tokenSwap?.quote.input.amountRaw.toString(),
         });
       }

--- a/src/swap/intent.ts
+++ b/src/swap/intent.ts
@@ -3,6 +3,7 @@ import type { Hex } from 'viem';
 import type { ChainListType } from '../domain';
 import { equalFold } from '../services/strings';
 import { type SwapData, type SwapIntent, SwapMode, type SwapRoute } from './types';
+import { resolveExactInAmountBasis, selectExactInQuoteOutput } from './amount-basis';
 
 // ---------------------------------------------------------------------------
 // createSwapIntent
@@ -18,6 +19,7 @@ export const createSwapIntent = (
   chainList: ChainListType
 ): SwapIntent => {
   const dstChainData = chainList.getChainByID(route.destination.chainId);
+  const exactInAmountBasis = resolveExactInAmountBasis(route.exactInAmountBasis);
 
   // Destination amount. A non-positive `toAmountRaw` in EXACT_OUT is the reservation /
   // gas-only sentinel — no tokens are delivered to the user, so the amount is "0" rather
@@ -31,7 +33,10 @@ export const createSwapIntent = (
   } else {
     // EXACT_IN: use swap output if available, else inputAmount.min
     if (route.destination.swap.tokenSwap) {
-      destinationAmount = route.destination.swap.tokenSwap.quote.output.amount;
+      destinationAmount = selectExactInQuoteOutput(
+        route.destination.swap.tokenSwap.quote,
+        exactInAmountBasis
+      ).amount;
     } else {
       destinationAmount = route.destination.inputAmount.min.toString();
     }
@@ -46,7 +51,10 @@ export const createSwapIntent = (
   if (input.mode === SwapMode.EXACT_OUT && (input.data.toAmountRaw ?? 0n) <= 0n) {
     destinationValue = '0';
   } else if (route.destination.swap.tokenSwap) {
-    destinationValue = route.destination.swap.tokenSwap.quote.output.value.toString();
+    destinationValue = selectExactInQuoteOutput(
+      route.destination.swap.tokenSwap.quote,
+      exactInAmountBasis
+    ).value.toString();
   } else {
     // No destination swap. Path A (directDestination) delivers the toToken via token-role SOURCE
     // swaps on the dst chain, so sum their aggregator-reported USD values — the direct analog of a
@@ -59,7 +67,11 @@ export const createSwapIntent = (
     const directSwapValue = route.directDestination
       ? route.source.swaps
           .filter((s) => s.chainID === route.destination.chainId && s.outputRole !== 'gas')
-          .reduce((sum, s) => sum.plus(s.quote.output.value), new Decimal(0))
+          .reduce(
+            (sum, s) =>
+              sum.plus(selectExactInQuoteOutput(s.quote, exactInAmountBasis).value),
+            new Decimal(0)
+          )
       : new Decimal(0);
     if (directSwapValue.gt(0)) {
       destinationValue = directSwapValue.toString();

--- a/src/swap/max.ts
+++ b/src/swap/max.ts
@@ -78,6 +78,7 @@ export async function calculateMaxForSwap(
     walletPathHints: preflight.walletPathHints,
     cotCurrencyId: options.cotCurrencyId,
     forceMayan: options.forceMayan ?? false,
+    exactInAmountBasis: 'minimum',
   });
   const resolvedTokenInfo = route.dstTokenInfo;
   const tokenSwap = route.destination.swap.tokenSwap;

--- a/src/swap/route.ts
+++ b/src/swap/route.ts
@@ -19,6 +19,7 @@ import type {
   WalletPath,
 } from './types';
 import { SwapMode } from './types';
+import { type ExactInAmountBasis, resolveExactInAmountBasis, selectExactInQuoteOutput } from './amount-basis';
 
 export type RouteOptions = {
   aggregators: Aggregator[];
@@ -36,6 +37,8 @@ export type RouteOptions = {
   quoteAddressHints?: Map<number, Hex>;
   forceMayan: boolean;
   timing?: TimingSpanHooks;
+  // Exact In only. Direct internal route callers default conservatively to protected minimums.
+  exactInAmountBasis?: ExactInAmountBasis;
   // Recursion stop for the B2 dynamic-COT re-entry: when a fast path re-enters `_exactInRoute` /
   // `_exactOutRoute` with an overridden `cotCurrencyId`, it sets this so the re-entered call runs
   // the default COT flow instead of re-classifying and looping. Never set by public callers.
@@ -45,6 +48,7 @@ export type RouteOptions = {
 // Never-throwing snapshot of a built route for the debug trace, so a tester (or we)
 // can reconstruct the exact scenario from the real amounts instead of guessing inputs.
 const summarizeRouteForLog = (input: SwapData, route: SwapRoute) => {
+  const amountBasis = resolveExactInAmountBasis(route.exactInAmountBasis);
   const decimal = (value: Decimal | null | undefined) => value?.toFixed();
   const mayanLeg = (q: unknown) => {
     const m = (q ?? {}) as Record<string, unknown>;
@@ -57,6 +61,7 @@ const summarizeRouteForLog = (input: SwapData, route: SwapRoute) => {
   try {
     return {
       mode: input.mode,
+      ...(input.mode === SwapMode.EXACT_IN ? { exactInAmountBasis: amountBasis } : {}),
       toChainId: input.data.toChainId,
       toToken: input.data.toTokenAddress,
       sourceBuffer: decimal(route.source?.srcBuffer),
@@ -64,7 +69,10 @@ const summarizeRouteForLog = (input: SwapData, route: SwapRoute) => {
         chainId: s.chainID,
         inputAmount: s.quote?.input?.amount,
         inputSymbol: s.quote?.input?.symbol,
-        outputAmount: s.quote?.output?.amount,
+        outputAmount:
+          input.mode === SwapMode.EXACT_IN
+            ? selectExactInQuoteOutput(s.quote, amountBasis).amount
+            : s.quote?.output?.amount,
         outputSymbol: s.quote?.output?.symbol,
       })),
       bridge: route.bridge
@@ -134,11 +142,5 @@ export const determineSwapRoute = async (
 
 export { resolveWalletDecisions } from './routing/addresses';
 export { enrichMayanBridge } from './routing/bridge';
-export {
-  classifyFastPath,
-  type FastPathClass,
-} from './routing/fast-paths';
-export {
-  greedyUsdPrefix,
-  selectRoughEligibleSources,
-} from './routing/holdings';
+export { classifyFastPath, type FastPathClass } from './routing/fast-paths';
+export { greedyUsdPrefix, selectRoughEligibleSources } from './routing/holdings';

--- a/src/swap/route.ts
+++ b/src/swap/route.ts
@@ -71,7 +71,9 @@ const summarizeRouteForLog = (input: SwapData, route: SwapRoute) => {
         inputSymbol: s.quote?.input?.symbol,
         outputAmount:
           input.mode === SwapMode.EXACT_IN
-            ? selectExactInQuoteOutput(s.quote, amountBasis).amount
+            ? s.quote
+              ? selectExactInQuoteOutput(s.quote, amountBasis).amount
+              : undefined
             : s.quote?.output?.amount,
         outputSymbol: s.quote?.output?.symbol,
       })),

--- a/src/swap/routing/bridge.ts
+++ b/src/swap/routing/bridge.ts
@@ -11,10 +11,21 @@ import { Errors } from '../../domain/errors';
 import { logger } from '../../domain/utils';
 import { isNativeAddress } from '../../services/addresses';
 import { divDecimals, mulDecimals } from '../../services/math';
-import { MAYAN_MIN_USD_PER_LEG, quoteMayanLegs } from '../../services/mayan';
+import {
+  MAYAN_MIN_USD_PER_LEG,
+  quoteMayanLegs,
+  selectMayanQuoteOutput,
+} from '../../services/mayan';
 import type { QuoteResponse } from '../aggregators/types';
+import { resolveExactInAmountBasis, selectExactInQuoteOutput } from '../amount-basis';
 import { resolveCOT } from '../cot';
-import type { BridgeAsset, BridgeQuoteResponse, SourceChainCOT, SwapRoute } from '../types';
+import type {
+  BridgeAsset,
+  BridgeQuoteResponse,
+  NexusFeeModel,
+  SourceChainCOT,
+  SwapRoute,
+} from '../types';
 import type { RouteOptions } from '../route';
 
 // Decide the bridge provider (Mayan vs Nexus) once, at the start of a route, by asking the
@@ -221,7 +232,7 @@ export const estimateBridgeFees = async (
 // src/bridge/intent/creator.ts.
 export const enrichMayanBridge = async (
   bridge: NonNullable<SwapRoute['bridge']>,
-  options: Pick<RouteOptions, 'chainList' | 'middlewareClient'>
+  options: Pick<RouteOptions, 'chainList' | 'middlewareClient' | 'exactInAmountBasis'>
 ): Promise<NonNullable<SwapRoute['bridge']>> => {
   // Defensive: destination check is also done up-front in determineSwapRoute when
   // forceMayan is true, but the threshold path can also land us here.
@@ -282,8 +293,9 @@ export const enrichMayanBridge = async (
     (sum, asset) => sum.plus(asset.eoaBalance).plus(asset.ephemeralBalance),
     new Decimal(0)
   );
+  const amountBasis = resolveExactInAmountBasis(options.exactInAmountBasis);
   const delivered = [...mayanQuotesBySource.values()].reduce(
-    (sum, quote) => sum.plus(new Decimal(quote.minReceived.toString())),
+    (sum, quote) => sum.plus(selectMayanQuoteOutput(quote, bridge.decimals, amountBasis)),
     new Decimal(0)
   );
   const haircut = Decimal.max(grossBridged.minus(delivered), new Decimal(0));
@@ -359,12 +371,34 @@ export const computeBridgeFees = (params: {
   estimatedFees: NonNullable<SwapRoute['bridge']>['estimatedFees'];
   totalFeeAmount: Decimal;
   deliveredAmount: Decimal;
+  nexusFeeModel: NexusFeeModel;
 } => {
-  const fulfilment = divDecimals(
-    params.quoteResponse.destination.fulfillmentFeeToken,
-    params.dstCOTDecimals
-  );
-  const protocol = params.grossBridged.mul(params.quoteResponse.fulfillmentBps).div(10000);
+  const nexusFeeModel = {
+    fulfillmentFee: divDecimals(
+      params.quoteResponse.destination.fulfillmentFeeToken,
+      params.dstCOTDecimals
+    ),
+    fulfillmentBps: new Decimal(params.quoteResponse.fulfillmentBps),
+  };
+  return {
+    ...computeNexusBridgeFees({
+      nexusFeeModel,
+      grossBridged: params.grossBridged,
+    }),
+    nexusFeeModel,
+  };
+};
+
+export const computeNexusBridgeFees = (params: {
+  nexusFeeModel: NexusFeeModel;
+  grossBridged: Decimal;
+}): {
+  estimatedFees: NonNullable<SwapRoute['bridge']>['estimatedFees'];
+  totalFeeAmount: Decimal;
+  deliveredAmount: Decimal;
+} => {
+  const fulfilment = params.nexusFeeModel.fulfillmentFee;
+  const protocol = params.grossBridged.mul(params.nexusFeeModel.fulfillmentBps).div(10000);
   // Collection (per-source deposit) fee only applies when the EOA funds the bridge directly,
   // which our smart-account-only model no longer supports — bridge funding always flows
   // through the ephemeral, which the solver covers gas for. Keep the field for the public
@@ -396,11 +430,13 @@ export const buildBridgeAssetsAndFees = (input: {
   currencyId: number;
   bridgeQuoteResponse: BridgeQuoteResponse | null | undefined;
   dstCOTDecimals: number;
+  exactInAmountBasis?: RouteOptions['exactInAmountBasis'];
 }): {
   assets: BridgeAsset[];
   grossBridged: Decimal;
   feeSummary: ReturnType<typeof computeBridgeFees> | null;
 } => {
+  const amountBasis = resolveExactInAmountBasis(input.exactInAmountBasis);
   const assetsByChain = new Map<number, BridgeAsset>();
   for (const swap of input.quoteResponses) {
     if (swap.chainID === input.destinationChainId) continue;
@@ -410,7 +446,7 @@ export const buildBridgeAssetsAndFees = (input: {
       contractAddress: cot?.address ?? swap.quote.output.contractAddress,
       decimals: cot?.decimals ?? swap.quote.output.decimals,
       balance: 'ephemeralBalance',
-      amount: new Decimal(swap.quote.output.amount),
+      amount: new Decimal(selectExactInQuoteOutput(swap.quote, amountBasis).amount),
     });
   }
   for (const source of input.cotSources) {

--- a/src/swap/routing/exact-in.ts
+++ b/src/swap/routing/exact-in.ts
@@ -3,7 +3,7 @@ import { formatUnits, type Hex } from 'viem';
 import { Errors } from '../../domain/errors';
 import { logger } from '../../domain/utils';
 import { divDecimals, mulDecimals } from '../../services/math';
-import { MAYAN_MIN_USD_PER_LEG } from '../../services/mayan';
+import { MAYAN_MIN_USD_PER_LEG, selectMayanQuoteOutput } from '../../services/mayan';
 import { equalFold } from '../../services/strings';
 import { withTimingSpan } from '../../services/timing';
 import { destinationSwapWithExactIn } from '../algorithms/destination';
@@ -12,6 +12,7 @@ import { DST_RECLAIM_DEDUCTION_PCT } from '../constants';
 import { resolveCOT, resolveSwapSettlement } from '../cot';
 import type { AssetsUsedEntry, DestinationSwap, SwapRoute } from '../types';
 import { SwapMode } from '../types';
+import { resolveExactInAmountBasis, selectExactInQuoteOutput } from '../amount-basis';
 import type { RouteOptions } from '../route';
 import {
   buildExecutorAddressByChain,
@@ -190,6 +191,7 @@ const buildExactInBridge = async (input: {
         currencyId: input.currencyId,
         bridgeQuoteResponse: input.options.bridgeQuoteResponse,
         dstCOTDecimals: input.dstCOT.decimals,
+        exactInAmountBasis: input.options.exactInAmountBasis,
       });
       if (!feeSummary) {
         return { bridge: null, cotAvailableForDestination: input.cotAvailableForDestination };
@@ -198,6 +200,7 @@ const buildExactInBridge = async (input: {
         estimatedFees,
         totalFeeAmount,
         deliveredAmount: effectiveBridgedToDestination,
+        nexusFeeModel,
       } = feeSummary;
       if (effectiveBridgedToDestination.lte(0)) {
         throw Errors.insufficientBalance(
@@ -220,6 +223,7 @@ const buildExactInBridge = async (input: {
         decimals: input.dstCOT.decimals,
         tokenAddress: input.dstCOT.address as Hex,
         estimatedFees,
+        ...(input.bridgeProvider === 'nexus' ? { nexusFeeModel } : {}),
         provider: input.bridgeProvider,
       };
 
@@ -227,7 +231,15 @@ const buildExactInBridge = async (input: {
         bridge = await enrichMayanBridge(bridge, input.options);
         if (bridge.mayanQuotesBySource) {
           const mayanDelivered = [...bridge.mayanQuotesBySource.values()].reduce(
-            (sum, quote) => Decimal.add(sum, new Decimal(quote.minReceived.toString())),
+            (sum, quote) =>
+              Decimal.add(
+                sum,
+                selectMayanQuoteOutput(
+                  quote,
+                  bridge.decimals,
+                  resolveExactInAmountBasis(input.options.exactInAmountBasis)
+                )
+              ),
             new Decimal(0)
           );
           cotAvailableForDestination = input.destinationChainCot.plus(mayanDelivered);
@@ -253,6 +265,7 @@ const buildExactInBridge = async (input: {
 export async function _exactInRoute(data: ExactInData, options: RouteOptions): Promise<SwapRoute> {
   const { aggregators, chainList, oraclePrices, dstTokenInfo, walletPathHints } = options;
   const destinationChain = chainList.getChainByID(data.toChainId);
+  const exactInAmountBasis = resolveExactInAmountBasis(options.exactInAmountBasis);
 
   // Build holdings from input
   const rawHoldings = await withTimingSpan(
@@ -424,7 +437,7 @@ export async function _exactInRoute(data: ExactInData, options: RouteOptions): P
     totalCOT = totalCOT.plus(divDecimals(c.amountRaw, cot.decimals));
   }
   for (const q of sourceSwaps) {
-    totalCOT = totalCOT.plus(q.quote.output.amount);
+    totalCOT = totalCOT.plus(selectExactInQuoteOutput(q.quote, exactInAmountBasis).amount);
   }
 
   let dstSwap: DestinationSwap = { tokenSwap: null, gasSwap: null };
@@ -441,7 +454,10 @@ export async function _exactInRoute(data: ExactInData, options: RouteOptions): P
   // a real under-sized dst swap otherwise). Mirrors `_exactOutRoute`'s `destinationChainSwapCot`.
   const destinationChainSwapCot = sourceSwaps
     .filter((q) => q.chainID === data.toChainId)
-    .reduce((sum, q) => sum.plus(q.quote.output.amount), new Decimal(0));
+    .reduce(
+      (sum, q) => sum.plus(selectExactInQuoteOutput(q.quote, exactInAmountBasis).amount),
+      new Decimal(0)
+    );
   const destinationChainCot = destinationChainDirectCot.plus(destinationChainSwapCot);
   const { bridge, cotAvailableForDestination } = allOnDstChain
     ? { bridge: null, cotAvailableForDestination: totalCOT }
@@ -515,6 +531,7 @@ export async function _exactInRoute(data: ExactInData, options: RouteOptions): P
     'flow.swap.route.assemble',
     async (): Promise<SwapRoute> => ({
       type: SwapMode.EXACT_IN,
+      exactInAmountBasis,
       settlementCurrencyId: currencyId,
       sameTokenBridge: false,
       source: {

--- a/src/swap/routing/exact-in.ts
+++ b/src/swap/routing/exact-in.ts
@@ -8,7 +8,6 @@ import { equalFold } from '../../services/strings';
 import { withTimingSpan } from '../../services/timing';
 import { destinationSwapWithExactIn } from '../algorithms/destination';
 import { liquidateInputHoldings } from '../algorithms/liquidate';
-import { DST_RECLAIM_DEDUCTION_PCT } from '../constants';
 import { resolveCOT, resolveSwapSettlement } from '../cot';
 import type { AssetsUsedEntry, DestinationSwap, SwapRoute } from '../types';
 import { SwapMode } from '../types';
@@ -568,14 +567,13 @@ export async function _exactInRoute(data: ExactInData, options: RouteOptions): P
           max: cotAvailableForDestination,
         },
         swap: dstSwap,
-        // Re-size the dst swap from the COT that actually landed at the wrapper (`actualCotRaw`): the
-        // input tracks that balance (less a small deduction). No floor and no upper clamp — `actual` IS
-        // the real on-chain balance and `deducted < actual`, so it can never over-spend; the source
-        // reclaim can deliver above the route estimate and that surplus is spent here, not swept.
+        // Re-size the dst swap from the COT that actually landed at the wrapper (`actualCotRaw`). No
+        // floor and no upper clamp — `actual` IS the real on-chain balance, and Exact In must consume
+        // it completely so settlement-token dust is not returned to the user. The source reclaim can
+        // deliver above the route estimate and that surplus is converted here too.
         getDstSwap: (actualCotRaw: bigint) => {
           const actual = divDecimals(actualCotRaw, dstCOT.decimals);
-          const execInput = actual.mul(new Decimal(1).minus(DST_RECLAIM_DEDUCTION_PCT));
-          return quoteDstSwapAtInput(execInput);
+          return quoteDstSwapAtInput(actual);
         },
       },
       // EXACT_IN has no buffer (no source buffer, no dst buffer).

--- a/src/swap/routing/exact-out.ts
+++ b/src/swap/routing/exact-out.ts
@@ -376,7 +376,7 @@ const buildExactOutBridge = async (input: {
       if (!feeSummary) {
         throw Errors.internal('Bridge assets unavailable -- cannot route cross-chain swap');
       }
-      const { estimatedFees, deliveredAmount } = feeSummary;
+      const { estimatedFees, deliveredAmount, nexusFeeModel } = feeSummary;
       const deliveredTokenAmount = Decimal.max(
         deliveredAmount.minus(input.gasInCot),
         new Decimal(0)
@@ -394,6 +394,7 @@ const buildExactOutBridge = async (input: {
         decimals: input.dstCOT.decimals,
         tokenAddress: input.dstCOT.address as Hex,
         estimatedFees,
+        ...(input.bridgeProvider === 'nexus' ? { nexusFeeModel } : {}),
         provider: input.bridgeProvider,
       };
       if (input.bridgeProvider === 'mayan') {

--- a/src/swap/routing/fast-paths.ts
+++ b/src/swap/routing/fast-paths.ts
@@ -6,6 +6,7 @@ import { Errors } from '../../domain/errors';
 import { logger } from '../../domain/utils';
 import { isNativeAddress } from '../../services/addresses';
 import { divDecimals, mulDecimals } from '../../services/math';
+import { selectMayanQuoteOutput } from '../../services/mayan';
 import { estimateRepresentativeSwapNativeReserveFee } from '../../services/swap-native-reserve-fee';
 import { equalFold } from '../../services/strings';
 import { withTimingSpan } from '../../services/timing';
@@ -18,8 +19,15 @@ import {
 import { liquidateInputHoldings } from '../algorithms/liquidate';
 import { B2_STABLE_CURRENCY_IDS } from '../constants';
 import { type CurrencyID, resolveCOT, resolveCurrencyId } from '../cot';
-import type { AssetsUsedEntry, BridgeAsset, SourceChainCOT, SwapRoute } from '../types';
+import type {
+  AssetsUsedEntry,
+  BridgeAsset,
+  NexusFeeModel,
+  SourceChainCOT,
+  SwapRoute,
+} from '../types';
 import { SwapMode } from '../types';
+import { resolveExactInAmountBasis, selectExactInQuoteOutput } from '../amount-basis';
 import type { RouteOptions } from '../route';
 import {
   buildExecutorAddressByChain,
@@ -199,6 +207,7 @@ export async function buildDirectDestinationExactInRoute(
   const { aggregators, chainList, oraclePrices, dstTokenInfo, walletPathHints } = options;
   const dstChainId = data.toChainId;
   const toTokenAddress = data.toTokenAddress;
+  const exactInAmountBasis = resolveExactInAmountBasis(options.exactInAmountBasis);
 
   // Split identity holdings (already the destination token) from those needing a swap.
   const identityHoldings = holdings.filter((h) => isSameSwapToken(h.tokenAddress, toTokenAddress));
@@ -253,7 +262,12 @@ export async function buildDirectDestinationExactInRoute(
   // Total delivered = Σ swap outputs (toToken) + Σ identity holdings (already toToken).
   const swappedDelivered = swaps.reduce(
     (sum, quote) =>
-      sum.plus(divDecimals(quote.quote.output.amountRaw, quote.quote.output.decimals)),
+      sum.plus(
+        divDecimals(
+          selectExactInQuoteOutput(quote.quote, exactInAmountBasis).amountRaw,
+          quote.quote.output.decimals
+        )
+      ),
     new Decimal(0)
   );
   const identityDelivered = identityHoldings.reduce(
@@ -275,6 +289,7 @@ export async function buildDirectDestinationExactInRoute(
     'flow.swap.route.assemble',
     async (): Promise<SwapRoute> => ({
       type: SwapMode.EXACT_IN,
+      exactInAmountBasis,
       // No bridge/cleanup on Path A (directDestination skips the sweep), but keep the COT for the
       // public surface's settlement currency.
       settlementCurrencyId: options.cotCurrencyId,
@@ -465,6 +480,7 @@ const finalizeSameTokenBridge = async (
     grossBridged: Decimal;
     tokenAmount: Decimal;
     fees: NonNullable<SwapRoute['bridge']>['estimatedFees'];
+    nexusFeeModel: NexusFeeModel;
     dstChainId: number;
     dstTokenAddress: Hex;
     dstTokenDecimals: number;
@@ -508,6 +524,7 @@ const finalizeSameTokenBridge = async (
         decimals: params.dstTokenDecimals,
         tokenAddress: params.dstTokenAddress,
         estimatedFees: params.fees,
+        ...(provider === 'nexus' ? { nexusFeeModel: params.nexusFeeModel } : {}),
         provider,
       };
       return provider === 'mayan' ? enrichMayanBridge(bridge, options) : bridge;
@@ -535,6 +552,7 @@ export async function buildSameTokenBridgeRoute(
 ): Promise<SwapRoute> {
   const { oraclePrices, dstTokenInfo, walletPathHints, aggregators } = options;
   const dstChainId = data.toChainId;
+  const exactInAmountBasis = resolveExactInAmountBasis(options.exactInAmountBasis);
   // Swap internals carry native as EADDRESS, but the bridge intent's `getTokenByAddress` lookup
   // only resolves ZERO_ADDRESS as native — normalize both the bridged token and source assets.
   const dstTokenAddress: Hex = isNativeAddress(dstTokenInfo.contractAddress)
@@ -579,6 +597,7 @@ export async function buildSameTokenBridgeRoute(
       estimatedFees: fees,
       totalFeeAmount: totalFee,
       deliveredAmount,
+      nexusFeeModel,
     } = computeBridgeFees({
       quoteResponse: bridgeQuoteResponse,
       grossBridged: bridgedToken,
@@ -599,6 +618,7 @@ export async function buildSameTokenBridgeRoute(
         grossBridged: bridgedToken,
         tokenAmount: deliveredFromBridge,
         fees,
+        nexusFeeModel,
         dstChainId,
         dstTokenAddress,
         dstTokenDecimals: dstTokenInfo.decimals,
@@ -606,8 +626,10 @@ export async function buildSameTokenBridgeRoute(
       options
     );
     if (bridge.provider === 'mayan' && bridge.mayanQuotesBySource) {
+      const bridgeDecimals = bridge.decimals;
       deliveredFromBridge = [...bridge.mayanQuotesBySource.values()].reduce(
-        (sum, quote) => sum.plus(new Decimal(quote.minReceived.toString())),
+        (sum, quote) =>
+          sum.plus(selectMayanQuoteOutput(quote, bridgeDecimals, exactInAmountBasis)),
         new Decimal(0)
       );
       bridge = {
@@ -635,6 +657,7 @@ export async function buildSameTokenBridgeRoute(
     'flow.swap.route.assemble',
     async (): Promise<SwapRoute> => ({
       type: SwapMode.EXACT_IN,
+      exactInAmountBasis,
       settlementCurrencyId,
       sameTokenBridge: true,
       source: {
@@ -760,7 +783,7 @@ export async function buildSameTokenBridgeExactOutRoute(
     );
   }
 
-  const { estimatedFees: fees } = computeBridgeFees({
+  const { estimatedFees: fees, nexusFeeModel } = computeBridgeFees({
     quoteResponse: fQuote,
     grossBridged,
     dstCOTDecimals: dstTokenInfo.decimals,
@@ -771,6 +794,7 @@ export async function buildSameTokenBridgeExactOutRoute(
       grossBridged,
       tokenAmount: toAmountHuman,
       fees,
+      nexusFeeModel,
       dstChainId,
       dstTokenAddress,
       dstTokenDecimals: dstTokenInfo.decimals,

--- a/src/swap/swap.md
+++ b/src/swap/swap.md
@@ -59,6 +59,10 @@ untested (this map exists because that scoping mistake has bitten twice):
   descends from `options.cotCurrencyId`, and `settlementCurrencyId` records the family actually used.
 - **Modes.** `EXACT_OUT` (deliver a fixed output) and `EXACT_IN` (spend fixed inputs). A
   **negative `toAmountRaw`** in EXACT_OUT is a reservation / gas‑only sentinel.
+- **Exact In amount basis.** Internally, every Exact In route carries one basis through all forward
+  sizing: `'expected'` for normal `swapWithExactIn` previews and `'minimum'` for
+  `calculateMaxForSwap`. Direct internal route calls default to `'minimum'`. The basis is not public;
+  Exact Out is unchanged. It selects route economics only—execution fields remain protected.
 - **Smart‑account‑only.** A swap is **never dispatched directly from the EOA**. Execution always
   runs through a per‑chain smart account, of which there are **two implemented kinds**
   (`WalletPath = 'ephemeral' | 'safe'`):
@@ -301,12 +305,12 @@ their amount propagation and requote policies remain mode-owned.
 
 `RouteOptions = { aggregators, bridgeQuoteResponse, chainList, cotCurrencyId, middlewareClient,
 publicClientList, oraclePrices, dstTokenInfo, eoaAddress, ephemeralAddress, balances,
-walletPathHints, quoteAddressHints? }`. Returned `SwapRoute`:
+walletPathHints, quoteAddressHints?, exactInAmountBasis? }`. Returned `SwapRoute`:
 
 ```text
 { type, source:{swaps[], creationTime, srcBuffer, cotByChain?},
   bridge: null | {amount, amounts:{tokenAmount,gasInCot,totalAmount}, assets[], chainID,
-                  decimals, tokenAddress, estimatedFees},
+                  decimals, tokenAddress, estimatedFees, nexusFeeModel?},
   destination:{chainId, eoaToEphemeral, inputAmount:{min,max}, swap:{tokenSwap,gasSwap}, getDstSwap()},
   buffer:{amount}, dstTokenInfo,
   extras:{aggregators,oraclePrices,balances,assetsUsed,
@@ -387,6 +391,7 @@ determineSwapRoute(input, opts) -> SwapRoute:
 
   # ── EXACT_IN ──
   if EXACT_IN:
+    basis = exactInAmountBasis ?? 'minimum'  # public preview passes expected; calculateMax passes minimum
     rawHoldings = resolveSources(sources)   # amountRaw absent ⇒ full balance; requested > balance ⇒ throw
     cot = resolveCOT(toChainId, chainList, cotCurrencyId)
     # ── Path A: direct destination swap (fast-path, gated FIRST) ── unless options.skipFastPaths:
@@ -418,18 +423,22 @@ determineSwapRoute(input, opts) -> SwapRoute:
       holdings = dropSubFloorMayanChains(rawHoldings)                # drop chains whose SELECTED USD < floor
       if holdings empty: throw "Mayan bridge requires ≥ $MAYAN_MIN_USD_PER_LEG per source …"
     source        = liquidateInputHoldings(holdings)                 # §6 (COT holdings skipped)
+    sourceCOT     = Σ select(source.quote, basis) + direct COT       # one selected amount per stage
     # no source buffer: source.srcBuffer = null (a failed leg re-quotes and proceeds, no drift guard)
-    dstQuoteInput = cotAvailable            # full; dst-swap floor (inputAmount.min) = 0 — Seam 2 tracks actuals
+    dstQuoteInput = cotAvailable            # expected/minimum source→bridge delivery under the selected basis
     buffer.amount = 0                        # EXACT_IN has no buffer (no source, no dst)
 
   # ── bridge ──
   bridge = (all source COT on toChainId) ? null : buildBridge(…, provider)
            # cross-chain requires bridgeQuoteResponse else throw "bridge fee quote unavailable"
            # collection fee = 0 (smart-account model); coalesce same-chain assets
-           # bridge funding → ephemeralBalance;  direct COT → eoaBalance
+           # bridge funding → ephemeralBalance; direct COT → eoaBalance
+           # Nexus applies fixed fulfillment + bps to selected gross and stores that normalized model
+           # Mayan quotes selected source amounts; expected basis chooses expectedAmountOutBaseUnits,
+           # then expectedAmountOut, then minReceived; preview fee = max(gross − selected delivery, 0)
            # dstChain COT deducted → destination.eoaToEphemeral{amount,contractAddress}
            # toNativeAmountRaw ⇒ gas swap sized off its COT input: tokenAmount + gasInCot == totalAmount
-  if provider == 'mayan': bridge = await enrichMayanBridge(bridge)   # fetch per-source quotes + validate (guard at call site)
+  if provider == 'mayan': bridge = await enrichMayanBridge(bridge)   # fetch the existing per-source quote batch + validate
 
   # ── destination swap ──
   if needTokenSwap:
@@ -458,14 +467,16 @@ determineSwapRoute(input, opts) -> SwapRoute:
 
 # getDstSwap() requote guards (execution-time, frozen bounds):
 #   EXACT_OUT: require (tokenInput + gasInput) ≤ originalBufferedMax   # max pinned, never creeps; accepted requote moves `min`
-#   EXACT_IN:  no guard — the requote is accepted whatever it returns (no rate tolerance)
+#   EXACT_IN:  mandatory balance read + resize before first dispatch; no rate-tolerance guard
 ```
 
 Balance→holding conversion uses `parseUnits` precision (no `Number()` rounding). `cotByChain`
 carries route‑resolved COT metadata into execution. `extras.assetsUsed` amounts are normalized to
 human strings (falls back to balance metadata for tokens absent from the deployment list).
 
-**`calculateMaxForSwap` haircut denomination.** The max‑amount safety haircut (`max(3%, $3)`) is kept
+**`calculateMaxForSwap` amount basis and haircut denomination.** Max routing explicitly uses the
+protected `'minimum'` basis through source, bridge, destination, and fast paths without adding quote
+requests. The max‑amount safety haircut (`max(3%, $3)`) is kept
 in USD space. When a destination token swap exists, it applies in COT space and scales to the output
 token via the swap's own ratio (unchanged). When there is **no** destination swap,
 `destination.inputAmount.max` is denominated in the *destination token itself* — USDC for the default
@@ -553,7 +564,13 @@ createAggregators(mw) → [LiFi, Bebop, Fibrous, 0x, Mystic, Relay]
 
 All adapters map a middleware response to a `Quote`, return `null` on throw/timeout, short‑circuit
 unsupported chains **without firing a request**, and send **no API‑key headers** (the proxy handles
-auth). Executable quotes use the **slippage-protected** output amount. Source-selection candidates
+auth). Every normalized `Quote` has both a required `output` (the **slippage-protected executable
+minimum**) and a required `expectedOutput` (`amountRaw`, human `amount`, and USD `value`). LiFi maps
+`toAmount`; Bebop maps `amount`; Relay, 0x, and Mystic map `amount`/`buyAmount`; Fibrous maps
+`amount_out`. Missing, malformed, non-positive, or below-minimum expected amounts normalize to
+`output`. Metadata enrichment recomputes both output and expected human/USD values for 0x/Mystic.
+Aggregator winners are still chosen only by protected `output.amountRaw` (or protected input for
+MinimizeInput), never by expected output. Source-selection candidates
 are requested as executable quotes from the outset so a fully consumed holding reuses one quote.
 Fibrous price surveys are reserved for indicative convergence seeds: they use the lighter `/v2/route`
 response, apply the configured slippage floor to `outputAmount` locally, and never enter execution;
@@ -582,7 +599,9 @@ route-scoped keyed-promise cache described in §5.
 
 ## 8. Intent, bridge intent, plan, prepare
 
-**`createSwapIntent(route, input, chainList)`** — destination amount/value (token‑swap output
+**`createSwapIntent(route, input, chainList)`** — Exact In destination amount/value use the route's
+selected basis: expected for normal previews and protected minimum for max calculations/internal
+minimum routes. Exact Out remains requested/protected as before. Destination token‑swap output
 semantics; **Path A** (`directDestination`, no dst swap) sums the token‑role source‑swap output USD
 values — oracle‑independent, the analog of a dst token‑swap's `output.value`; other no‑swap
 destinations, e.g. COT, use `amount × oraclePriceUsd`, else `amount`); reservation
@@ -594,7 +613,8 @@ from the gas‑swap output; `feesAndBuffer.bridge` set iff a bridge exists; `bri
 Ethereum sorted last; copies `bridge.provider`; the five‑field fees map from `bridge.estimatedFees`
 (`collection → deposit`, plus `fulfilment/caGas/protocol/solver`); destination amount from
 **execution‑time assets** (`executionTokenAmount = totalBridged − collection − fulfilment −
-protocol`, throws if negative); **native amount stays 0** (`gasInCot` bridged as COT for the dst gas
+protocol`, throws if negative). Nexus recomputes its stored fixed-plus-bps fee model from the
+execution-time total rather than reusing route-time absolute fees. **Native amount stays 0** (`gasInCot` bridged as COT for the dst gas
 swap). When `provider === 'mayan'` it stamps each source with its per‑source `mayanQuote` (looked up
 from `bridge.mayanQuotesBySource` by `${chainID}:${address.toLowerCase()}`; throws
 `Mayan quote missing for source …` if absent); Nexus leaves `mayanQuote` undefined.
@@ -712,7 +732,8 @@ executeSwapBridge(bridge, executedAssets, ctx, meta):   # bridges the ACTUAL wra
       if mayan: bridge = refreshMayanQuotesForExecution(bridge, bridgedAssets)   # re-quote per leg at
                 #   the FINAL bridged amount — route-time quotes were signed for the ESTIMATE, and a
                 #   source re-quote can drift the executed COT. Middleware enforces RFF source.value ==
-                #   mayanQuote.effectiveAmountIn; re-quoting here makes them match (and refreshes deadline)
+                #   mayanQuote.effectiveAmountIn; re-quoting here makes them match (and refreshes deadline).
+                #   Replace preview fees with protected accounting: max(actual gross − ΣminReceived, 0).
       intent    = createSwapBridgeIntent(bridge, bridgedAssets, recipient)   # carries provider + mayanQuotes
 
       # ── Mayan (intent.provider == 'mayan') → runMayanEphemeralBridge, then return ──
@@ -747,6 +768,9 @@ executeDestinationSwap(destination, dstTokenInfo, ctx, meta):
   # SEAM 2 (reclaim): read balanceOf(COT, dstWrapper) → re-size the dst swap input from the ACTUAL
   #   delivered COT. EXACT_IN re-sizes BOTH ways — grows on surplus (more output), shrinks when a
   #   down-drifted source delivered less (never over-size, floor 0); EXACT_OUT keeps the exact output.
+  #   EXACT_IN: the read AND a complete resized quote are mandatory before first dispatch. Either
+  #   failure consumes an attempt; 3 failures → destination-scoped error, no optimistic dispatch,
+  #   then orchestrator cleanup. EXACT_OUT keeps its best-effort surplus read.
   #   getDstSwap re-quotes with no tolerance guard (EXACT_IN) / within [floor, ceiling] (EXACT_OUT); also on expiry.
   direct EOA COT on the dst chain (destination.eoaToEphemeral) → [permit?, transferFrom](eoa→executor) prepended (BOTH paths)
   path(dstChain):
@@ -792,7 +816,7 @@ failure falls back to `0n` (never throws).
 **`createSweeperTxs(token, receiver, chainId, cache?, ephemeralOwner?)`** — the blind drain: ERC20 →
 `[approve, sweepERC20]`; native → `[approveNative(→CALIBUR), sweepERC7914(→SWEEPER)]`; a sufficient
 cached allowance drops the approve; undefined cache → safe fallback (include approve). Now reserved for
-the **failure cleanup** (§11) and the destination fallback when the `balanceOf` read fails.
+the **failure cleanup** (§11) and Exact Out's destination fallback when its best-effort balance read fails.
 
 **`buildRefundSweepCall(token, amount, eoa)`** — the success-path COT return: ONE `erc20.transfer(eoa,
 amount)` (native → bare value send). The destination swap returns the *known* leftover COT
@@ -854,7 +878,8 @@ principle is *execution tracks actuals, while route‑time quotes/buffers are co
 
 ```text
 holding.amountRaw (route)
-   │  aggregator @ route → quote.output            # the minReceived FLOOR shown to the user
+   │  aggregator @ route → quote.output (protected) + expectedOutput
+   │  EXACT_IN preview carries expected forward; calculateMax carries protected minimum
    ▼
 source swap executes ──[attempt-0 dispatch fail]──⟳ requoteFailedChains (ONCE, re-quote @ holding)
    │                       ▣ EXACT_OUT: Σnew ≥ Σold − srcBuffer (POOLED; an over-leg offsets an under-leg)
@@ -867,15 +892,15 @@ SEAM 1  balanceOf(COT, sourceWrapper)              ◄ the COT that ACTUALLY lan
 bridge assets (executed)
    ├──────────────────────────────┬──────────────────────────────────────┐
    ▼                              ▼                                       ▼
-RFF source.value = executed       MAYAN: refresh effectiveAmountIn64       NEXUS: destination = Σ(executed) − route-time fees
-   = intent.source.amountRaw       = re-quote @ the executed amount          DERIVED (not refreshed) — gives MORE on more input;
-   (Nexus deposit = RFF value,      → value == effectiveAmountIn64            the only route-time-frozen term is the FEE
+RFF source.value = executed       MAYAN: refresh effectiveAmountIn64       NEXUS: destination = Σ(executed) − recomputed fees
+   = intent.source.amountRaw       = re-quote @ the executed amount          MODEL-DERIVED — gives MORE on more input;
+   (Nexus deposit = RFF value,      → value == effectiveAmountIn64            fixed fee + bps model reapplied to actual gross
     no signed quote → no mismatch)     (the a4ba539 invariant)
    ▼
 bridge fill → COT at dstWrapper
    ▼
 SEAM 2  balanceOf(COT, dstWrapper)                 ◄ the COT that ACTUALLY arrived
-   │  dst swap re-sized: EXACT_IN tracks the actual balance BOTH ways (grow on surplus → MORE output,
+   │  dst swap re-sized: EXACT_IN MUST track the actual balance BOTH ways before any dispatch (grow on surplus → MORE output,
    │  shrink on a short source → no over-size, floor 0); EXACT_OUT keeps the EXACT output.
    │  getDstSwap ⟳ re-quote: EXACT_IN no tolerance guard; EXACT_OUT within [floor, ceiling] (≤3 attempts)
    ▼
@@ -906,8 +931,9 @@ unchanged: no buffer and no gas pass, with `inputAmount.min = Σ delivered`.
 absorbed by re‑derivation — *except* the Mayan per‑leg `effectiveAmountIn64`, the one EXACT, per‑leg,
 signed value with no buffer. A drift that's harmless elsewhere (even an UPWARD drift the pooled source
 guard waves through) breaks `value == effectiveAmountIn64`, so only Mayan needs the execution‑time
-re‑quote (`refreshMayanQuotesForExecution`). Nexus needs none: its destination is `Σ(executed) − fees`,
-a formula over the (already‑updated) inputs, so it tracks them automatically.
+re‑quote (`refreshMayanQuotesForExecution`), which also recomputes the protected haircut from actual
+input and refreshed `minReceived`. Nexus needs no quote refresh: the route stores its normalized
+fixed-plus-bps model and reapplies it to `Σ(executed)` when building the bridge intent.
 
 ### 12.2 Invariants
 

--- a/src/swap/swap.md
+++ b/src/swap/swap.md
@@ -770,14 +770,17 @@ executeDestinationSwap(destination, dstTokenInfo, ctx, meta):
   #   down-drifted source delivered less (never over-size, floor 0); EXACT_OUT keeps the exact output.
   #   EXACT_IN: the read AND a complete resized quote are mandatory before first dispatch. Either
   #   failure consumes an attempt; 3 failures → destination-scoped error, no optimistic dispatch,
-  #   then orchestrator cleanup. EXACT_OUT keeps its best-effort surplus read.
+  #   then orchestrator cleanup. The quote must consume the complete measured COT balance; an
+  #   under-consuming quote is rejected instead of returning settlement-token dust to the user.
+  #   EXACT_OUT keeps its best-effort surplus read.
   #   getDstSwap re-quotes with no tolerance guard (EXACT_IN) / within [floor, ceiling] (EXACT_OUT); also on expiry.
   direct EOA COT on the dst chain (destination.eoaToEphemeral) → [permit?, transferFrom](eoa→executor) prepended (BOTH paths)
   path(dstChain):
     ephemeral → SBC [permit?, transferFrom?, approve, swap, transfer(leftover COT → EOA)?]
     safe      → Safe.execTransaction [permit?, transferFrom?, approve, swap, transfer(leftover COT → EOA)?]
-  # leftover COT = balanceOf − consumed → ONE direct transfer → EOA (replaces the blind approve+Sweeper
-  #   drain), skipped when ≤ 0. Output token lands at the EOA (receiver=EOA) → its dust sweep is skipped;
+  # EXACT_OUT leftover COT = balanceOf − consumed → ONE direct transfer → EOA (replaces the blind
+  #   approve+Sweeper drain), skipped when ≤ 0. EXACT_IN consumes the complete balance. Output token
+  #   lands at the EOA (receiver=EOA) → its dust sweep is skipped;
   #   native output NEVER swept (EADDRESS → approveNative at the Safe → GS013). gas-swap approve+swap ride the same batch
   retry: twice (3 attempts, forced requotes) then rethrow            # no fallback sweep
   meta.dst = {chid, tx_hash, swaps[]}
@@ -901,10 +904,12 @@ bridge fill → COT at dstWrapper
    ▼
 SEAM 2  balanceOf(COT, dstWrapper)                 ◄ the COT that ACTUALLY arrived
    │  dst swap re-sized: EXACT_IN MUST track the actual balance BOTH ways before any dispatch (grow on surplus → MORE output,
-   │  shrink on a short source → no over-size, floor 0); EXACT_OUT keeps the EXACT output.
+   │  shrink on a short source → no over-size, floor 0) and MUST consume the complete measured COT;
+   │  EXACT_OUT keeps the EXACT output.
    │  getDstSwap ⟳ re-quote: EXACT_IN no tolerance guard; EXACT_OUT within [floor, ceiling] (≤3 attempts)
    ▼
-leftover = balanceOf − consumed → ONE transfer(→ EOA)   ◄ skipped if ≤ 0 (replaces the blind Sweeper drain)
+EXACT_OUT leftover = balanceOf − consumed → ONE transfer(→ EOA)   ◄ skipped if ≤ 0
+EXACT_IN requires consumed = balanceOf; otherwise fail before dispatch
 ```
 
 **Path A (directDestination) short‑circuits this graph.** EXACT_OUT selects input→toToken *directly* on
@@ -1152,11 +1157,11 @@ MAYAN  native → EOA payable vault.depositMayan{value} + reportMayanNativeTx
 
 # ── destination swap (iff destination_swap; on WRAPPER(dstChain), §9) ──
 #   funds are already at the wrapper from the bridge fill; the same-chain fast path prepends EOA→WRAPPER funding.
-(7702) → SBC  [funding?, approve(EPH→ROUTER),  swap(pullFrom=EPH,  taker=EPH,  receiver=EOA), transfer(leftover COT→EOA)?]
-(safe) → Safe [funding?, approve(SAFE→ROUTER), swap(pullFrom=SAFE, taker=SAFE, receiver=EOA), transfer(leftover COT→EOA)?]
-# receiver=EOA for BOTH the token swap and the gas swap. Leftover COT (balanceOf − consumed) → ONE direct
-# transfer → EOA (replaces the blind approve+Sweeper drain), skipped when ≤ 0. The output token lands at the
-# EOA so its dust sweep is skipped; gas-swap native → EOA, never swept.
+(7702) → SBC  [funding?, approve(EPH→ROUTER),  swap(pullFrom=EPH,  taker=EPH,  receiver=EOA), EXACT_OUT transfer(leftover COT→EOA)?]
+(safe) → Safe [funding?, approve(SAFE→ROUTER), swap(pullFrom=SAFE, taker=SAFE, receiver=EOA), EXACT_OUT transfer(leftover COT→EOA)?]
+# receiver=EOA for BOTH the token swap and the gas swap. EXACT_IN consumes the complete measured COT
+# balance or fails before dispatch. EXACT_OUT leftover COT (balanceOf − consumed) returns by one direct
+# transfer. The output token lands at the EOA so its dust sweep is skipped; gas-swap native → EOA, never swept.
 ```
 
 Two invariants this view makes explicit (both asserted by the suite):

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -19,6 +19,7 @@ import type {
 import type { Aggregator, Holding, Quote, QuoteResponse } from './aggregators/types';
 import type { CurrencyID } from './cot';
 import type { SwapCache } from './wallet/cache';
+import type { ExactInAmountBasis } from './amount-basis';
 
 export type { OraclePriceResponse, QuoteResponse };
 export type { BridgeQuoteResponse };
@@ -201,6 +202,11 @@ export type BridgeAsset = {
   ephemeralBalance: Decimal; // human-readable decimal amount
 };
 
+export type NexusFeeModel = {
+  fulfillmentFee: Decimal;
+  fulfillmentBps: Decimal;
+};
+
 export type DestinationSwap = {
   tokenSwap: QuoteResponse | null;
   gasSwap: QuoteResponse | null;
@@ -214,6 +220,8 @@ export type SourceChainCOT = {
 
 export type SwapRoute = {
   type: SwapMode;
+  // Present on Exact In routes; omitted on Exact Out. Internal callers default to `minimum`.
+  exactInAmountBasis?: ExactInAmountBasis;
   // Currency the route settles/bridges in (the destination family for a same-token bridge, else
   // the COT/USDC). Drives the on-failure cleanup sweep's `currencyId`.
   settlementCurrencyId: number;
@@ -257,6 +265,8 @@ export type SwapRoute = {
       protocol: Decimal; // human-readable decimal amount (stubbed to 0)
       solver: Decimal; // human-readable decimal amount (stubbed to 0)
     };
+    // Retained so execution can apply the fixed-plus-bps model to actual bridged balances.
+    nexusFeeModel?: NexusFeeModel;
     provider: BridgeProvider;
     // Populated only when provider === 'mayan'. Keyed by `${chainID}:${contractAddress.toLowerCase()}`.
     mayanQuotesBySource?: Map<string, MayanQuote>;

--- a/tests/flows/characterization/swap-pipeline.test.ts
+++ b/tests/flows/characterization/swap-pipeline.test.ts
@@ -2118,6 +2118,8 @@ const makeExactInScenario = (scenario: ExactInScenario): ExactInScenarioContext 
 
 const runExactInScenario = async (scenario: ExactInScenario): Promise<ExactInHarnessResult> => {
   const ctx = makeExactInScenario(scenario);
+  let destinationWrapperCotRaw = 0n;
+  const sourceWrapperCotRawByAddress = new Map<string, bigint>();
 
   hoisted.readContract.mockImplementation(async ({ address, functionName }: { address: Hex; functionName: string }) => {
     const normalized = address.toLowerCase();
@@ -2129,6 +2131,11 @@ const runExactInScenario = async (scenario: ExactInScenario): Promise<ExactInHar
     }
     if (functionName === 'allowance') {
       return 0n;
+    }
+    if (functionName === 'balanceOf') {
+      return normalized === USDC_BASE.toLowerCase()
+        ? destinationWrapperCotRaw
+        : (sourceWrapperCotRawByAddress.get(normalized) ?? 0n);
     }
     if (functionName === 'name') {
       if (normalized === SOURCE_DAI.toLowerCase()) return 'Dai Stablecoin';
@@ -2183,6 +2190,17 @@ const runExactInScenario = async (scenario: ExactInScenario): Promise<ExactInHar
     forceMayan: false,
     preflight,
   });
+  destinationWrapperCotRaw = toRawAmount(
+    previewState.route.destination.inputAmount.max,
+    previewState.route.destination.swap.tokenSwap?.quote.input.decimals ?? 6
+  );
+  for (const swap of previewState.route.source.swaps) {
+    const key = swap.quote.output.contractAddress.toLowerCase();
+    sourceWrapperCotRawByAddress.set(
+      key,
+      (sourceWrapperCotRawByAddress.get(key) ?? 0n) + swap.quote.output.amountRaw
+    );
+  }
 
   const preparedExecution = await prepareSwapExecution({
     chainList: ctx.chainList,

--- a/tests/helpers/quote.ts
+++ b/tests/helpers/quote.ts
@@ -1,0 +1,28 @@
+import type { Quote, QuoteResponse } from '../../src/swap/aggregators/types';
+
+export type QuoteFixture = Omit<Quote, 'expectedOutput'> | Quote;
+
+export type QuoteResponseFixtureOverrides = Omit<Partial<QuoteResponse>, 'quote'> & {
+  quote?: QuoteFixture;
+};
+
+export const quoteFixture = (quote: QuoteFixture): Quote => ({
+  ...quote,
+  expectedOutput:
+    'expectedOutput' in quote
+      ? quote.expectedOutput
+      : {
+          amountRaw: quote.output.amountRaw,
+          amount: quote.output.amount,
+          value: quote.output.value,
+        },
+});
+
+export const quoteResponseFixture = (
+  base: Omit<QuoteResponse, 'quote'> & { quote: QuoteFixture },
+  overrides?: QuoteResponseFixtureOverrides
+): QuoteResponse => ({
+  ...base,
+  ...overrides,
+  quote: quoteFixture(overrides?.quote ?? base.quote),
+});

--- a/tests/services/mayan.test.ts
+++ b/tests/services/mayan.test.ts
@@ -1,6 +1,11 @@
 import { type Hex, toHex } from 'viem';
 import { describe, expect, it } from 'vitest';
-import { MAYAN_MIN_USD_PER_LEG, MAYAN_SLIPPAGE_BPS, quoteMayanLegs } from '../../src/services/mayan';
+import {
+  MAYAN_MIN_USD_PER_LEG,
+  MAYAN_SLIPPAGE_BPS,
+  quoteMayanLegs,
+  selectMayanQuoteOutput,
+} from '../../src/services/mayan';
 import type { MayanQuote, MayanQuoteRequest } from '../../src/transport';
 import { makeMiddlewareClient } from '../helpers/middleware-client';
 
@@ -146,5 +151,43 @@ describe('quoteMayanLegs', () => {
 
   it('pins the Mayan slippage bps', () => {
     expect(MAYAN_SLIPPAGE_BPS).toBe(5);
+  });
+});
+
+describe('selectMayanQuoteOutput', () => {
+  const quote = (overrides: Record<string, unknown> = {}) =>
+    ({
+      minReceived: 9.8,
+      expectedAmountOut: 9.9,
+      expectedAmountOutBaseUnits: '10000000',
+      ...overrides,
+    }) as unknown as MayanQuote;
+
+  it('prefers positive expected base units at destination decimals', () => {
+    expect(selectMayanQuoteOutput(quote(), 6, 'expected').toFixed()).toBe('10');
+  });
+
+  it('falls back from malformed base units to the human expected amount', () => {
+    expect(
+      selectMayanQuoteOutput(
+        quote({ expectedAmountOutBaseUnits: 'invalid', expectedAmountOut: 9.9 }),
+        6,
+        'expected'
+      ).toFixed()
+    ).toBe('9.9');
+  });
+
+  it('falls below-minimum expected values back to minReceived', () => {
+    expect(
+      selectMayanQuoteOutput(
+        quote({ expectedAmountOutBaseUnits: '9700000', expectedAmountOut: 9.7 }),
+        6,
+        'expected'
+      ).toFixed()
+    ).toBe('9.8');
+  });
+
+  it('always selects minReceived in minimum mode', () => {
+    expect(selectMayanQuoteOutput(quote(), 6, 'minimum').toFixed()).toBe('9.8');
   });
 });

--- a/tests/services/quote-parser.test.ts
+++ b/tests/services/quote-parser.test.ts
@@ -4,12 +4,13 @@ import ERC20ABI, { ERC20PermitABI } from '../../src/abi/erc20';
 import { parseQuote } from '../../src/services/quote-parser';
 import type { Quote } from '../../src/swap/aggregators/types';
 import { EADDRESS } from '../../src/swap/constants';
+import { quoteFixture } from '../helpers/quote';
 
 const TOKEN = '0xaf88d065e77c8cc2239327c5edb3a432268e5831' as Hex;
 const ROUTER = '0x2222222222222222222222222222222222222222' as Hex;
 const APPROVAL = '0x1111111111111111111111111111111111111111' as Hex;
 
-const makeQuote = (inputToken = TOKEN): Quote => ({
+const makeQuote = (inputToken = TOKEN): Quote => quoteFixture({
   input: {
     contractAddress: inputToken,
     amount: '3000',

--- a/tests/swap/aggregators/aggregate.test.ts
+++ b/tests/swap/aggregators/aggregate.test.ts
@@ -16,7 +16,11 @@ import { EADDRESS } from '../../../src/swap/constants';
 import { ZERO_ADDRESS } from '../../../src/domain/constants/addresses';
 import { logger } from '../../../src/domain/utils';
 
-const makeQuote = (outputAmountRaw: bigint, inputAmountRaw = 1000000n): Quote => ({
+const makeQuote = (
+  outputAmountRaw: bigint,
+  inputAmountRaw = 1000000n,
+  expectedAmountRaw?: bigint
+): Quote => ({
   input: {
     contractAddress: '0x01' as `0x${string}`,
     amount: inputAmountRaw.toString(),
@@ -32,6 +36,11 @@ const makeQuote = (outputAmountRaw: bigint, inputAmountRaw = 1000000n): Quote =>
     decimals: 18,
     value: 1,
     symbol: 'WETH',
+  },
+  expectedOutput: {
+    amountRaw: expectedAmountRaw ?? outputAmountRaw,
+    amount: (expectedAmountRaw ?? outputAmountRaw).toString(),
+    value: 1,
   },
   txData: {
     approvalAddress: '0x03' as `0x${string}`,
@@ -70,6 +79,21 @@ describe('aggregateAggregators', () => {
     expect(results[0].quote).not.toBeNull();
     expect(results[0].quote!.output.amountRaw).toBe(950000n);
     expect(results[0].aggregator).toBe(aggB);
+  });
+
+  it('selects by protected output even when another quote has a higher expected output', async () => {
+    const betterMinimum = makeAggregator([makeQuote(950000n, 1000000n, 960000n)]);
+    const betterExpected = makeAggregator([makeQuote(940000n, 1000000n, 990000n)]);
+
+    const [result] = await aggregateAggregators(
+      [makeRequest()],
+      [betterMinimum, betterExpected],
+      AggregateMode.MaximizeOutput
+    );
+
+    expect(result.aggregator).toBe(betterMinimum);
+    expect(result.quote!.output.amountRaw).toBe(950000n);
+    expect(result.quote!.expectedOutput.amountRaw).toBe(960000n);
   });
 
   it('picks lowest input in MinimizeInput mode', async () => {
@@ -196,6 +220,11 @@ describe('aggregateAggregators — sibling backfill (price-less 0x)', () => {
     expect(res.quote!.output.symbol).toBe('WETH'); // borrowed
     expect(res.quote!.output.amount).toBe('2'); // recomputed: 2e18 / 1e18
     expect(res.quote!.output.value).toBe(4); // 2 × $2 (borrowed priceUsd)
+    expect(res.quote!.expectedOutput).toEqual({
+      amountRaw: 2100000000000000000n,
+      amount: '2.1',
+      value: 4.2,
+    });
     expect(res.quote!.input.decimals).toBe(6);
     expect(res.quote!.input.amount).toBe('1');
     expect(res.quote!.input.value).toBe(1); // 1 USDC × $1
@@ -563,8 +592,29 @@ describe('aggregateAggregators — Mystic tier-1 selection', () => {
   // (decimals/symbol, no USD price → value 0) rather than dropped.
   it('enriches a lone Mystic quote from its own token resolve instead of dropping it', async () => {
     const mysticToken = vi.fn().mockResolvedValue({ symbol: 'USDC', decimals: 6, name: 'USD Coin' });
-    const mystic = new MysticAggregator(vi.fn() as any, mysticToken as any);
-    vi.spyOn(mystic, 'getQuotes').mockResolvedValue([makeQuote(900_000n)]);
+    const postMystic = vi.fn(async (path: string) =>
+      path === 'v1/swap/build'
+        ? {
+            txRequest: {
+              to: '0x0000000000000000000000000000000000000004',
+              data: '0x05',
+              value: '0',
+            },
+            approval: null,
+          }
+        : {
+            quoteSetId: 'set-1',
+            quotes: [
+              {
+                quoteId: 'quote-1',
+                sellAmount: '1000000',
+                buyAmount: '990000',
+                minBuyAmount: '985000',
+              },
+            ],
+          }
+    );
+    const mystic = new MysticAggregator(postMystic as any, mysticToken as any);
 
     const [res] = await aggregateAggregators(
       [chainRequest(4114)],
@@ -576,6 +626,11 @@ describe('aggregateAggregators — Mystic tier-1 selection', () => {
     expect(res.quote).not.toBeNull();
     expect(res.quote!.output.decimals).toBe(6); // from Mystic /v1/tokens/resolve
     expect(res.quote!.output.value).toBe(0); // Mystic reports no USD price
+    expect(res.quote!.expectedOutput).toEqual({
+      amountRaw: 990000n,
+      amount: '0.99',
+      value: 0,
+    });
     expect(mysticToken).toHaveBeenCalled();
   });
 });

--- a/tests/swap/aggregators/bebop.test.ts
+++ b/tests/swap/aggregators/bebop.test.ts
@@ -72,7 +72,13 @@ const makeExactOutRequest = (
 // checksummed address.
 const makeBebopResponseData = (
   overrides?: {
-    buyToken?: Partial<{ minimumAmount: string; priceUsd: number; symbol: string; decimals: number }>;
+    buyToken?: Partial<{
+      amount: string;
+      minimumAmount: string;
+      priceUsd: number;
+      symbol: string;
+      decimals: number;
+    }>;
     sellToken?: Partial<{ amount: string; priceUsd: number; symbol: string; decimals: number }>;
   }
 ) => ({
@@ -133,6 +139,31 @@ describe('BebopAggregator', () => {
     expect(quote!.expiry).toBeGreaterThan(0);
     expect(quote!.input.amount).toBe('1.000000');
     expect(quote!.output.amount).toBe('0.980100000000000000');
+    expect(quote!.expectedOutput).toEqual({
+      amountRaw: 980100000000000000n,
+      amount: '0.980100000000000000',
+      value: 2940.3,
+    });
+  });
+
+  it('maps buyTokens.amount as expected output while keeping minimumAmount executable', async () => {
+    getQuoteFn.mockResolvedValue(
+      makeBebopResponseData({
+        buyToken: {
+          amount: '1000000000000000000',
+          minimumAmount: '980000000000000000',
+        },
+      })
+    );
+
+    const [quote] = await agg.getQuotes([makeRequest()]);
+
+    expect(quote!.output.amountRaw).toBe(980000000000000000n);
+    expect(quote!.expectedOutput).toEqual({
+      amountRaw: 1000000000000000000n,
+      amount: '1',
+      value: 3000,
+    });
   });
 
   it('surfaces per-token priceUsd so price-less siblings (0x) can backfill from it', async () => {

--- a/tests/swap/aggregators/expected-output.test.ts
+++ b/tests/swap/aggregators/expected-output.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeExpectedOutput } from '../../../src/swap/aggregators/expected-output';
+import type { Quote } from '../../../src/swap/aggregators/types';
+
+const protectedOutput: Quote['output'] = {
+  contractAddress: '0x0000000000000000000000000000000000000001',
+  amount: '1',
+  amountRaw: 1_000n,
+  decimals: 3,
+  value: 2,
+  priceUsd: 2,
+  symbol: 'OUT',
+};
+
+describe('normalizeExpectedOutput', () => {
+  it.each([undefined, null, 'invalid', 0, -1, 999])(
+    'falls back to the protected output for %s',
+    (candidate) => {
+      expect(normalizeExpectedOutput(candidate, protectedOutput)).toEqual({
+        amountRaw: protectedOutput.amountRaw,
+        amount: protectedOutput.amount,
+        value: protectedOutput.value,
+      });
+    }
+  );
+
+  it('derives human and USD expected values from a valid above-minimum raw amount', () => {
+    expect(normalizeExpectedOutput(1_200n, protectedOutput)).toEqual({
+      amountRaw: 1_200n,
+      amount: '1.2',
+      value: 2.4,
+    });
+  });
+});

--- a/tests/swap/aggregators/fibrous.test.ts
+++ b/tests/swap/aggregators/fibrous.test.ts
@@ -149,6 +149,11 @@ describe('FibrousAggregator', () => {
     expect(quote!.output.contractAddress).toBe(OUTPUT_TOKEN);
     expect(quote!.output.decimals).toBe(18);
     expect(quote!.output.symbol).toBe('HYPE');
+    expect(quote!.expectedOutput).toEqual({
+      amountRaw: 40_000_000_000_000_000n,
+      amount: '0.04',
+      value: 1,
+    });
   });
 
   it('passes the chain name in params so the transport can build the proxy path', async () => {

--- a/tests/swap/aggregators/lifi.test.ts
+++ b/tests/swap/aggregators/lifi.test.ts
@@ -78,6 +78,11 @@ describe('LiFiAggregator', () => {
     expect(quote!.txData.tx.data).toBe('0xabcdef');
     expect(quote!.input.amount).toBe('1');
     expect(quote!.output.amount).toBe('0.0000000000009801');
+    expect(quote!.expectedOutput).toEqual({
+      amountRaw: 990000n,
+      amount: '0.00000000000099',
+      value: 0.00000000396,
+    });
   });
 
   it('computes input/output value from human amount × token priceUSD (ca-common parity)', async () => {
@@ -105,7 +110,31 @@ describe('LiFiAggregator', () => {
 
     expect(quote!.input.value).toBe(1); // 1 USDC × $1
     expect(quote!.output.value).toBe(6); // 4 DAI (toAmountMin) × $1.5
+    expect(quote!.expectedOutput).toEqual({
+      amountRaw: 5000000n,
+      amount: '5',
+      value: 7.5,
+    });
   });
+
+  it.each([undefined, 'not-an-integer', '0', '3999999'])(
+    'falls expected output back to the protected output when toAmount is %s',
+    async (toAmount) => {
+      const response = makeLiFiResponseData();
+      Object.assign(response.estimate, { toAmount, toAmountMin: '4000000' });
+      response.action.toToken.decimals = 6;
+      response.action.toToken.priceUSD = '1.5';
+      getQuoteFn.mockResolvedValueOnce(response);
+
+      const [quote] = await agg.getQuotes([makeRequest()]);
+
+      expect(quote!.expectedOutput).toEqual({
+        amountRaw: 4000000n,
+        amount: '4',
+        value: 6,
+      });
+    }
+  );
 
   it('surfaces per-token priceUsd so price-less siblings (0x) can backfill from it', async () => {
     const [quote] = await agg.getQuotes([makeRequest()]);

--- a/tests/swap/aggregators/mystic.test.ts
+++ b/tests/swap/aggregators/mystic.test.ts
@@ -55,6 +55,7 @@ describe('MysticAggregator', () => {
     expect(quote).not.toBeNull();
     expect(quote!.input.amountRaw).toBe(1000000n); // sellAmount
     expect(quote!.output.amountRaw).toBe(985000n); // minBuyAmount, NOT buyAmount
+    expect(quote!.expectedOutput.amountRaw).toBe(990000n);
     expect(quote!.txData.approvalAddress).toBe(SPENDER);
     expect(quote!.txData.tx.to).toBe(ROUTER);
     expect(quote!.txData.tx.data).toBe('0xabcdef');

--- a/tests/swap/aggregators/relay.test.ts
+++ b/tests/swap/aggregators/relay.test.ts
@@ -96,6 +96,11 @@ describe('RelayAggregator', () => {
     expect(quote!.output.amountRaw).toBe(399000000000000n); // minimumAmount, NOT the expected amount
     expect(quote!.output.decimals).toBe(18);
     expect(quote!.output.symbol).toBe('WETH');
+    expect(quote!.expectedOutput).toEqual({
+      amountRaw: 400000000000000n,
+      amount: '0.0004',
+      value: 1.2,
+    });
     // tx comes from the 'swap' step, never 'approve'.
     expect(quote!.txData.tx.to).toBe(ROUTER);
     expect(quote!.txData.tx.data).toBe('0xswapdata');

--- a/tests/swap/aggregators/zerox.test.ts
+++ b/tests/swap/aggregators/zerox.test.ts
@@ -80,6 +80,7 @@ describe('ZeroExAggregator', () => {
     expect(quote).not.toBeNull();
     expect(quote!.input.amountRaw).toBe(1000000n); // sellAmount
     expect(quote!.output.amountRaw).toBe(980100000000000000n); // minBuyAmount, NOT buyAmount
+    expect(quote!.expectedOutput.amountRaw).toBe(990000000000000000n);
     expect(quote!.input.contractAddress).toBe(INPUT);
     expect(quote!.output.contractAddress).toBe(OUTPUT);
     expect(quote!.txData.approvalAddress).toBe(ALLOWANCE_TARGET);

--- a/tests/swap/algorithms/auto-select-mayan-min.test.ts
+++ b/tests/swap/algorithms/auto-select-mayan-min.test.ts
@@ -1,6 +1,7 @@
 import Decimal from 'decimal.js';
 import { describe, expect, it, vi } from 'vitest';
 import type { Hex } from 'viem';
+import { quoteFixture } from '../../helpers/quote';
 import { autoSelectSources, type SourceHolding } from '../../../src/swap/algorithms/auto-select';
 import type {
   Aggregator,
@@ -182,7 +183,7 @@ describe('autoSelectSources — Mayan per-source USD minimum', () => {
       );
       const outputHuman = inputHuman.mul(wethToUsdcRate);
       const outputAmountRaw = BigInt(outputHuman.mul(new Decimal(10).pow(6)).toFixed(0, 1));
-      return {
+      return quoteFixture({
         input: {
           contractAddress: WETH,
           amount: inputHuman.toString(),
@@ -207,7 +208,7 @@ describe('autoSelectSources — Mayan per-source USD minimum', () => {
             value: '0x0' as Hex,
           },
         },
-      };
+      });
     };
     const seriousInputs: bigint[] = [];
     const aggregator: Aggregator = {

--- a/tests/swap/algorithms/auto-select.test.ts
+++ b/tests/swap/algorithms/auto-select.test.ts
@@ -6,6 +6,7 @@ import { QuoteSeriousness, QuoteType } from '../../../src/swap/aggregators/types
 import { SAFETY_MULTIPLIER } from '../../../src/swap/algorithms/convergence';
 import { CurrencyID } from '../../../src/swap/cot';
 import { ARB_CHAIN, OP_CHAIN, USDC_ARB, USDC_OP, WETH, makeSwapChainList } from '../../helpers/swap';
+import { quoteFixture } from '../../helpers/quote';
 
 const tokenMeta = (tokenAddress: `0x${string}`) => {
   if (tokenAddress.toLowerCase() === USDC_ARB.toLowerCase()) return { decimals: 6, symbol: 'USDC' };
@@ -28,7 +29,7 @@ const makeHolding = (
   ...overrides,
 });
 
-const makeQuote = (outputAmountRaw: bigint, inputAmountRaw: bigint): Quote => ({
+const makeQuote = (outputAmountRaw: bigint, inputAmountRaw: bigint): Quote => quoteFixture({
   input: {
     contractAddress: WETH,
     amount: new Decimal(inputAmountRaw.toString()).div(new Decimal(10).pow(18)).toString(),
@@ -521,7 +522,7 @@ describe('selectDirectDestinationSwaps', () => {
     inputAmountRaw: bigint,
     outputContract: `0x${string}`,
     outputDecimals: number
-  ): Quote => ({
+  ): Quote => quoteFixture({
     input: { contractAddress: WETH, amount: divRaw(inputAmountRaw, 18), amountRaw: inputAmountRaw, decimals: 18, value: 1, symbol: 'WETH' },
     output: { contractAddress: outputContract, amount: divRaw(outputAmountRaw, outputDecimals), amountRaw: outputAmountRaw, decimals: outputDecimals, value: 1, symbol: 'PEPE' },
     txData: { approvalAddress: '0x03' as `0x${string}`, tx: { to: '0x04' as `0x${string}`, data: '0x05' as `0x${string}`, value: '0x0' as `0x${string}` } },

--- a/tests/swap/algorithms/convergence.test.ts
+++ b/tests/swap/algorithms/convergence.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../src/swap/algorithms/convergence';
 import type { Aggregator, Quote, QuoteRequest } from '../../../src/swap/aggregators';
 import { QuoteSeriousness, QuoteType } from '../../../src/swap/aggregators';
+import { quoteFixture } from '../../helpers/quote';
 
 const later = <T>(ms: number, value: T): Promise<T> =>
   new Promise((resolve) => setTimeout(() => resolve(value), ms));
@@ -50,7 +51,7 @@ const TOKEN_IN = '0x1111111111111111111111111111111111111111' as Hex;
 const TOKEN_OUT = '0x2222222222222222222222222222222222222222' as Hex;
 const USER = '0x3333333333333333333333333333333333333333' as Hex;
 
-const makeQuote = (inputAmountRaw: bigint, outputAmountRaw: bigint): Quote => ({
+const makeQuote = (inputAmountRaw: bigint, outputAmountRaw: bigint): Quote => quoteFixture({
   input: {
     contractAddress: TOKEN_IN,
     amount: inputAmountRaw.toString(),

--- a/tests/swap/algorithms/destination.test.ts
+++ b/tests/swap/algorithms/destination.test.ts
@@ -12,6 +12,7 @@ import { SAFETY_MULTIPLIER } from '../../../src/swap/algorithms/convergence';
 import { EADDRESS } from '../../../src/swap/constants';
 import { CurrencyID } from '../../../src/swap/cot';
 import { BASE_CHAIN, USDC_BASE, WETH, makeSwapChainList } from '../../helpers/swap';
+import { quoteFixture } from '../../helpers/quote';
 
 const makeQuote = (
   outputAmountRaw: bigint,
@@ -22,7 +23,7 @@ const makeQuote = (
   const inputIsUsdc = inputContract === USDC_BASE;
   const outputIsUsdc = outputContract === USDC_BASE;
 
-  return {
+  return quoteFixture({
     input: {
       contractAddress: inputContract,
       amount: new Decimal(inputAmountRaw.toString())
@@ -47,7 +48,7 @@ const makeQuote = (
     approvalAddress: '0x03' as `0x${string}`,
     tx: { to: '0x04' as `0x${string}`, data: '0x05' as `0x${string}`, value: '0x0' as `0x${string}` },
   },
-  };
+  });
 };
 
 // First (uncapped) convergence step = ceil(seed × SAFETY_MULTIPLIER), mirroring convergence.ts.

--- a/tests/swap/algorithms/direct-destination-size.test.ts
+++ b/tests/swap/algorithms/direct-destination-size.test.ts
@@ -10,6 +10,7 @@ import {
 import type { Aggregator, QuoteResponse } from '../../../src/swap/aggregators/types';
 import { EADDRESS } from '../../../src/swap/constants';
 import type { OraclePriceResponse } from '../../../src/swap/types';
+import { quoteFixture } from '../../helpers/quote';
 
 vi.mock('../../../src/swap/algorithms/auto-select', () => ({
   selectDirectDestinationSwaps: vi.fn(),
@@ -42,7 +43,7 @@ const quote = (
   chainID: CHAIN_ID,
   holding: overrides.holding ?? holding,
   aggregator: {} as Aggregator,
-  quote: {
+  quote: quoteFixture({
     input: {
       contractAddress: INPUT_TOKEN,
       amount: '1',
@@ -65,7 +66,7 @@ const quote = (
       approvalAddress: USER,
       tx: { to: RECIPIENT, data: '0x', value: '0x0' },
     },
-  },
+  }),
 });
 
 describe('sizeDirectDestinationExactOut', () => {

--- a/tests/swap/algorithms/liquidate.test.ts
+++ b/tests/swap/algorithms/liquidate.test.ts
@@ -3,6 +3,7 @@ import { liquidateInputHoldings } from '../../../src/swap/algorithms/liquidate';
 import type { Aggregator, Holding, Quote } from '../../../src/swap/aggregators/types';
 import { CurrencyID } from '../../../src/swap/cot';
 import { ARB_CHAIN, OP_CHAIN, USDC_ARB, USDC_OP, WETH, DAI, makeSwapChainList } from '../../helpers/swap';
+import { quoteFixture } from '../../helpers/quote';
 
 const makeHolding = (chainID: number, tokenAddress: `0x${string}`, amountRaw: bigint, decimals: number, symbol: string): Holding => ({
   chainID,
@@ -12,7 +13,7 @@ const makeHolding = (chainID: number, tokenAddress: `0x${string}`, amountRaw: bi
   symbol,
 });
 
-const makeQuote = (outputAmountRaw: bigint, inputContract: `0x${string}` = WETH): Quote => ({
+const makeQuote = (outputAmountRaw: bigint, inputContract: `0x${string}` = WETH): Quote => quoteFixture({
   input: {
     contractAddress: inputContract,
     amount: '1000000',

--- a/tests/swap/amount-basis.test.ts
+++ b/tests/swap/amount-basis.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import type { Hex } from 'viem';
+import { selectExactInQuoteOutput } from '../../src/swap/amount-basis';
+import type { Quote } from '../../src/swap/aggregators/types';
+
+const quote = {
+  output: {
+    contractAddress: '0x0000000000000000000000000000000000000001' as Hex,
+    amountRaw: 980_000n,
+    amount: '0.98',
+    decimals: 6,
+    value: 0.98,
+    symbol: 'USDC',
+  },
+  expectedOutput: {
+    amountRaw: 1_000_000n,
+    amount: '1',
+    value: 1,
+  },
+} as Quote;
+
+describe('selectExactInQuoteOutput', () => {
+  it('selects the normalized expected output in expected mode', () => {
+    expect(selectExactInQuoteOutput(quote, 'expected')).toBe(quote.expectedOutput);
+  });
+
+  it('selects the executable output in minimum mode', () => {
+    expect(selectExactInQuoteOutput(quote, 'minimum')).toBe(quote.output);
+  });
+
+  it('falls back to the executable output when expected output is absent', () => {
+    const malformedRuntimeQuote = { ...quote, expectedOutput: undefined } as unknown as Quote;
+    expect(selectExactInQuoteOutput(malformedRuntimeQuote, 'expected')).toBe(quote.output);
+  });
+});

--- a/tests/swap/bridge-intent.test.ts
+++ b/tests/swap/bridge-intent.test.ts
@@ -314,6 +314,47 @@ describe('createSwapBridgeIntent', () => {
     ).toBe('3.5');
   });
 
+  it.each([
+    { actualBalance: '3000', protocolFee: '30', delivered: '2968' },
+    { actualBalance: '7000', protocolFee: '70', delivered: '6928' },
+  ])(
+    'recomputes Nexus fixed-plus-bps fees from the actual $actualBalance execution balance',
+    ({ actualBalance, protocolFee, delivered }) => {
+      const assets = [makeBridgeAsset(ARB_CHAIN, USDC_ARB, actualBalance)];
+      const bridge = makeBridge(assets, {
+        amount: new Decimal('6000'),
+        amounts: {
+          tokenAmount: new Decimal('5938'),
+          gasInCot: new Decimal(0),
+          totalAmount: new Decimal('6000'),
+        },
+        estimatedFees: {
+          collection: new Decimal(0),
+          fulfilment: new Decimal(2),
+          caGas: new Decimal(2),
+          protocol: new Decimal(60),
+          solver: new Decimal(0),
+        },
+        nexusFeeModel: {
+          fulfillmentFee: new Decimal(2),
+          fulfillmentBps: new Decimal(100),
+        },
+      });
+
+      const intent = createSwapBridgeIntent({
+        bridge,
+        assets,
+        chainList: makeChainList(),
+        recipient: EPHEMERAL_ADDRESS,
+        ephemeralAddress: EPHEMERAL_ADDRESS,
+      });
+
+      expect(intent.destination.amount.toString()).toBe(delivered);
+      expect(intent.fees.fulfillment).toBe('2');
+      expect(intent.fees.protocol).toBe(protocolFee);
+    }
+  );
+
   it('EXACT_OUT same-token (B1): per-chain split sources, destination = the exact target, no gas', () => {
     // B1 EXACT_OUT bridges the family token directly from EOA-held (fast-path) assets. The destination
     // is derived as Σassets − fees; B1 grosses the split up to cover the fees, so with a zero-fee quote

--- a/tests/swap/characterization/swap.test.ts
+++ b/tests/swap/characterization/swap.test.ts
@@ -241,19 +241,17 @@ describe('swap execution characterization', () => {
     // S5 — exactly the two source chains + the destination chain emit batches; nothing stray.
     expect(dispatchedChains(middlewareClient)).toEqual([OP_CHAIN, BASE_CHAIN, ARB_CHAIN].sort((a, b) => a - b));
 
-    // ── DESTINATION_SWAP (BASE 7702): approve→swap(recv=EOA)→transfer(leftover COT → EOA) ──
-    // #86: the unused COT is returned by ONE direct transfer (balance − consumed), replacing the blind
-    // approve+Sweeper drain; the output token lands at the EOA so its dust sweep is skipped.
+    // ── DESTINATION_SWAP (BASE 7702): approve→swap(recv=EOA), consuming all delivered COT ──
     const dstBatches = sbcBatchesForChain(middlewareClient, BASE_CHAIN);
     expect(dstBatches.length, 'dst SBC batch count').toBe(1);
     const [dst] = dstBatches;
 
-    // Y is reclaim-sized; assert consistency (router approve == swap input) and Y ≤ bridged total.
+    // Y is reclaim-sized; router approval and swap input equal the complete bridged total.
     const swapCall = dst.find((c) => c.fn === 'swap')!;
     const approveRouterCall = dst.find((c) => c.fn === 'approve')!;
     const Y = approveRouterCall.args[1] as bigint;
     expect(swapCall.args[2]).toBe(Y); // approve amount == swap inputAmount
-    expect(Y).toBeLessThanOrEqual(2n * srcOut); // ≤ bridged total
+    expect(Y).toBe(2n * srcOut);
 
     expectCallSequence(
       dst,
@@ -269,7 +267,6 @@ describe('swap execution characterization', () => {
             eq(EOA)(a[5]); // receiver = EOA
           },
         },
-        { fn: 'transfer', to: USDC_BASE, argsMatch: (a) => { eq(EOA)(a[0]); } }, // leftover COT → EOA
       ],
       'dst'
     );
@@ -603,7 +600,7 @@ describe('swap execution characterization', () => {
     const dstSwap = dst[0].find((c) => c.fn === 'swap')!;
     eq(EPH)(dstSwap.args[4]); // taker = wrapper
     eq(EOA)(dstSwap.args[5]); // receiver = EOA
-    expect(dst[0].map((c) => c.fn)).toEqual(['approve', 'swap', 'transfer']);
+    expect(dst[0].map((c) => c.fn)).toEqual(['approve', 'swap']);
 
     // No native legs → EOA signed nothing (Safe txs are middleware-sponsored).
     expect(sentTxs).toHaveLength(0);
@@ -939,17 +936,16 @@ describe('swap execution characterization', () => {
     expect(rffRecipient(middlewareClient)).toBe(bytes32Address(PREDICTED_SAFE));
 
     // Destination swap via Safe.execTransaction (no funding — bridge filled the Safe):
-    // approve(router)→swap(taker=SAFE, recv=EOA)→transfer leftover COT → EOA. No WETH output sweep
-    // (Safe delivers output direct to the EOA).
+    // approve(router)→swap(taker=SAFE, recv=EOA), consuming all COT. No WETH output sweep because
+    // the Safe delivers output directly to the EOA.
     const dst = safeBatchesForChain(middlewareClient, BASE_CHAIN);
     expect(dst.length, 'dst Safe batch count').toBe(1);
-    expect(dst[0].map((c) => c.fn)).toEqual(['approve', 'swap', 'transfer']);
+    expect(dst[0].map((c) => c.fn)).toEqual(['approve', 'swap']);
     const swp = dst[0][1];
     eq(USDC_BASE)(swp.args[0]);
     eq(WETH)(swp.args[1]);
     eq(PREDICTED_SAFE)(swp.args[4]); // taker = Safe wrapper
     eq(EOA)(swp.args[5]); // receiver = EOA
-    eq(USDC_BASE)(dst[0][2].to); // leftover COT transferred to the EOA
   });
 
   it('EXACT_IN · Nexus · Path A: all sources on dst chain → direct source swap, no bridge/dst swap', async () => {
@@ -1480,7 +1476,7 @@ describe('swap execution characterization', () => {
     expect(rffRecipient(middlewareClient)).toBe(bytes32Address(PREDICTED_SAFE));
     const dst = safeBatchesForChain(middlewareClient, BASE_CHAIN);
     expect(dst.length).toBe(1);
-    expect(dst[0].map((c) => c.fn)).toEqual(['approve', 'swap', 'transfer']);
+    expect(dst[0].map((c) => c.fn)).toEqual(['approve', 'swap']);
     eq(PREDICTED_SAFE)(dst[0][1].args[4]); // taker = Safe
     eq(EOA)(dst[0][1].args[5]); // receiver = EOA
   });
@@ -1524,10 +1520,9 @@ describe('swap execution characterization', () => {
     expect(rffRecipient(middlewareClient)).toBe(bytes32Address(EPH));
     const dst = sbcBatchesForChain(middlewareClient, BASE_CHAIN);
     expect(dst.length).toBe(1);
-    expect(dst[0].map((c) => c.fn)).toEqual(['approve', 'swap', 'transfer']);
+    expect(dst[0].map((c) => c.fn)).toEqual(['approve', 'swap']);
     eq(EPH)(dst[0][1].args[4]); // taker = EPH
     eq(EOA)(dst[0][1].args[5]); // receiver = EOA
-    eq(USDC_BASE)(dst[0][2].to); // leftover COT transferred to the EOA (output WETH delivered direct)
   });
 
   it('EXACT_OUT · Nexus · token swap + gas in the same destination batch (7702 dst)', async () => {
@@ -1700,7 +1695,7 @@ describe('swap execution characterization', () => {
     expect(rffRecipient(middlewareClient)).toBe(bytes32Address(PREDICTED_SAFE));
     const dst = safeBatchesForChain(middlewareClient, BASE_CHAIN);
     expect(dst.length).toBe(1);
-    expect(dst[0].map((c) => c.fn)).toEqual(['approve', 'swap', 'transfer']);
+    expect(dst[0].map((c) => c.fn)).toEqual(['approve', 'swap']);
     eq(PREDICTED_SAFE)(dst[0][1].args[4]);
     eq(EOA)(dst[0][1].args[5]);
   });
@@ -1808,23 +1803,19 @@ describe('swap execution characterization', () => {
     const delivered = rff.destinations.reduce((sum, d) => sum + BigInt(d.value), 0n);
     expect(delivered, 'both legs deliver in full (zero mock haircut)').toBe(2000n * 10n ** 6n);
 
-    // Destination: approve → swap(COT→native, taker=EPH, recv=EOA) → leftover COT → EOA. Native
-    // output is delivered direct, so there is NO native sweep call.
+    // Destination: approve → swap(COT→native, taker=EPH, recv=EOA), consuming all delivered COT.
+    // Native output is delivered direct, so there is no native sweep call.
     const dst = sbcBatchesForChain(middlewareClient, BASE_CHAIN);
     expect(dst.length, 'dst SBC batch count').toBe(1);
-    expect(dst[0].map((c) => c.fn)).toEqual(['approve', 'swap', 'transfer']);
+    expect(dst[0].map((c) => c.fn)).toEqual(['approve', 'swap']);
     const swp = dst[0][1];
     eq(USDC_BASE)(swp.args[0]); // input = COT
     eq(EADDRESS as Hex)(swp.args[1]); // output = native
     eq(EPH)(swp.args[4]); // taker = wrapper
     eq(EOA)(swp.args[5]); // receiver = EOA
-    // EXACT_IN resize: the swap consumes the delivered COT less the reclaim margin; the tiny
-    // remainder goes back to the EOA in the same batch.
-    expect(swp.args[2] as bigint).toBeLessThanOrEqual(delivered);
+    // EXACT_IN resize consumes the complete delivered COT balance.
+    expect(swp.args[2] as bigint).toBe(delivered);
     expect(dst[0][0].args[1]).toBe(swp.args[2]); // approve == swap input
-    eq(USDC_BASE)(dst[0][2].to);
-    eq(EOA)(dst[0][2].args[0]);
-    expect(dst[0][2].args[1] as bigint).toBe(delivered - (swp.args[2] as bigint));
     expect(sentTxs).toHaveLength(0);
   });
 

--- a/tests/swap/constants.test.ts
+++ b/tests/swap/constants.test.ts
@@ -4,7 +4,6 @@ import {
   B2_STABLE_CURRENCY_IDS,
   DST_BUFFER_MAX_USD,
   DST_BUFFER_PCT,
-  DST_RECLAIM_DEDUCTION_PCT,
   GAS_TO_COT_BUFFER,
   MAX_RETRIES,
   MAX_SWAP_HAIRCUT_MIN_USDC,
@@ -36,10 +35,6 @@ describe('swap economic constants', () => {
   it('EXACT_OUT source buffer = min(2%, $1)', () => {
     expect(SRC_BUFFER_PCT).toBe(0.02);
     expect(SRC_BUFFER_MAX_USD).toBe(1);
-  });
-
-  it('EXACT_IN dst reclaim deduction = 1 bp', () => {
-    expect(DST_RECLAIM_DEDUCTION_PCT).toBe(0.0001);
   });
 
   it('max-amount haircut = max(3%, $3)', () => {

--- a/tests/swap/execution/destination-swap.test.ts
+++ b/tests/swap/execution/destination-swap.test.ts
@@ -427,7 +427,7 @@ describe('executeDestinationSwap', () => {
     const resized = makeQuoteResponse({
       quote: {
         ...planned.quote,
-        input: { ...planned.quote.input, amount: '3149.685', amountRaw: 3149685000n },
+        input: { ...planned.quote.input, amount: '3150', amountRaw: 3150000000n },
         output: { ...planned.quote.output, amount: '1.05', amountRaw: 1050000000000000000n },
       },
     });
@@ -456,19 +456,18 @@ describe('executeDestinationSwap', () => {
     // grew the input from the actual balance (3150), not the route-time planned input (3000)
     expect(destination.getDstSwap).toHaveBeenCalledWith(3150000000n);
     // executed swap used the larger quote → bigger input + output recorded
-    expect(metadata.dst?.swaps[0].inputAmount).toBe(3149685000n);
+    expect(metadata.dst?.swaps[0].inputAmount).toBe(3150000000n);
     expect(metadata.dst?.swaps[0].outputAmount).toBe(1050000000000000000n);
   });
 
-  it('EXACT_IN reclaim: re-sizes even when the actual balance equals the planned input (applies the deduction)', async () => {
+  it('EXACT_IN reclaim: consumes the complete balance when it equals the planned input', async () => {
     // No source buffer: the dst swap re-sizes from the actual balance in BOTH directions. Even when
-    // balanceOf equals the route-time input, getDstSwap runs so the reclaim deduction applies and a
-    // leftover survives — the swap never consumes 100% of the wrapper balance.
+    // balanceOf equals the route-time input, getDstSwap runs and consumes all settlement currency.
     const planned = makeQuoteResponse(); // route-time input = 3000 USDC
     const resized = makeQuoteResponse({
       quote: {
         ...planned.quote,
-        input: { ...planned.quote.input, amount: '2999.7', amountRaw: 2999700000n }, // 3000 − 1bp
+        input: { ...planned.quote.input, amount: '3000', amountRaw: 3000000000n },
       },
     });
     const destination = makeDestination({ tokenSwap: planned });
@@ -486,7 +485,42 @@ describe('executeDestinationSwap', () => {
     );
 
     expect(destination.getDstSwap).toHaveBeenCalledWith(3000000000n);
-    expect(metadata.dst?.swaps[0].inputAmount).toBe(2999700000n); // deducted → a leftover remains
+    expect(metadata.dst?.swaps[0].inputAmount).toBe(3000000000n);
+  });
+
+  it('EXACT_IN reclaim: refuses a resized quote that would return settlement-token dust', async () => {
+    const planned = makeQuoteResponse();
+    const underConsuming = makeQuoteResponse({
+      quote: {
+        ...planned.quote,
+        input: { ...planned.quote.input, amount: '2999.7', amountRaw: 2999700000n },
+      },
+    });
+    const destination = makeDestination({ tokenSwap: planned });
+    destination.getDstSwap = vi
+      .fn()
+      .mockResolvedValue({ tokenSwap: underConsuming, gasSwap: null });
+
+    const ctx = makeCtx('ephemeral');
+    withReclaimClient(ctx, 3000000000n);
+    const metadata: SwapMetadata = { src: [], dst: null, has_xcs: false, intent_request_hash: null };
+
+    await expect(
+      executeDestinationSwap(
+        destination as unknown as SwapRoute['destination'],
+        SwapMode.EXACT_IN,
+        makeDstTokenInfo(),
+        ctx,
+        metadata
+      )
+    ).rejects.toMatchObject({
+      code: ERROR_CODES.EXTERNAL_DESTINATION_SWAP_QUOTE_FAILED,
+      context: expect.objectContaining({ stepType: 'destination_swap' }),
+    });
+
+    expect(destination.getDstSwap).toHaveBeenCalledTimes(3);
+    expect(ctx.middlewareClient.submitSBCs).not.toHaveBeenCalled();
+    expect(metadata.dst).toBeNull();
   });
 
   it('EXACT_IN reclaim: shrinks the destination swap when the actual balance is BELOW the planned input', async () => {
@@ -496,7 +530,7 @@ describe('executeDestinationSwap', () => {
     const resized = makeQuoteResponse({
       quote: {
         ...planned.quote,
-        input: { ...planned.quote.input, amount: '2499.75', amountRaw: 2499750000n }, // 2500 − 1bp
+        input: { ...planned.quote.input, amount: '2500', amountRaw: 2500000000n },
       },
     });
     const destination = makeDestination({ tokenSwap: planned });
@@ -514,7 +548,7 @@ describe('executeDestinationSwap', () => {
     );
 
     expect(destination.getDstSwap).toHaveBeenCalledWith(2500000000n);
-    expect(metadata.dst?.swaps[0].inputAmount).toBe(2499750000n); // shrank to actual − 1bp
+    expect(metadata.dst?.swaps[0].inputAmount).toBe(2500000000n);
   });
 
   it('EXACT_IN reclaim: never dispatches the route-time quote when mandatory resizing fails', async () => {
@@ -547,7 +581,19 @@ describe('executeDestinationSwap', () => {
   });
 
   it('EXACT_IN retries the mandatory destination balance read before first dispatch', async () => {
-    const destination = makeDestination();
+    const planned = makeQuoteResponse();
+    const resized = makeQuoteResponse({
+      quote: {
+        ...planned.quote,
+        input: {
+          ...planned.quote.input,
+          amount: '3150',
+          amountRaw: 3150000000n,
+        },
+      },
+    });
+    const destination = makeDestination({ tokenSwap: planned });
+    destination.getDstSwap = vi.fn().mockResolvedValue({ tokenSwap: resized, gasSwap: null });
     const ctx = makeCtx('ephemeral');
     const readContract = vi
       .fn()
@@ -650,7 +696,7 @@ describe('executeDestinationSwap', () => {
       metadata
     );
 
-    // one transfer of the surplus (3120 − 3000 = 120 USDC, less the 1bp margin) to the EOA
+    // one transfer of the surplus (3120 − 3000 = 120 USDC) to the EOA
     const transfer = findCotTransfer(lastSbcCalls(), USDC_ARB);
     expect(transfer?.[0].toLowerCase()).toBe(EOA);
     expect(transfer?.[1]).toBe(120000000n); // exact B − consumed (3120 − 3000)
@@ -1041,6 +1087,7 @@ describe('executeDestinationSwap', () => {
     };
     const ctx = makeCtx('ephemeral');
     const destination = makeDestination({ tokenSwap, gasSwap });
+    withReclaimClient(ctx, 3025000000n);
     const metadata: SwapMetadata = { src: [], dst: null, has_xcs: false, intent_request_hash: null };
 
     await executeDestinationSwap(destination as unknown as SwapRoute['destination'], SwapMode.EXACT_IN, makeDstTokenInfo(), ctx, metadata);
@@ -1229,6 +1276,7 @@ describe('executeDestinationSwap', () => {
         ensureSafeAccount: vi.fn().mockResolvedValue({}),
       }),
     } as DstCtx;
+    withReclaimClient(ctx, 0n);
     const destination = {
       ...makeDestination({ tokenSwap }),
       eoaToEphemeral: { amount: 3000000000n, contractAddress: USDC_ARB },
@@ -1296,6 +1344,7 @@ describe('executeDestinationSwap', () => {
         ensureSafeAccount: vi.fn().mockResolvedValue({}),
       }),
     } as DstCtx;
+    withReclaimClient(ctx, 5000000n);
     const destination = makeDestination({ tokenSwap });
     const metadata: SwapMetadata = {
       src: [],
@@ -1361,6 +1410,7 @@ describe('executeDestinationSwap', () => {
         ensureSafeAccount: vi.fn().mockResolvedValue({}),
       }),
     } as DstCtx;
+    withReclaimClient(ctx, 3025000000n);
     const destination = makeDestination({ tokenSwap, gasSwap });
     const metadata: SwapMetadata = {
       src: [],
@@ -1414,6 +1464,7 @@ describe('executeDestinationSwap', () => {
     };
 
     const ctx = makeCtx('ephemeral');
+    withReclaimClient(ctx, 3025000000n);
     const destination = makeDestination({ tokenSwap, gasSwap });
     const metadata: SwapMetadata = { src: [], dst: null, has_xcs: false, intent_request_hash: null };
 

--- a/tests/swap/execution/destination-swap.test.ts
+++ b/tests/swap/execution/destination-swap.test.ts
@@ -79,6 +79,11 @@ import {
 import type { QuoteResponse, Aggregator } from '../../../src/swap/aggregators/types';
 import type { TokenInfo } from '../../../src/domain';
 import { ERROR_CODES } from '../../../src/domain/errors';
+import {
+  quoteFixture,
+  quoteResponseFixture,
+  type QuoteResponseFixtureOverrides,
+} from '../../helpers/quote';
 
 const USDC_ARB = '0xaf88d065e77c8cc2239327c5edb3a432268e5831' as Hex;
 const WETH = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as Hex;
@@ -96,7 +101,8 @@ const requestToData = (request: {
     args: request.args as readonly [Hex, bigint],
   });
 
-const makeQuoteResponse = (overrides?: Partial<QuoteResponse>): QuoteResponse => ({
+const makeQuoteResponse = (overrides?: QuoteResponseFixtureOverrides): QuoteResponse =>
+  quoteResponseFixture({
   chainID: ARB_CHAIN,
   quote: {
     input: { contractAddress: USDC_ARB, amount: '3000', amountRaw: 3000000000n, decimals: 6, value: 3000, symbol: 'USDC' },
@@ -108,22 +114,25 @@ const makeQuoteResponse = (overrides?: Partial<QuoteResponse>): QuoteResponse =>
   },
   holding: { chainID: ARB_CHAIN, tokenAddress: USDC_ARB, amountRaw: 3000000000n, decimals: 6, symbol: 'USDC' },
   aggregator: {} as Aggregator,
-  ...overrides,
-});
+  }, overrides);
 
 const makeDestination = (overrides?: {
   tokenSwap?: QuoteResponse | null;
   gasSwap?: QuoteResponse | null;
-}) => ({
-  chainId: ARB_CHAIN,
-  eoaToEphemeral: null,
-  inputAmount: { min: new Decimal('3000'), max: new Decimal('3150') },
-  swap: {
-    tokenSwap: overrides && 'tokenSwap' in overrides ? overrides.tokenSwap : makeQuoteResponse(),
-    gasSwap: overrides?.gasSwap ?? null,
-  } as DestinationSwap,
-  getDstSwap: vi.fn().mockResolvedValue(null),
-});
+}) => {
+  const destination = {
+    chainId: ARB_CHAIN,
+    eoaToEphemeral: null,
+    inputAmount: { min: new Decimal('3000'), max: new Decimal('3150') },
+    swap: {
+      tokenSwap: overrides && 'tokenSwap' in overrides ? overrides.tokenSwap : makeQuoteResponse(),
+      gasSwap: overrides?.gasSwap ?? null,
+    } as DestinationSwap,
+    getDstSwap: vi.fn(),
+  };
+  destination.getDstSwap.mockResolvedValue(destination.swap);
+  return destination;
+};
 
 type DstCtx = Pick<
   ExecutionContext,
@@ -212,6 +221,7 @@ const makeCtx = (
   publicClientList: {
     get: vi.fn().mockReturnValue({
       getCode: vi.fn().mockResolvedValue(undefined),
+      readContract: vi.fn().mockResolvedValue(3000000000n),
       waitForTransactionReceipt: vi.fn().mockResolvedValue({
         status: 'success',
         transactionHash: '0xdst_tx' as Hex,
@@ -507,7 +517,7 @@ describe('executeDestinationSwap', () => {
     expect(metadata.dst?.swaps[0].inputAmount).toBe(2499750000n); // shrank to actual − 1bp
   });
 
-  it('EXACT_IN reclaim: falls back to the route-time quote when the grow re-quote fails', async () => {
+  it('EXACT_IN reclaim: never dispatches the route-time quote when mandatory resizing fails', async () => {
     const planned = makeQuoteResponse();
     const destination = makeDestination({ tokenSwap: planned });
     destination.getDstSwap = vi.fn().mockRejectedValue(new Error('aggregator down'));
@@ -516,16 +526,87 @@ describe('executeDestinationSwap', () => {
     withReclaimClient(ctx, 3150000000n);
     const metadata: SwapMetadata = { src: [], dst: null, has_xcs: false, intent_request_hash: null };
 
+    await expect(
+      executeDestinationSwap(
+        destination as unknown as SwapRoute['destination'],
+        SwapMode.EXACT_IN,
+        makeDstTokenInfo(),
+        ctx,
+        metadata
+      )
+    ).rejects.toMatchObject({
+      context: expect.objectContaining({
+        stepType: 'destination_swap',
+        chainId: ARB_CHAIN,
+      }),
+    });
+
+    expect(destination.getDstSwap).toHaveBeenCalledTimes(3);
+    expect(ctx.middlewareClient.submitSBCs).not.toHaveBeenCalled();
+    expect(metadata.dst).toBeNull();
+  });
+
+  it('EXACT_IN retries the mandatory destination balance read before first dispatch', async () => {
+    const destination = makeDestination();
+    const ctx = makeCtx('ephemeral');
+    const readContract = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('rpc unavailable'))
+      .mockRejectedValueOnce(new Error('rpc unavailable'))
+      .mockResolvedValue(3150000000n);
+    (ctx.publicClientList.get as unknown) = vi.fn().mockReturnValue({
+      getCode: vi.fn().mockResolvedValue(undefined),
+      waitForTransactionReceipt: vi
+        .fn()
+        .mockResolvedValue({ status: 'success', transactionHash: '0xdst_tx' as Hex }),
+      readContract,
+    });
+    const metadata: SwapMetadata = { src: [], dst: null, has_xcs: false, intent_request_hash: null };
+
     await executeDestinationSwap(
       destination as unknown as SwapRoute['destination'],
-      SwapMode.EXACT_IN, makeDstTokenInfo(),
+      SwapMode.EXACT_IN,
+      makeDstTokenInfo(),
       ctx,
       metadata
     );
 
-    // the grow is best-effort: a failed re-quote must not abort the swap
-    expect(destination.getDstSwap).toHaveBeenCalled();
-    expect(metadata.dst?.swaps[0].inputAmount).toBe(3000000000n); // original quote executed
+    expect(destination.getDstSwap).toHaveBeenCalledWith(3150000000n);
+    expect(ctx.middlewareClient.submitSBCs).toHaveBeenCalledTimes(1);
+    expect(
+      readContract.mock.calls.filter(([request]) => request.address === USDC_ARB)
+    ).toHaveLength(3);
+  });
+
+  it('EXACT_IN fails with destination context and does not dispatch after balance-read exhaustion', async () => {
+    const destination = makeDestination();
+    const ctx = makeCtx('ephemeral');
+    const readContract = vi.fn().mockRejectedValue(new Error('rpc unavailable'));
+    (ctx.publicClientList.get as unknown) = vi.fn().mockReturnValue({
+      getCode: vi.fn().mockResolvedValue(undefined),
+      waitForTransactionReceipt: vi.fn(),
+      readContract,
+    });
+    const metadata: SwapMetadata = { src: [], dst: null, has_xcs: false, intent_request_hash: null };
+
+    await expect(
+      executeDestinationSwap(
+        destination as unknown as SwapRoute['destination'],
+        SwapMode.EXACT_IN,
+        makeDstTokenInfo(),
+        ctx,
+        metadata
+      )
+    ).rejects.toMatchObject({
+      context: expect.objectContaining({
+        stepType: 'destination_swap',
+        chainId: ARB_CHAIN,
+      }),
+    });
+
+    expect(readContract).toHaveBeenCalledTimes(3);
+    expect(destination.getDstSwap).not.toHaveBeenCalled();
+    expect(ctx.middlewareClient.submitSBCs).not.toHaveBeenCalled();
   });
 
   // EXACT_OUT surplus return (Seam 2): the output is fixed, so the COT that arrived beyond what the
@@ -696,7 +777,6 @@ describe('executeDestinationSwap', () => {
       { to: USDC_ARB, data: '0xaaa1', value: 0n },
       { to: tokenSwap.quote.txData.tx.to, data: '0xbbb1', value: 0n },
       { to: tokenSwap.quote.output.contractAddress, data: '0xsweep', value: 0n },
-      { to: USDC_ARB, data: '0xsweep', value: 0n },
     ]);
   });
 
@@ -945,7 +1025,7 @@ describe('executeDestinationSwap', () => {
     const tokenSwap = makeQuoteResponse();
     const gasSwap: QuoteResponse = {
       chainID: ARB_CHAIN,
-      quote: {
+      quote: quoteFixture({
         input: { contractAddress: USDC_ARB, amount: '25', amountRaw: 25_000_000n, decimals: 6, value: 25, symbol: 'USDC' },
         output: {
           contractAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' as Hex,
@@ -955,7 +1035,7 @@ describe('executeDestinationSwap', () => {
           approvalAddress: '0x4444444444444444444444444444444444444444' as Hex,
           tx: { to: '0x5555555555555555555555555555555555555555' as Hex, data: '0xfeedface' as Hex, value: '0x0' as Hex },
         },
-      },
+      }),
       holding: { chainID: ARB_CHAIN, tokenAddress: USDC_ARB, amountRaw: 25_000_000n, decimals: 6, symbol: 'USDC' },
       aggregator: {} as Aggregator,
     };
@@ -1051,7 +1131,8 @@ describe('executeDestinationSwap', () => {
     destination.getDstSwap = vi
       .fn()
       .mockResolvedValueOnce({ tokenSwap: requotedA, gasSwap: null })
-      .mockResolvedValueOnce({ tokenSwap: requotedB, gasSwap: null });
+      .mockResolvedValueOnce({ tokenSwap: requotedB, gasSwap: null })
+      .mockResolvedValueOnce({ tokenSwap: baseQuote, gasSwap: null });
 
     const metadata: SwapMetadata = { src: [], dst: null, has_xcs: false, intent_request_hash: null };
 
@@ -1064,7 +1145,7 @@ describe('executeDestinationSwap', () => {
       )
     ).rejects.toThrow(/attempt 3 failed|SBC submission/i);
 
-    expect(destination.getDstSwap).toHaveBeenCalledTimes(2);
+    expect(destination.getDstSwap).toHaveBeenCalledTimes(3);
     expect(createSBCTxFromCalls).toHaveBeenCalledTimes(3);
   });
 
@@ -1112,13 +1193,9 @@ describe('executeDestinationSwap', () => {
     expect(createSafeExecuteTxFromCalls).toHaveBeenCalledTimes(1);
     expect(createSBCTxFromCalls).not.toHaveBeenCalled();
 
-    // Sweeper sender = Safe address so Sweeper.sweepERC20 pulls the residual COT/output from
-    // the Safe wrapper (not the ephemeral).
-    const sweepCallArgs = vi.mocked(createSweeperTxs).mock.calls[0];
-    const sweeperSender = sweepCallArgs?.[4]; // 5th arg is the sender address override
-    expect(sweeperSender?.toLowerCase()).toBe(
-      '0x2d7E4C3ef02B86D271624742C6e81636f4c9e663'.toLowerCase()
-    );
+    // The mandatory read proves the resized swap consumes the full measured COT balance, while the
+    // aggregator delivers output directly to the EOA on Safe paths, so no blind sweep is needed.
+    expect(createSweeperTxs).not.toHaveBeenCalled();
   });
 
   it('Safe path: moves EOA-held direct COT into the Safe before the destination swap', async () => {
@@ -1238,8 +1315,8 @@ describe('executeDestinationSwap', () => {
       .mocked(createSweeperTxs)
       .mock.calls.map((args) => (args[0] as string).toLowerCase());
     expect(sweptTokens).not.toContain('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
-    // Input COT must still be swept so residual COT at Safe drains to EOA.
-    expect(sweptTokens).toContain(USDC_ARB.toLowerCase());
+    // The measured input is fully consumed, so no blind input-COT sweep is appended either.
+    expect(sweptTokens).not.toContain(USDC_ARB.toLowerCase());
   });
 
   it('Safe path: includes gas-swap approve+swap in the same batch, no raw native value-send', async () => {
@@ -1250,7 +1327,7 @@ describe('executeDestinationSwap', () => {
     const tokenSwap = makeQuoteResponse();
     const gasSwap: QuoteResponse = {
       chainID: ARB_CHAIN,
-      quote: {
+      quote: quoteFixture({
         input: { contractAddress: USDC_ARB, amount: '25', amountRaw: 25_000_000n, decimals: 6, value: 25, symbol: 'USDC' },
         output: {
           contractAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' as Hex,
@@ -1260,7 +1337,7 @@ describe('executeDestinationSwap', () => {
           approvalAddress: '0x4444444444444444444444444444444444444444' as Hex,
           tx: { to: '0x5555555555555555555555555555555555555555' as Hex, data: '0xfeedface' as Hex, value: '0x0' as Hex },
         },
-      },
+      }),
       holding: { chainID: ARB_CHAIN, tokenAddress: USDC_ARB, amountRaw: 25_000_000n, decimals: 6, symbol: 'USDC' },
       aggregator: {} as Aggregator,
     };
@@ -1321,7 +1398,7 @@ describe('executeDestinationSwap', () => {
     const tokenSwap = makeQuoteResponse();
     const gasSwap: QuoteResponse = {
       chainID: ARB_CHAIN,
-      quote: {
+      quote: quoteFixture({
         input: { contractAddress: USDC_ARB, amount: '25', amountRaw: 25_000_000n, decimals: 6, value: 25, symbol: 'USDC' },
         output: {
           contractAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' as Hex,
@@ -1331,7 +1408,7 @@ describe('executeDestinationSwap', () => {
           approvalAddress: '0x4444444444444444444444444444444444444444' as Hex,
           tx: { to: '0x5555555555555555555555555555555555555555' as Hex, data: '0xfeedface' as Hex, value: '0x0' as Hex },
         },
-      },
+      }),
       holding: { chainID: ARB_CHAIN, tokenAddress: USDC_ARB, amountRaw: 25_000_000n, decimals: 6, symbol: 'USDC' },
       aggregator: {} as Aggregator,
     };

--- a/tests/swap/execution/direct-destination.test.ts
+++ b/tests/swap/execution/direct-destination.test.ts
@@ -26,6 +26,7 @@ import type {
 } from '../../../src/swap/types';
 import { SwapMode } from '../../../src/swap/types';
 import { buildTransferAuthorization } from '../../../src/swap/wallet/transfer-authorization';
+import { quoteFixture } from '../../helpers/quote';
 
 vi.mock('../../../src/swap/execution/source-swaps', async () => {
   const actual = await vi.importActual<
@@ -73,7 +74,7 @@ const makeSwap = (
   },
   aggregator: {} as Aggregator,
   outputRole,
-  quote: {
+  quote: quoteFixture({
     input: {
       contractAddress: USDC,
       amount: new Decimal(inputAmountRaw.toString()).div(1_000_000).toFixed(),
@@ -94,7 +95,7 @@ const makeSwap = (
       approvalAddress: ROUTER,
       tx: { to: ROUTER, data: outputRole === 'token' ? '0xaaaa' : '0xbbbb', value: '0x0' },
     },
-  },
+  }),
 });
 
 const makeRoute = (swaps: QuoteResponse[]): SwapRoute => ({

--- a/tests/swap/execution/mayan-bridge-requote.test.ts
+++ b/tests/swap/execution/mayan-bridge-requote.test.ts
@@ -132,4 +132,37 @@ describe('refreshMayanQuotesForExecution', () => {
     expect(quoteEffectiveIn).toBe(EXECUTED_RAW);
     expect(rffValue).toBe(quoteEffectiveIn);
   });
+
+  it('recomputes protected Mayan delivery and fees from actual input and refreshed minReceived', async () => {
+    const middleware = {
+      getMayanQuotes: async (req: {
+        sources: { chain_id: string; contract_address: Hex; amount: string }[];
+      }) => ({
+        destination: { chainId: BASE_CHAIN, tokenAddress: USDC_BASE },
+        quotes: req.sources.map((source) => ({
+          source: {
+            chainId: Number(BigInt(source.chain_id)),
+            tokenAddress: source.contract_address,
+            amount: source.amount,
+          },
+          mayanQuote: {
+            ...makeMayanQuote(source.amount),
+            minReceived: 470,
+            expectedAmountOut: 476,
+          },
+        })),
+      }),
+    };
+
+    const refreshed = await refreshMayanQuotesForExecution(
+      makeStaleBridge(),
+      makeExecutedAssets(),
+      middleware as never
+    );
+
+    expect(refreshed.amount.toString()).toBe('477.873208');
+    expect(refreshed.amounts.totalAmount.toString()).toBe('477.873208');
+    expect(refreshed.amounts.tokenAmount.toString()).toBe('470');
+    expect(refreshed.estimatedFees.protocol.toString()).toBe('7.873208');
+  });
 });

--- a/tests/swap/execution/orchestrator.test.ts
+++ b/tests/swap/execution/orchestrator.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CurrencyID } from '../../../src/swap/cot';
+import { SwapMode } from '../../../src/swap/types';
+
+vi.mock('../../../src/swap/execution/source-swaps', () => ({
+  executeSourceSwaps: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../../src/swap/execution/bridge', () => ({
+  executeSwapBridge: vi.fn(),
+}));
+
+vi.mock('../../../src/swap/execution/direct-destination', () => ({
+  executeDirectDestinationExactOut: vi.fn(),
+}));
+
+vi.mock('../../../src/swap/execution/destination-swap', () => ({
+  executeDestinationSwap: vi.fn(),
+}));
+
+vi.mock('../../../src/swap/execution/failure-cleanup', () => ({
+  resolveFailureSweepCurrencyId: vi.fn().mockReturnValue(CurrencyID.USDC),
+  cleanupStrandedCot: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { executeDestinationSwap } from '../../../src/swap/execution/destination-swap';
+import { cleanupStrandedCot } from '../../../src/swap/execution/failure-cleanup';
+import { executeSwapRoute } from '../../../src/swap/execution/orchestrator';
+
+describe('executeSwapRoute destination cleanup', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('runs destination-chain cleanup when mandatory Exact In balance reads are exhausted', async () => {
+    vi.mocked(executeDestinationSwap).mockRejectedValue(new Error('destination balance read failed'));
+    const route = {
+      type: SwapMode.EXACT_IN,
+      directDestination: false,
+      sameTokenBridge: false,
+      settlementCurrencyId: CurrencyID.USDC,
+      source: { swaps: [], creationTime: Date.now(), srcBuffer: null },
+      bridge: null,
+      destination: {
+        chainId: 8453,
+        swap: { tokenSwap: {}, gasSwap: null },
+      },
+      dstTokenInfo: {},
+    } as never;
+    const context = { destinationChainId: 8453 } as never;
+
+    await expect(executeSwapRoute(route, context)).rejects.toThrow(
+      'destination balance read failed'
+    );
+
+    expect(cleanupStrandedCot).toHaveBeenCalledWith({
+      currencyId: CurrencyID.USDC,
+      chainIds: [8453],
+      ctx: context,
+    });
+  });
+});

--- a/tests/swap/execution/source-swap-requote.test.ts
+++ b/tests/swap/execution/source-swap-requote.test.ts
@@ -22,6 +22,7 @@ import type {
   WalletPath,
 } from '../../../src/swap/types';
 import { EADDRESS } from '../../../src/swap/constants';
+import { quoteFixture } from '../../helpers/quote';
 
 const ARB_CHAIN = 42161;
 const USDC = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913' as Hex;
@@ -44,14 +45,14 @@ const innerData = (data: Hex) => {
 // tells stale (original) from fresh (re-quoted) apart.
 const makeNativeQuote = (swapData: Hex, outputRaw: bigint, aggregator?: Aggregator): QuoteResponse => ({
   chainID: ARB_CHAIN,
-  quote: {
+  quote: quoteFixture({
     input: { contractAddress: EADDRESS as Hex, amount: '0.015', amountRaw: NATIVE_IN, decimals: 18, value: 45, symbol: 'ETH' },
     output: { contractAddress: USDC, amount: '45', amountRaw: outputRaw, decimals: 6, value: 45, symbol: 'USDC' },
     txData: {
       approvalAddress: '0x1111111111111111111111111111111111111111' as Hex,
       tx: { to: BEBOP, data: swapData, value: '0x354a6ba7a18000' as Hex },
     },
-  },
+  }),
   holding: { chainID: ARB_CHAIN, tokenAddress: EADDRESS as Hex, amountRaw: NATIVE_IN, decimals: 18, symbol: 'ETH' },
   aggregator: aggregator ?? ({} as Aggregator),
 });

--- a/tests/swap/execution/source-swaps.test.ts
+++ b/tests/swap/execution/source-swaps.test.ts
@@ -68,6 +68,10 @@ import { createSweeperTxs } from '../../../src/swap/sweep';
 import { signPermitForAddressAndValue } from '../../../src/services/allowance-utils';
 import { makeSwapExecutionMiddlewareClient } from '../../helpers/middleware-client';
 import type { QuoteResponse, Aggregator } from '../../../src/swap/aggregators/types';
+import {
+  quoteResponseFixture,
+  type QuoteResponseFixtureOverrides,
+} from '../../helpers/quote';
 import type {
   PreparedSwapExecution,
   SwapMetadata,
@@ -112,8 +116,8 @@ const makeSbcFailure = (chainId: number, message: string) => ({
 
 const makeQuoteResponse = (
   chainId = ARB_CHAIN,
-  overrides?: Partial<QuoteResponse>
-): QuoteResponse => ({
+  overrides?: QuoteResponseFixtureOverrides
+): QuoteResponse => quoteResponseFixture({
   chainID: chainId,
   quote: {
     input: { contractAddress: WETH, amount: '1.0', amountRaw: 1000000000000000000n, decimals: 18, value: 3000, symbol: 'WETH' },
@@ -125,8 +129,7 @@ const makeQuoteResponse = (
   },
   holding: { chainID: chainId, tokenAddress: WETH, amountRaw: 1000000000000000000n, decimals: 18, symbol: 'WETH' },
   aggregator: {} as Aggregator,
-  ...overrides,
-});
+}, overrides);
 
 type SrcCtx = Pick<
   ExecutionContext,

--- a/tests/swap/intent.test.ts
+++ b/tests/swap/intent.test.ts
@@ -6,13 +6,18 @@ import { SwapMode } from '../../src/swap/types';
 import type { SwapRoute, SwapData } from '../../src/swap/types';
 import type { Aggregator, QuoteResponse } from '../../src/swap/aggregators/types';
 import type { ChainListType, TokenInfo } from '../../src/domain';
+import {
+  quoteResponseFixture,
+  type QuoteResponseFixtureOverrides,
+} from '../helpers/quote';
 
 const USDC_ARB = '0xaf88d065e77c8cc2239327c5edb3a432268e5831' as Hex;
 const WETH = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as Hex;
 const ARB_CHAIN = 42161;
 const BASE_CHAIN = 8453;
 
-const makeQuoteResponse = (overrides?: Partial<QuoteResponse>): QuoteResponse => ({
+const makeQuoteResponse = (overrides?: QuoteResponseFixtureOverrides): QuoteResponse =>
+  quoteResponseFixture({
   chainID: ARB_CHAIN,
   quote: {
     input: { contractAddress: WETH, amount: '1.0', amountRaw: 1000000000000000000n, decimals: 18, value: 3000, symbol: 'WETH' },
@@ -24,8 +29,7 @@ const makeQuoteResponse = (overrides?: Partial<QuoteResponse>): QuoteResponse =>
   },
   holding: { chainID: ARB_CHAIN, tokenAddress: WETH, amountRaw: 1000000000000000000n, decimals: 18, symbol: 'WETH' },
   aggregator: {} as Aggregator,
-  ...overrides,
-});
+  }, overrides);
 
 const makeChainList = () => ({
   getChainByID: (id: number) => ({

--- a/tests/swap/max.test.ts
+++ b/tests/swap/max.test.ts
@@ -37,12 +37,13 @@ import {
   makeSwapChainList,
   makeSwapPreflight,
 } from '../helpers/swap';
+import { quoteFixture } from '../helpers/quote';
 
 type MaxOptions = Parameters<typeof calculateMaxForSwap>[1];
 
 const makeQuote = (inputRaw: bigint, outputRaw: bigint): QuoteResponse => ({
   chainID: ARB_CHAIN,
-  quote: {
+  quote: quoteFixture({
     input: {
       contractAddress: USDC_ARB,
       amount: new Decimal(inputRaw.toString()).div(new Decimal(10).pow(6)).toString(),
@@ -63,7 +64,7 @@ const makeQuote = (inputRaw: bigint, outputRaw: bigint): QuoteResponse => ({
       approvalAddress: '0x1111111111111111111111111111111111111111' as Hex,
       tx: { to: '0x2222222222222222222222222222222222222222' as Hex, data: '0xabcdef' as Hex, value: '0x0' as Hex },
     },
-  },
+  }),
   holding: { chainID: ARB_CHAIN, tokenAddress: USDC_ARB, amountRaw: inputRaw, decimals: 6, symbol: 'USDC' },
   aggregator: {} as Aggregator,
 });
@@ -77,7 +78,7 @@ const makeOutputValueQuote = (
   outputDecimals = 18
 ): QuoteResponse => ({
   chainID: ARB_CHAIN,
-  quote: {
+  quote: quoteFixture({
     input: { contractAddress: USDC_ARB, amount: '0', amountRaw: 0n, decimals: 6, value: 0, symbol: 'USDC' },
     output: {
       contractAddress: outputContract,
@@ -91,7 +92,7 @@ const makeOutputValueQuote = (
       approvalAddress: '0x1111111111111111111111111111111111111111' as Hex,
       tx: { to: '0x2222222222222222222222222222222222222222' as Hex, data: '0xabcdef' as Hex, value: '0x0' as Hex },
     },
-  },
+  }),
   holding: { chainID: ARB_CHAIN, tokenAddress: USDC_ARB, amountRaw: 0n, decimals: 6, symbol: 'USDC' },
   aggregator: {} as Aggregator,
 });
@@ -333,6 +334,19 @@ describe('calculateMaxForSwap', () => {
     expect(vi.mocked(determineSwapRoute).mock.calls[0][1]).toMatchObject({
       bridgeQuoteResponse,
     });
+  });
+
+  it('constructs the synthetic Exact In route with the minimum amount basis', async () => {
+    vi.mocked(determineSwapRoute).mockResolvedValue(makeRoute());
+
+    await calculateMaxForSwap(
+      { toChainId: ARB_CHAIN, toTokenAddress: WETH },
+      makeOptions()
+    );
+
+    expect(vi.mocked(determineSwapRoute).mock.calls[0][1].exactInAmountBasis).toBe('minimum');
+    expect(buildSwapPreflight).toHaveBeenCalledTimes(1);
+    expect(determineSwapRoute).toHaveBeenCalledTimes(1);
   });
 
   it('passes sources restrictions into the synthetic EXACT_IN max route input', async () => {

--- a/tests/swap/prepare.test.ts
+++ b/tests/swap/prepare.test.ts
@@ -11,6 +11,7 @@ import type { Aggregator } from '../../src/swap/aggregators/types';
 import type { TokenInfo } from '../../src/domain';
 import { makeChain, makeChainList } from '../helpers/chains';
 import { makeTimingHooks } from '../helpers/timing';
+import { quoteFixture } from '../helpers/quote';
 
 vi.mock('../../src/services/allowance-utils', () => ({
   signPermitForAddressAndValue: vi.fn(),
@@ -37,7 +38,7 @@ const SUPPORTED_TOKEN: TokenInfo = {
 
 const makeQuoteResponse = (): QuoteResponse => ({
   chainID: ARB_CHAIN,
-  quote: {
+  quote: quoteFixture({
     input: {
       contractAddress: USDC_ARB,
       amount: '3000',
@@ -62,7 +63,7 @@ const makeQuoteResponse = (): QuoteResponse => ({
         value: '0x0' as Hex,
       },
     },
-  },
+  }),
   holding: {
     chainID: ARB_CHAIN,
     tokenAddress: USDC_ARB,

--- a/tests/swap/route.test.ts
+++ b/tests/swap/route.test.ts
@@ -1581,7 +1581,7 @@ describe('determineSwapRoute', () => {
     );
   });
 
-  it('EXACT_IN getDstSwap sizes the input to actual - deduction (floor 0)', async () => {
+  it('EXACT_IN getDstSwap sizes the input to the full actual balance (floor 0)', async () => {
     const input: SwapData = {
       mode: SwapMode.EXACT_IN,
       data: {
@@ -1600,20 +1600,18 @@ describe('determineSwapRoute', () => {
         ],
       })
     );
-    // No source buffer: floor = 0, max = cotAvailable = 3000.
-    // Full delivery, no drift: actual COT at the wrapper = 3000. deduction = 1bp of 3000 = 0.3.
-    // execInput = 3000 - 0.3 = 2999.7 → 2999700000n raw.
+    // No source buffer: floor = 0, max = cotAvailable = 3000. Execution must quote the complete
+    // measured balance so the user receives only the requested destination token, not residual COT.
     const resized = await route.destination.getDstSwap(3000000000n);
     expect(resized).not.toBeNull();
     expect(vi.mocked(destinationSwapWithExactIn)).toHaveBeenLastCalledWith(
-      expect.objectContaining({ input: expect.objectContaining({ amountRaw: 2999700000n }) })
+      expect.objectContaining({ input: expect.objectContaining({ amountRaw: 3000000000n }) })
     );
-    // Input scales with the actual delivered balance (minus deduction) and is NOT capped at the
-    // route estimate — the source reclaim can over-deliver, and that surplus must be spent here.
-    // 5000 actual → 5000 - 0.5 (1bp) = 4999.5 → 4999500000n.
+    // Input scales with the actual delivered balance and is NOT capped at the route estimate — the
+    // source reclaim can over-deliver, and all of that surplus must be converted here.
     await route.destination.getDstSwap(5000000000n);
     expect(vi.mocked(destinationSwapWithExactIn)).toHaveBeenLastCalledWith(
-      expect.objectContaining({ input: expect.objectContaining({ amountRaw: 4999500000n }) })
+      expect.objectContaining({ input: expect.objectContaining({ amountRaw: 5000000000n }) })
     );
   });
 

--- a/tests/swap/route.test.ts
+++ b/tests/swap/route.test.ts
@@ -67,10 +67,16 @@ import {
   makeSwapChainListWithUsdtCot,
 } from '../helpers/swap';
 import { makeTimingHooks } from '../helpers/timing';
+import {
+  quoteFixture,
+  quoteResponseFixture,
+  type QuoteResponseFixtureOverrides,
+} from '../helpers/quote';
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-const makeQuoteResponse = (overrides?: Partial<QuoteResponse>): QuoteResponse => ({
+const makeQuoteResponse = (overrides?: QuoteResponseFixtureOverrides): QuoteResponse =>
+  quoteResponseFixture({
   chainID: ARB_CHAIN,
   quote: {
     input: { contractAddress: WETH, amount: '1.0', amountRaw: 1000000000000000000n, decimals: 18, value: 3000, symbol: 'WETH' },
@@ -82,9 +88,9 @@ const makeQuoteResponse = (overrides?: Partial<QuoteResponse>): QuoteResponse =>
   },
   holding: { chainID: ARB_CHAIN, tokenAddress: WETH, amountRaw: 1000000000000000000n, decimals: 18, symbol: 'WETH' },
   aggregator: {} as Aggregator,
-  ...overrides,
-});
-const makeDestinationQuoteResponse = (overrides?: Partial<QuoteResponse>): QuoteResponse => ({
+  }, overrides);
+const makeDestinationQuoteResponse = (overrides?: QuoteResponseFixtureOverrides): QuoteResponse =>
+  quoteResponseFixture({
   chainID: ARB_CHAIN,
   quote: {
     input: { contractAddress: USDC_ARB, amount: '3100', amountRaw: 3100000000n, decimals: 6, value: 3100, symbol: 'USDC' },
@@ -96,8 +102,7 @@ const makeDestinationQuoteResponse = (overrides?: Partial<QuoteResponse>): Quote
   },
   holding: { chainID: ARB_CHAIN, tokenAddress: USDC_ARB, amountRaw: 3100000000n, decimals: 6, symbol: 'WETH' },
   aggregator: {} as Aggregator,
-  ...overrides,
-});
+  }, overrides);
 const makeGasQuoteResponse = (overrides?: {
   chainID?: number;
   inputAmountRaw?: bigint;
@@ -114,14 +119,14 @@ const makeGasQuoteResponse = (overrides?: {
   const inputContract = overrides?.inputContract ?? USDC_BASE;
   return {
     chainID,
-    quote: {
+    quote: quoteFixture({
       input: { contractAddress: inputContract, amount: inputAmount, amountRaw: inputAmountRaw, decimals: 6, value: Number(inputAmount), symbol: 'USDC' },
       output: { contractAddress: EADDRESS, amount: outputAmount, amountRaw: outputAmountRaw, decimals: 18, value: Number(inputAmount), symbol: 'ETH' },
       txData: {
         approvalAddress: '0x1111111111111111111111111111111111111111' as Hex,
         tx: { to: '0x2222222222222222222222222222222222222222' as Hex, data: '0xabcdef' as Hex, value: '0x0' as Hex },
       },
-    },
+    }),
     holding: { chainID, tokenAddress: inputContract, amountRaw: inputAmountRaw, decimals: 6, symbol: 'USDC' },
     aggregator: {} as Aggregator,
   };
@@ -215,6 +220,141 @@ describe('determineSwapRoute', () => {
     vi.mocked(selectDirectDestinationSwaps).mockReset();
     vi.mocked(selectDirectDestinationSwaps).mockResolvedValue({ quoteResponses: [], usedCOTs: [] });
   });
+
+  it.each([
+    {
+      basis: 'expected' as const,
+      sourceAmount: '3200',
+      mayanDelivery: '3150',
+      bridgeFee: '50',
+      intentAmount: '1.1',
+      intentValue: '3300',
+    },
+    {
+      basis: 'minimum' as const,
+      sourceAmount: '3000',
+      mayanDelivery: '2900',
+      bridgeFee: '100',
+      intentAmount: '1',
+      intentValue: '3000',
+    },
+  ])(
+    'EXACT_IN cascades the $basis amount through source, Mayan, destination, and intent',
+    async ({ basis, sourceAmount, mayanDelivery, bridgeFee, intentAmount, intentValue }) => {
+      const sourceQuote = makeQuoteResponse();
+      sourceQuote.quote.expectedOutput = {
+        amountRaw: 3_200_000_000n,
+        amount: '3200',
+        value: 3200,
+      };
+      vi.mocked(liquidateInputHoldings).mockResolvedValue([sourceQuote]);
+
+      const destinationQuote = makeDestinationQuoteResponse({ chainID: BASE_CHAIN });
+      destinationQuote.quote.input = {
+        ...destinationQuote.quote.input,
+        contractAddress: USDC_BASE,
+        amount: mayanDelivery,
+        amountRaw: BigInt(new Decimal(mayanDelivery).mul(1_000_000).toFixed(0)),
+      };
+      destinationQuote.quote.output = {
+        ...destinationQuote.quote.output,
+        amount: '1',
+        amountRaw: 1_000_000_000_000_000_000n,
+        value: 3000,
+      };
+      destinationQuote.quote.expectedOutput = {
+        amountRaw: 1_100_000_000_000_000_000n,
+        amount: '1.1',
+        value: 3300,
+      };
+      vi.mocked(destinationSwapWithExactIn).mockResolvedValue(destinationQuote);
+
+      const mayanRequests: string[] = [];
+      const middleware = {
+        getBridgeProvider: vi.fn(),
+        getMayanQuotes: vi.fn().mockImplementation(
+          async (req: {
+            sources: { chain_id: Hex; contract_address: Hex; amount: string }[];
+            destination: { chain_id: Hex; contract_address: Hex };
+          }) => {
+            const amountRaw = BigInt(req.sources[0].amount);
+            mayanRequests.push(req.sources[0].amount);
+            const minReceivedRaw = amountRaw - 100_000_000n;
+            const expectedReceivedRaw = amountRaw - 50_000_000n;
+            return {
+              destination: req.destination,
+              quotes: req.sources.map((source) => ({
+                source: {
+                  chainId: Number(BigInt(source.chain_id)),
+                  tokenAddress: source.contract_address,
+                  amount: source.amount,
+                },
+                mayanQuote: {
+                  effectiveAmountIn64: source.amount,
+                  expectedAmountOutBaseUnits: expectedReceivedRaw.toString(),
+                  expectedAmountOut: Number(expectedReceivedRaw) / 1_000_000,
+                  minReceived: Number(minReceivedRaw) / 1_000_000,
+                  protocolBps: 3,
+                },
+              })),
+            };
+          }
+        ),
+      };
+      const input: SwapData = {
+        mode: SwapMode.EXACT_IN,
+        data: {
+          sources: [{ chainId: ARB_CHAIN, tokenAddress: WETH }],
+          toChainId: BASE_CHAIN,
+          toTokenAddress: DAI,
+        },
+      };
+      const chainList = makeSwapChainList() as unknown as ChainListType;
+      const route = await determineSwapRoute(
+        input,
+        makeRouteOptions({
+          chainList,
+          middlewareClient: middleware as never,
+          forceMayan: true,
+          skipFastPaths: true,
+          exactInAmountBasis: basis,
+          dstTokenInfo: makeDstTokenInfo({
+            contractAddress: DAI,
+            decimals: 18,
+            symbol: 'DAI',
+            name: 'Dai',
+          }),
+          balances: [
+            {
+              amount: '1',
+              chainID: ARB_CHAIN,
+              decimals: 18,
+              symbol: 'WETH',
+              tokenAddress: WETH,
+              value: 3200,
+              logo: '',
+              name: 'WETH',
+            },
+          ],
+        })
+      );
+      const intent = createSwapIntent(route, input, chainList);
+
+      expect(route.bridge!.amount.toFixed()).toBe(sourceAmount);
+      expect(mayanRequests).toEqual([new Decimal(sourceAmount).mul(1_000_000).toFixed()]);
+      expect(route.bridge!.amounts.tokenAmount.toFixed()).toBe(mayanDelivery);
+      expect(route.bridge!.estimatedFees.protocol.toFixed()).toBe(bridgeFee);
+      expect(destinationSwapWithExactIn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            amountRaw: BigInt(new Decimal(mayanDelivery).mul(1_000_000).toFixed(0)),
+          }),
+        })
+      );
+      expect(intent.destination.amount).toBe(intentAmount);
+      expect(intent.destination.value).toBe(intentValue);
+    }
+  );
   it('EXACT_OUT destination-only holdings route directly with no bridge', async () => {
     const input: SwapData = {
       mode: SwapMode.EXACT_OUT,
@@ -2733,11 +2873,11 @@ describe('determineSwapRoute', () => {
     const human = (raw: bigint, decimals: number) => new Decimal(raw.toString()).div(new Decimal(10).pow(decimals)).toString();
     const leg = (inputToken: Hex, inputRaw: bigint, inputDecimals: number, outputToken: Hex, outputRaw: bigint, outputDecimals: number): QuoteResponse => ({
       chainID: ARB_CHAIN,
-      quote: {
+      quote: quoteFixture({
         input: { contractAddress: inputToken, amount: human(inputRaw, inputDecimals), amountRaw: inputRaw, decimals: inputDecimals, value: 0, symbol: 'IN' },
         output: { contractAddress: outputToken, amount: human(outputRaw, outputDecimals), amountRaw: outputRaw, decimals: outputDecimals, value: 0, symbol: 'OUT' },
         txData: { approvalAddress: '0x1111111111111111111111111111111111111111' as Hex, tx: { to: '0x2222222222222222222222222222222222222222' as Hex, data: '0xabcdef' as Hex, value: '0x0' as Hex } },
-      },
+      }),
       holding: { chainID: ARB_CHAIN, tokenAddress: inputToken, amountRaw: inputRaw, decimals: inputDecimals, symbol: 'IN' },
       aggregator: {} as Aggregator,
     });

--- a/tests/swap/routing/bridge.test.ts
+++ b/tests/swap/routing/bridge.test.ts
@@ -53,5 +53,9 @@ describe('swap routing bridge mechanics', () => {
     expect(result.estimatedFees.protocol).toEqual(new Decimal(1));
     expect(result.totalFeeAmount).toEqual(new Decimal(3));
     expect(result.deliveredAmount).toEqual(new Decimal(97));
+    expect(result.nexusFeeModel).toEqual({
+      fulfillmentFee: new Decimal(2),
+      fulfillmentBps: new Decimal(100),
+    });
   });
 });

--- a/tests/swap/swap-steps-builder.test.ts
+++ b/tests/swap/swap-steps-builder.test.ts
@@ -6,6 +6,7 @@ import type { BridgeAsset, DestinationSwap, SwapRoute } from '../../src/swap/typ
 import { SwapMode } from '../../src/swap/types';
 import type { Aggregator, Holding, Quote } from '../../src/swap/aggregators/types';
 import { makeChain, makeChainList } from '../helpers/chains';
+import { quoteFixture } from '../helpers/quote';
 
 const token = {
   contractAddress: '0x0000000000000000000000000000000000000001' as const,
@@ -24,7 +25,7 @@ const noSwap: DestinationSwap = { tokenSwap: null, gasSwap: null };
 const withTokenSwap: DestinationSwap = {
   tokenSwap: {
     chainID: 8453,
-    quote: {
+    quote: quoteFixture({
       input: {
         contractAddress: token.contractAddress,
         amount: '100',
@@ -49,7 +50,7 @@ const withTokenSwap: DestinationSwap = {
           value: '0x0' as Hex,
         },
       },
-    } as Quote,
+    }),
     holding: {} as Holding,
     aggregator: {} as Aggregator,
   },
@@ -76,7 +77,7 @@ const makeRoute = (overrides: Partial<SwapRoute> = {}): SwapRoute => ({
 
 const makeQuoteResponse = (chainID: number) => ({
   chainID,
-  quote: {
+  quote: quoteFixture({
     input: {
       contractAddress: '0x00000000000000000000000000000000000000aa' as Hex,
       amount: '50000',
@@ -101,7 +102,7 @@ const makeQuoteResponse = (chainID: number) => ({
         value: '0x0' as Hex,
       },
     },
-  } as Quote,
+  }),
   holding: {
     chainID,
     tokenAddress: '0x01' as Hex,


### PR DESCRIPTION
## Summary

Exact In previews currently carry slippage-protected minimum outputs through each routing stage, which understates the destination amount and value shown to users. This change carries normalized expected outputs through Exact In route construction while preserving protected minimums for quote selection and execution safety.

Normal Exact In previews use the expected source-swap output to size the bridge, the expected bridge delivery to size the destination swap, and the expected destination output in the existing `SwapIntent.destination` fields. `calculateMaxForSwap` remains conservative and continues using protected minimums without requesting additional quotes. Exact Out behavior is unchanged.

## Changes

- Add a required normalized `expectedOutput` to aggregator quotes while retaining `output` as the executable protected minimum.
- Populate expected outputs from LiFi, Bebop, Relay, 0x, Mystic, and Fibrous responses.
- Fall back to the protected output when an expected value is missing, malformed, non-positive, or below the protected minimum.
- Recalculate expected human-readable and USD values when 0x or Mystic quotes receive token metadata enrichment.
- Keep aggregator winner selection, calldata, approvals, retries, and execution guards based on protected quote fields.
- Add an internal Exact In amount basis:
  - Use expected amounts for `swapWithExactIn` previews.
  - Use protected minimums for `calculateMaxForSwap` and direct internal calls by default.
- Carry the selected basis consistently through source aggregation, bridge sizing, COT totals, fast paths, destination quoting, intent values, and route logging without adding quote requests or parallel routes.
- Use Mayan expected delivery data with protected fallback and apply Nexus's fixed-plus-bps fee model to expected preview inputs.
- Preserve execution accounting by recomputing Nexus fees from actual bridged balances and Mayan protected fees from refreshed quotes and actual inputs.
- Require the Exact In destination balance read and destination quote resize before dispatch, retrying three times before failing with destination-step context and running existing cleanup.
- Consume the complete measured destination COT balance for Exact In and reject under-consuming resized quotes instead of returning settlement-token dust to the user.
- Update the README and swap implementation documentation for the new Exact In intent semantics and execution-time reconciliation.
- Add adapter, routing, fee-accounting, execution retry, cleanup, and characterization coverage.

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

## Risk / Impact

- No public SDK method signature, exported intent type, or quote-request count changes.
- Exact In `SwapIntent.destination.amount` and `.value` now represent expected output rather than the protected minimum. Consumers that display or analyze these existing fields will observe the intentional semantic change.
- Exact In route construction can size later stages from optimistic expected values, but execution still uses protected quote fields and must resize the destination quote against the actual delivered balance before dispatch.
- Exact In destination swaps now spend the complete measured COT balance. If an aggregator returns a quote whose input does not match that balance, execution retries and ultimately fails safely rather than delivering both the requested token and residual COT.
- A destination balance read or resize that fails on all three attempts now prevents dispatch and triggers cleanup instead of using the optimistic preview size.
- Malformed or unavailable expected data falls back to the executable protected output, so it does not invalidate an otherwise usable quote.
- Exact Out routing and execution remain unchanged, and maximum-input calculations remain based on protected minimums.