### PR TITLE
dependency: add adm-zip version to override to fix hardhat audit issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3225,13 +3225,13 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
-      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.3.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/aes-js": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
   "overrides": {
     "tmp": "0.2.7",
     "ws": "8.21.0",
-    "uuid": "11.1.1"
+    "uuid": "11.1.1",
+    "adm-zip": "0.6.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Resolves `CVE-2026-39244`

## Changes
- Add `adm-zip@0.6.0` to overrides in package.json 

## Testing
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

## Risk / Impact