### PR TITLE
bridge: remove haircut from max calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,7 +916,7 @@ type SwapMaxResult = {
 
 Calculate the maximum amount that can be bridged to a destination token across all same-currency holdings on other chains. Useful for populating a "Max" button before calling `bridge`.
 
-The max is sized against the provider the bridge will actually use: the summed bridge amount is checked against the Mayan threshold (the same decision the real bridge makes), and the receivable max is computed for that provider — Nexus backs out deposit/fulfillment/protocol fees, Mayan sums the per-leg `minReceived`. A `max(3%, $3)` safety haircut is applied so the suggested amount survives fee drift before execution. The returned `provider` tells you which path was used.
+The max is sized against the provider the bridge will actually use: the summed bridge amount is checked against the Mayan threshold (the same decision the real bridge makes), and the receivable max is computed for that provider — Nexus backs out deposit/fulfillment/protocol fees, while Mayan sums the per-leg `minReceived`. No additional safety haircut is applied. The returned `provider` tells you which path was used.
 
 ```typescript
 const max = await client.calculateMaxForBridge({

--- a/src/bridge/max.ts
+++ b/src/bridge/max.ts
@@ -15,12 +15,6 @@ import {
 } from './intent/quote-request';
 import type { BridgeMaxParams, BridgeMaxResult } from './types';
 
-// Safety haircut applied to the computed max so the suggested amount survives fee/quote drift
-// between this estimate and execution. Mirrors calculateMaxForSwap: the larger of 3% or $3,
-// with the $3 floor converted to token units (so it stays $3, not 3 ETH, for non-stables).
-const MAX_BRIDGE_HAIRCUT_PCT = 0.03;
-const MAX_BRIDGE_HAIRCUT_MIN_USD = 3;
-
 type BridgeMaxExecutionParams = {
   chainList: ChainListType;
   evmAddress: Hex;
@@ -52,7 +46,6 @@ type SourceEntry = {
  *    middleware, which compares it against the Mayan threshold.
  * 3. Compute the receivable max for that provider (Nexus: back out deposit/fulfillment/bps;
  *    Mayan: sum minReceived across eligible legs quoted at full balance).
- * 4. Apply the max(3%, $3) safety haircut.
  */
 export async function calculateMaxForBridge(
   input: BridgeMaxParams,
@@ -121,14 +114,12 @@ export async function calculateMaxForBridge(
     ({ maxToken, selected } = computeNexusBridgeMax({ entries, dstToken, quoteResponse }));
   }
 
-  const adjusted = applyHaircut(maxToken, tokenPriceUsd(asset.value.value, asset.value.balance));
-
   return {
     toChainId: input.toChainId,
     toTokenSymbol: input.toTokenSymbol,
     provider,
-    maxAmount: adjusted.toFixed(dstToken.decimals),
-    maxAmountRaw: mulDecimals(adjusted, dstToken.decimals),
+    maxAmount: maxToken.toFixed(dstToken.decimals),
+    maxAmountRaw: mulDecimals(maxToken, dstToken.decimals),
     symbol: dstToken.symbol,
     decimals: dstToken.decimals,
     sources: selected.map((entry) => ({
@@ -234,18 +225,4 @@ const computeMayanBridgeMax = async (args: {
     maxToken: quotes.reduce((sum, leg) => Decimal.add(sum, leg.minReceived), new Decimal(0)),
     selected: eligible.map((leg) => leg.entry),
   };
-};
-
-const tokenPriceUsd = (valueUsd: string, balance: string): Decimal => {
-  const value = new Decimal(valueUsd);
-  const bal = new Decimal(balance);
-  return value.gt(0) && bal.gt(0) ? value.div(bal) : new Decimal(0);
-};
-
-const applyHaircut = (maxToken: Decimal, priceUsd: Decimal): Decimal => {
-  const haircutPct = maxToken.mul(MAX_BRIDGE_HAIRCUT_PCT);
-  const haircutMin = priceUsd.gt(0)
-    ? new Decimal(MAX_BRIDGE_HAIRCUT_MIN_USD).div(priceUsd)
-    : new Decimal(0);
-  return Decimal.max(maxToken.minus(Decimal.max(haircutPct, haircutMin)), new Decimal(0));
 };

--- a/tests/bridge/max.test.ts
+++ b/tests/bridge/max.test.ts
@@ -136,7 +136,7 @@ describe('calculateMaxForBridge', () => {
     vi.clearAllMocks();
   });
 
-  it('nexus path: sums usable across sources, 3% haircut dominates', async () => {
+  it('nexus path: returns the full usable amount across sources', async () => {
     vi.mocked(getBalancesForBridge).mockResolvedValue([
       makeAsset({
         balance: '150',
@@ -151,16 +151,15 @@ describe('calculateMaxForBridge', () => {
     const input: BridgeMaxParams = { toChainId: 137, toTokenSymbol: 'USDC' };
     const result = await calculateMaxForBridge(input, makeOptions({ quote: zeroFeeQuote([1, 10], 137) }));
 
-    // total usable 150 → 3% haircut = 4.5 (> $3) → 145.5
     expect(result.provider).toBe('nexus');
-    expect(result.maxAmount).toBe('145.500000');
-    expect(result.maxAmountRaw).toBe(145_500_000n);
+    expect(result.maxAmount).toBe('150.000000');
+    expect(result.maxAmountRaw).toBe(150_000_000n);
     expect(result.symbol).toBe('USDC');
     expect(result.decimals).toBe(6);
     expect(result.sources.map((s) => s.chainId).sort()).toEqual([1, 10]);
   });
 
-  it('nexus path: $3 floor applies when 3% is smaller', async () => {
+  it('nexus path: does not deduct a minimum safety amount', async () => {
     vi.mocked(getBalancesForBridge).mockResolvedValue([
       makeAsset({
         balance: '50',
@@ -174,12 +173,11 @@ describe('calculateMaxForBridge', () => {
       makeOptions({ quote: zeroFeeQuote([1], 137) })
     );
 
-    // 3% of 50 = 1.5 < $3 → haircut = $3 → 47
-    expect(result.maxAmount).toBe('47.000000');
-    expect(result.maxAmountRaw).toBe(47_000_000n);
+    expect(result.maxAmount).toBe('50.000000');
+    expect(result.maxAmountRaw).toBe(50_000_000n);
   });
 
-  it('nexus path: $3 floor is denominated in USD, not 3 tokens, for non-stables', async () => {
+  it('nexus path: returns the full usable amount for non-stables', async () => {
     const WETH: TokenInfo = {
       contractAddress: '0x0000000000000000000000000000000000000002',
       decimals: 18,
@@ -215,9 +213,7 @@ describe('calculateMaxForBridge', () => {
       makeOptions({ token: WETH, quote: zeroFeeQuote([1], 137, WETH.contractAddress) })
     );
 
-    // 1 ETH max. 3% = 0.03 ETH; $3 floor = 3/2500 = 0.0012 ETH → 3% dominates → 0.97 ETH
-    // (NOT 1 - 3 = clamped 0, which a literal "3 token" floor would give).
-    expect(result.maxAmount).toBe('0.970000000000000000');
+    expect(result.maxAmount).toBe('1.000000000000000000');
     expect(result.decimals).toBe(18);
     expect(result.symbol).toBe('WETH');
   });
@@ -243,10 +239,9 @@ describe('calculateMaxForBridge', () => {
       })
     );
 
-    // each 100 → 99 out, total 198 → 3% haircut 5.94 → 192.06
     expect(result.provider).toBe('mayan');
-    expect(result.maxAmount).toBe('192.060000');
-    expect(result.maxAmountRaw).toBe(192_060_000n);
+    expect(result.maxAmount).toBe('198.000000');
+    expect(result.maxAmountRaw).toBe(198_000_000n);
     expect(result.sources.map((s) => s.chainId).sort((a, b) => a - b)).toEqual([8453, 42161]);
   });
 
@@ -267,8 +262,7 @@ describe('calculateMaxForBridge', () => {
       makeOptions({ quote: zeroFeeQuote([1, 10], 137) })
     );
 
-    // only chain 1's 100 considered → 3% = 3 = $3 floor → 97
-    expect(result.maxAmount).toBe('97.000000');
+    expect(result.maxAmount).toBe('100.000000');
     expect(result.sources.map((s) => s.chainId)).toEqual([1]);
   });
 
@@ -292,8 +286,7 @@ describe('calculateMaxForBridge', () => {
     );
 
     expect(result.provider).toBe('mayan');
-    // 100 → 99 out → 3% = 2.97 < $3 → haircut $3 → 96
-    expect(result.maxAmount).toBe('96.000000');
+    expect(result.maxAmount).toBe('99.000000');
   });
 
   it('falls back to nexus when no source clears the Mayan per-leg minimum', async () => {


### PR DESCRIPTION
## Summary

`calculateMaxForBridge` currently reduces the provider-computed receivable maximum by an additional `max(3%, $3)` safety haircut. This understates the amount available to bridge because the Nexus path already accounts for deposit, fulfillment, and protocol fees, while the Mayan path already uses each leg's quoted `minReceived`.

This change returns the provider-computed maximum directly without applying a second deduction.

## Changes

- Remove the bridge-specific percentage and minimum-USD haircut constants and helper.
- Return `maxToken` directly in both human-readable and raw-unit result fields.
- Preserve provider selection and the existing Nexus and Mayan fee calculations.
- Update bridge maximum tests for Nexus, Mayan, restricted-source, forced-provider, stablecoin, and non-stable-token scenarios.
- Update the README to document that `calculateMaxForBridge` does not apply an additional safety haircut.

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

## Risk / Impact

- No public method signature, exported type, provider-selection behavior, or quote-request behavior changes.
- Returned bridge maximums increase by the removed haircut amount, so consumers displaying or pre-filling the existing result fields will observe the intentional value change.
- Nexus results continue to account for deposit, fulfillment, and protocol fees; Mayan results continue to use protected `minReceived` quote values.
- The additional fee-drift cushion is intentionally removed, so execution relies on the provider-specific fee and quote calculations already included in the maximum.