### PR TITLE
example: update browser app to React Router 8

### DIFF
--- a/example/browser/package-lock.json
+++ b/example/browser/package-lock.json
@@ -23,7 +23,7 @@
         "decimal.js": "10.6.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "^6.30.4",
+        "react-router": "^8.3.0",
         "recharts": "^2.15.4",
         "sonner": "^2.0.7",
         "viem": "^2.52.2",
@@ -40,7 +40,7 @@
     },
     "../..": {
       "name": "@avail-project/nexus-core",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@avail-project/nexus-types": "0.1.21",
@@ -952,15 +952,6 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
       "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
       "license": "MIT"
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/@reown/appkit": {
       "version": "1.8.17-wc-circular-dependencies-fix.0",
@@ -5197,9 +5188,9 @@
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -5433,9 +5424,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -5453,7 +5444,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5637,36 +5628,31 @@
       "license": "0BSD"
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
-    "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
+    "node_modules/react-router/node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/react-smooth": {
       "version": "4.0.4",

--- a/example/browser/package.json
+++ b/example/browser/package.json
@@ -24,7 +24,7 @@
     "decimal.js": "10.6.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^6.30.4",
+    "react-router": "^8.3.0",
     "recharts": "^2.15.4",
     "sonner": "^2.0.7",
     "viem": "^2.52.2",

--- a/example/browser/src/App.tsx
+++ b/example/browser/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { Route, Routes, useLocation } from "react-router-dom";
+import { Route, Routes, useLocation } from "react-router";
 import { useConnection } from "wagmi";
 import { Toaster } from "sonner";
 import type { TokenBalance } from "@avail-project/nexus-core";

--- a/example/browser/src/components/AppShell.tsx
+++ b/example/browser/src/components/AppShell.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { NavLink, useLocation, useNavigate } from "react-router-dom";
+import { NavLink, useLocation, useNavigate } from "react-router";
 import * as Dialog from "@radix-ui/react-dialog";
 import type { TokenBalance } from "@avail-project/nexus-core";
 import type { NetworkMode, TabConfig } from "../lib/types";

--- a/example/browser/src/main.tsx
+++ b/example/browser/src/main.tsx
@@ -7,7 +7,7 @@ import "@fontsource/geist-mono";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router";
 import type { Transport } from "viem";
 import { http, WagmiProvider } from "wagmi";
 import {

--- a/example/browser/src/pages/Home.tsx
+++ b/example/browser/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router";
 import type { NexusClient } from "@avail-project/nexus-core";
 import type { NetworkMode, TabConfig } from "../lib/types";
 import type {


### PR DESCRIPTION
## Summary

This PR updates the browser example from React Router 6 to React Router 8 to resolve its dependency audit findings and align imports with the v8 package layout.

The browser example now audits with zero vulnerabilities while preserving its existing declarative routing behavior.

## Changes

- Replace `react-router-dom` with `react-router` 8.3.0 in the browser example.
- Move `BrowserRouter`, route components, navigation components, and routing hooks to `react-router` imports.
- Refresh the browser lockfile with the React Router 8 dependency graph and audited Nano ID and PostCSS patch updates.

## Risk / Impact

- No public Nexus SDK APIs or exports change.
- Browser routing behavior is unchanged; this only migrates the dependency and import source.
- The browser example now inherits React Router 8's Node 22.22+ requirement.
- The regenerated lockfile also includes audited Nano ID and PostCSS patch updates.