### PR TITLE
swap: exclude failed relay routers from requotes

### DIFF
--- a/src/swap/aggregators/index.ts
+++ b/src/swap/aggregators/index.ts
@@ -11,7 +11,7 @@ import { FibrousAggregator } from './fibrous';
 import { LiFiAggregator } from './lifi';
 import { MysticAggregator } from './mystic';
 import { RelayAggregator } from './relay';
-import type { Aggregator, Quote, QuoteRequest, TokenInfoProvider } from './types';
+import type { Aggregator, Quote, QuoteRequest, RouterExclusions, TokenInfoProvider } from './types';
 import { ZeroExAggregator } from './zerox';
 
 /**
@@ -122,7 +122,8 @@ const remainingForChain = (
 export const aggregateAggregators = async (
   requests: QuoteRequest[],
   aggregators: Aggregator[],
-  mode: AggregateMode
+  mode: AggregateMode,
+  routerExclusions?: RouterExclusions
 ): Promise<{ quote: Quote | null; aggregator: Aggregator }[]> => {
   // Native is canonically EADDRESS for the aggregators (the gas swap already quotes it that way).
   // A caller may pass it as ZERO_ADDRESS (e.g. a user's native toTokenAddress); normalize here so
@@ -153,7 +154,11 @@ export const aggregateAggregators = async (
         let failed = false;
         let quoted = 0;
         try {
-          const quotes = await agg.getQuotes(reqIdxs.map((reqIdx) => normalized[reqIdx]));
+          const selectedRequests = reqIdxs.map((reqIdx) => normalized[reqIdx]);
+          const excludedRouterIds = routerExclusions?.get(agg);
+          const quotes = excludedRouterIds?.length
+            ? await agg.getQuotes(selectedRequests, excludedRouterIds)
+            : await agg.getQuotes(selectedRequests);
           reqIdxs.forEach((reqIdx, k) => {
             allResults[aggIdx][reqIdx] = quotes[k] ?? null;
             if (quotes[k]) quoted++;
@@ -373,6 +378,13 @@ export { LiFiAggregator } from './lifi';
 export { MysticAggregator } from './mystic';
 export { RelayAggregator } from './relay';
 // Re-exports
-export type { Aggregator, Holding, Quote, QuoteRequest, QuoteResponse } from './types';
+export type {
+  Aggregator,
+  Holding,
+  Quote,
+  QuoteRequest,
+  QuoteResponse,
+  RouterExclusions,
+} from './types';
 export { QuoteSeriousness, QuoteType } from './types';
 export { ZeroExAggregator } from './zerox';

--- a/src/swap/aggregators/relay.ts
+++ b/src/swap/aggregators/relay.ts
@@ -44,11 +44,14 @@ export class RelayAggregator implements Aggregator {
     return SUPPORTED_CHAINS.has(chainId);
   }
 
-  async getQuotes(requests: QuoteRequest[]): Promise<(Quote | null)[]> {
-    return Promise.all(requests.map((req) => this.fetchQuote(req)));
+  async getQuotes(
+    requests: QuoteRequest[],
+    excludedRouterIds: string[] = []
+  ): Promise<(Quote | null)[]> {
+    return Promise.all(requests.map((req) => this.fetchQuote(req, excludedRouterIds)));
   }
 
-  private async fetchQuote(req: QuoteRequest): Promise<Quote | null> {
+  private async fetchQuote(req: QuoteRequest, excludedRouterIds: string[]): Promise<Quote | null> {
     try {
       const isExactOut = req.type === QuoteType.EXACT_OUT;
       const chainId = req.chainId.toString();
@@ -69,7 +72,7 @@ export class RelayAggregator implements Aggregator {
         amount: amountRaw.toString(),
         tradeType: isExactOut ? 'EXACT_OUTPUT' : 'EXACT_INPUT',
         slippageTolerance: SLIPPAGE_BPS_STRING,
-        excludedSwapSources: GLOBAL_DENY,
+        excludedSwapSources: [...new Set([...GLOBAL_DENY, ...excludedRouterIds])],
       };
 
       const data = (await this.getQuote(params)) as RelayResponse;
@@ -102,6 +105,7 @@ const parseResponse = (
 
   const output = buildSide(currencyOut, req.outputToken, outputAmountRaw);
   return {
+    routerId: data.details?.route?.origin?.router,
     input: buildSide(currencyIn, req.inputToken, inputAmountRaw),
     output,
     expectedOutput: normalizeExpectedOutput(currencyOut.amount, output),
@@ -170,5 +174,9 @@ type RelayCurrencyDetail = {
 };
 type RelayResponse = {
   steps?: RelayStep[];
-  details?: { currencyIn?: RelayCurrencyDetail; currencyOut?: RelayCurrencyDetail };
+  details?: {
+    currencyIn?: RelayCurrencyDetail;
+    currencyOut?: RelayCurrencyDetail;
+    route?: { origin?: { router?: string } };
+  };
 };

--- a/src/swap/aggregators/types.ts
+++ b/src/swap/aggregators/types.ts
@@ -20,6 +20,9 @@ export enum QuoteSeriousness {
 
 export type Quote = {
   expiry?: number;
+  // Provider-internal route identifier. Execution retries can return it to the same aggregator
+  // so that aggregator avoids repeating a route that already failed on-chain.
+  routerId?: string;
   input: {
     contractAddress: Hex;
     amount: string; // human decimal string
@@ -96,10 +99,14 @@ export type QuoteResponse = {
 // ---------------------------------------------------------------------------
 
 export interface Aggregator {
-  getQuotes(requests: QuoteRequest[]): Promise<(Quote | null)[]>;
+  getQuotes(requests: QuoteRequest[], excludedRouterIds?: string[]): Promise<(Quote | null)[]>;
   // Static chain gate consulted by aggregateAggregators' per-request tiered selection.
   supportsChain(chainId: number): boolean;
 }
+
+// Key exclusions by aggregator object identity so provider-internal route IDs never leak between
+// adapters (or between two independently configured instances of the same adapter).
+export type RouterExclusions = Map<Aggregator, string[]>;
 
 // ---------------------------------------------------------------------------
 // Token metadata enrichment

--- a/src/swap/algorithms/auto-select.ts
+++ b/src/swap/algorithms/auto-select.ts
@@ -14,6 +14,7 @@ import {
   type QuoteResponse,
   QuoteSeriousness,
   QuoteType,
+  type RouterExclusions,
 } from '../aggregators';
 import type { CurrencyID } from '../cot';
 import { convergeExactIn, firstSuccess, timedCandidate, tryExactOutDirect } from './convergence';
@@ -282,6 +283,7 @@ export const autoSelectSources = async (input: AutoSelectInput): Promise<AutoSel
         aggregators,
         targetTokenFor(item.holding.chainID),
         undefined,
+        undefined,
         userAddressByChain,
         recipientAddressByChain
       );
@@ -319,6 +321,7 @@ export type DirectSelectInput = {
   // Caps convergence input growth in the target token's raw units (Path A passes ≈$0.50 via oracle;
   // absent ⇒ convergenceQuote's default of 0.5 whole output tokens).
   maxConvergenceExtraRaw?: Decimal;
+  routerExclusions?: RouterExclusions;
 };
 
 /**
@@ -370,7 +373,12 @@ export const selectDirectDestinationSwaps = async (
         inputAmount: item.holding.amountRaw,
       };
     });
-    const results = await aggregateAggregators(requests, aggregators, AggregateMode.MaximizeOutput);
+    const results = await aggregateAggregators(
+      requests,
+      aggregators,
+      AggregateMode.MaximizeOutput,
+      input.routerExclusions
+    );
     swappable.forEach((item, i) => {
       const r = results[i];
       if (r?.quote) indicativeByIdx.set(item.idx, { quote: r.quote, aggregator: r.aggregator });
@@ -411,6 +419,7 @@ export const selectDirectDestinationSwaps = async (
         aggregators,
         target,
         input.maxConvergenceExtraRaw,
+        input.routerExclusions,
         userAddressByChain,
         recipientAddressByChain
       );
@@ -433,6 +442,7 @@ async function convergenceQuote(
   aggregators: Aggregator[],
   target: { contractAddress: Hex; decimals: number },
   maxConvergenceExtraRaw: Decimal | undefined,
+  routerExclusions: RouterExclusions | undefined,
   userAddressByChain: Map<number, `0x${string}`>,
   recipientAddressByChain: Map<number, Hex>
 ): Promise<QuoteResponse> {
@@ -481,6 +491,7 @@ async function convergenceQuote(
       outputAmount: requiredOutputAmountRaw,
     },
     aggregators,
+    routerExclusions,
     requiredOutputAmountRaw,
     maxInputAmountRaw: item.holding.amountRaw,
   });
@@ -491,6 +502,7 @@ async function convergenceQuote(
     maxExtraInputAmountRaw,
     maxInputAmountRaw: holdingBalanceDecimal,
     aggregators,
+    routerExclusions,
     makeRequest: (inputAmountRaw) => ({
       userAddress: addresses.userAddress,
       recipientAddress: addresses.recipientAddress,

--- a/src/swap/algorithms/convergence.ts
+++ b/src/swap/algorithms/convergence.ts
@@ -7,6 +7,7 @@ import {
   type Quote,
   type QuoteRequest,
   type QuoteType,
+  type RouterExclusions,
 } from '../aggregators';
 
 // 0.5% safety on each proposed input. A usable under-delivering quote is corrected by its observed
@@ -38,12 +39,14 @@ export type ExactOutConvergenceArgs = {
   // for destination swaps where COT is bridged in).
   maxInputAmountRaw?: Decimal;
   aggregators: Aggregator[];
+  routerExclusions?: RouterExclusions;
   maxAttempts?: number;
 };
 
 export type ExactOutDirectArgs = {
   request: QuoteRequest & { type: QuoteType.EXACT_OUT };
   aggregators: Aggregator[];
+  routerExclusions?: RouterExclusions;
   requiredOutputAmountRaw: bigint;
   maxInputAmountRaw?: bigint;
 };
@@ -77,7 +80,8 @@ export const tryExactOutDirect = async (
   const results = await aggregateAggregators(
     [args.request],
     args.aggregators,
-    AggregateMode.MinimizeInput
+    AggregateMode.MinimizeInput,
+    args.routerExclusions
   );
   const best = results[0];
   const hit =
@@ -147,7 +151,8 @@ export const convergeExactIn = async (
     const results = await aggregateAggregators(
       [request],
       args.aggregators,
-      AggregateMode.MaximizeOutput
+      AggregateMode.MaximizeOutput,
+      args.routerExclusions
     );
     const best = results[0];
     if (best?.quote && best.quote.output.amountRaw >= args.requiredOutputAmountRaw) {

--- a/src/swap/algorithms/destination.ts
+++ b/src/swap/algorithms/destination.ts
@@ -10,6 +10,7 @@ import {
   type QuoteResponse,
   QuoteSeriousness,
   QuoteType,
+  type RouterExclusions,
 } from '../aggregators';
 import { EADDRESS } from '../constants';
 import { CurrencyID } from '../cot';
@@ -44,6 +45,7 @@ type DetermineInput = {
     // Optional price-derived COT seed. When present, convergence can start with a serious forward
     // quote instead of first surveying the reverse direction.
     estimatedInputAmountRaw?: Decimal;
+    routerExclusions?: RouterExclusions;
   };
 };
 
@@ -83,6 +85,7 @@ export const determineDestinationSwaps = async ({
       outputAmount: dst.token.amountRaw,
     },
     aggregators: options.aggregators,
+    routerExclusions: options.routerExclusions,
     requiredOutputAmountRaw: dst.token.amountRaw,
   });
 
@@ -103,7 +106,8 @@ export const determineDestinationSwaps = async ({
           },
         ],
         options.aggregators,
-        AggregateMode.MaximizeOutput
+        AggregateMode.MaximizeOutput,
+        options.routerExclusions
       );
       const reverseQuote = reverseResults[0]?.quote;
       logger.debug('swap.route.destination.reverse_quote.completed', {
@@ -139,6 +143,7 @@ export const determineDestinationSwaps = async ({
       getFallbackInitialInputAmountRaw:
         seedSource === 'price' ? resolveReverseInputAmountRaw : undefined,
       aggregators: options.aggregators,
+      routerExclusions: options.routerExclusions,
       makeRequest: (inputAmountRaw) => ({
         userAddress: options.userAddress,
         recipientAddress: options.recipientAddress,
@@ -197,6 +202,7 @@ type ExactInInput = {
     userAddress: Hex;
     recipientAddress: Hex;
     chainList: ChainListType;
+    routerExclusions?: RouterExclusions;
   };
 };
 
@@ -224,7 +230,8 @@ export const destinationSwapWithExactIn = async ({
       },
     ],
     options.aggregators,
-    AggregateMode.MaximizeOutput
+    AggregateMode.MaximizeOutput,
+    options.routerExclusions
   );
   const best = results[0];
 
@@ -257,6 +264,7 @@ type GasSwapInput = {
     recipientAddress: Hex;
     chainList: ChainListType;
     cotCurrencyID?: CurrencyID;
+    routerExclusions?: RouterExclusions;
   };
 };
 
@@ -284,6 +292,7 @@ export const destinationGasSwapExactIn = async ({
       userAddress: options.userAddress,
       recipientAddress: options.recipientAddress,
       chainList: options.chainList,
+      routerExclusions: options.routerExclusions,
     },
   });
 };

--- a/src/swap/algorithms/direct-destination-size.ts
+++ b/src/swap/algorithms/direct-destination-size.ts
@@ -3,12 +3,12 @@ import type { Hex } from 'viem';
 import { ZERO_ADDRESS } from '../../domain/constants/addresses';
 import { Errors } from '../../domain/errors';
 import { isNativeAddress } from '../../services/addresses';
-import type { Aggregator, QuoteResponse } from '../aggregators/types';
 import { divDecimals } from '../../services/math';
 import { equalFold } from '../../services/strings';
+import type { Aggregator, QuoteResponse, RouterExclusions } from '../aggregators/types';
 import { EADDRESS } from '../constants';
 import type { OraclePriceResponse } from '../types';
-import { selectDirectDestinationSwaps, type SourceHolding } from './auto-select';
+import { type SourceHolding, selectDirectDestinationSwaps } from './auto-select';
 
 type DirectDestinationSizeInput = {
   holdings: SourceHolding[];
@@ -18,6 +18,7 @@ type DirectDestinationSizeInput = {
   nativeDecimals: number;
   gasTargetRaw: bigint;
   aggregators: Aggregator[];
+  routerExclusions?: RouterExclusions;
   userAddressByChain: Map<number, Hex>;
   recipientAddressByChain: Map<number, Hex>;
   convergenceExtraRaw: (tokenAddress: Hex, decimals: number) => Decimal | undefined;
@@ -26,15 +27,15 @@ type DirectDestinationSizeInput = {
 const deliveredRaw = (quoteResponses: QuoteResponse[]): bigint =>
   quoteResponses.reduce((sum, quote) => sum + quote.quote.output.amountRaw, 0n);
 
-export const makeConvergenceExtraRaw = (
-  oraclePrices: OraclePriceResponse,
-  chainId: number
-): ((tokenAddress: Hex, decimals: number) => Decimal | undefined) =>
+export const makeConvergenceExtraRaw =
+  (
+    oraclePrices: OraclePriceResponse,
+    chainId: number
+  ): ((tokenAddress: Hex, decimals: number) => Decimal | undefined) =>
   (tokenAddress, decimals) => {
     const oracleAddress = isNativeAddress(tokenAddress) ? ZERO_ADDRESS : tokenAddress;
     const price = oraclePrices.find(
-      (entry) =>
-        entry.chainId === chainId && equalFold(entry.tokenAddress, oracleAddress)
+      (entry) => entry.chainId === chainId && equalFold(entry.tokenAddress, oracleAddress)
     )?.priceUsd;
     if (!price || price.lte(0)) return undefined;
     return new Decimal('0.5').div(price).mul(Decimal.pow(10, decimals));
@@ -84,6 +85,7 @@ export const sizeDirectDestinationExactOut = async (
     userAddressByChain: input.userAddressByChain,
     recipientAddressByChain: input.recipientAddressByChain,
     maxConvergenceExtraRaw: input.convergenceExtraRaw(input.tokenAddress, input.tokenDecimals),
+    routerExclusions: input.routerExclusions,
   });
 
   if (tokenResult.usedCOTs.length > 0) {
@@ -109,6 +111,7 @@ export const sizeDirectDestinationExactOut = async (
       userAddressByChain: input.userAddressByChain,
       recipientAddressByChain: input.recipientAddressByChain,
       maxConvergenceExtraRaw: input.convergenceExtraRaw(ZERO_ADDRESS, input.nativeDecimals),
+      routerExclusions: input.routerExclusions,
     });
     if (gasResult.usedCOTs.length > 0) {
       throw Errors.internal(
@@ -116,10 +119,7 @@ export const sizeDirectDestinationExactOut = async (
       );
     }
     gasSwaps = gasResult.quoteResponses;
-    const gasDeliveredRaw = gasSwaps.reduce(
-      (sum, quote) => sum + quote.quote.output.amountRaw,
-      0n
-    );
+    const gasDeliveredRaw = gasSwaps.reduce((sum, quote) => sum + quote.quote.output.amountRaw, 0n);
     if (gasDeliveredRaw < input.gasTargetRaw) {
       if (gasResult.quoteResponses.length > 0) {
         throw Errors.insufficientBalance(

--- a/src/swap/execution/destination-swap.ts
+++ b/src/swap/execution/destination-swap.ts
@@ -21,7 +21,7 @@ import {
 import { createSBCTxFromCalls, requireSuccessfulSbcResult, type SBCCall } from '../../services/sbc';
 import { createDestinationSwapStepId } from '../../services/step-ids';
 import { withTimingSpan } from '../../services/timing';
-import { aggregatorService } from '../aggregators';
+import { aggregatorService, type RouterExclusions } from '../aggregators';
 import { predictSafeAccountAddress } from '../safe/predict';
 import { createSweeperTxs } from '../sweep';
 import {
@@ -35,6 +35,7 @@ import {
 import { chainSupports7702 } from '../wallet/capabilities';
 import { resolvePreparedFundingTransferCalls } from './eoa-to-ephemeral';
 import { getParsedQuote } from './parsed-quote';
+import { addRouterExclusions } from './router-exclusions';
 import { readSettlementBalanceRaw } from './settlement-balance';
 
 const logger = getLogger();
@@ -271,7 +272,13 @@ export const executeDestinationSwap = async (
   let currentSwap = destination.swap;
   const requiresTokenSwap = Boolean(destination.swap.tokenSwap);
   const requiresGasSwap = Boolean(destination.swap.gasSwap);
+  const routerExclusions: RouterExclusions = new Map();
   let lastError: unknown;
+
+  const getDstSwap = (actualCotRaw: bigint) =>
+    routerExclusions.size > 0
+      ? destination.getDstSwap(actualCotRaw, routerExclusions)
+      : destination.getDstSwap(actualCotRaw);
 
   if (!currentSwap.tokenSwap && !currentSwap.gasSwap) {
     logger.debug('swap.execute.destination.noop.skipped', {
@@ -337,6 +344,7 @@ export const executeDestinationSwap = async (
     | undefined;
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    let attemptedDispatch = false;
     try {
       if (mode === SwapMode.EXACT_IN) {
         if (wrapperCotBalance === null) {
@@ -346,7 +354,7 @@ export const executeDestinationSwap = async (
         const resized = await withTimingSpan(
           ctx.timing,
           'flow.swap.execute.destination.resize_or_requote',
-          async () => destination.getDstSwap(actualCotBalance),
+          async () => getDstSwap(actualCotBalance),
           { tags: { mode, wallet_path: wrapper, attempt } }
         );
         const hasEveryRequiredLeg =
@@ -393,7 +401,7 @@ export const executeDestinationSwap = async (
         const requoted = await withTimingSpan(
           ctx.timing,
           'flow.swap.execute.destination.resize_or_requote',
-          async () => destination.getDstSwap(wrapperCotBalance ?? 0n),
+          async () => getDstSwap(wrapperCotBalance ?? 0n),
           { tags: { mode, wallet_path: wrapper, attempt } }
         );
         const hasEveryRequiredLeg =
@@ -471,6 +479,7 @@ export const executeDestinationSwap = async (
               publicClient,
               safeAddress,
             });
+            attemptedDispatch = true;
             return ctx.middlewareClient.createSafeExecuteTx(request);
           },
           { tags: { mode, wallet_path: wrapper, attempt } }
@@ -522,6 +531,7 @@ export const executeDestinationSwap = async (
               publicClient: ctx.publicClientList.get(destination.chainId),
             });
 
+            attemptedDispatch = true;
             return ctx.middlewareClient.submitSBCs([sbcTx]);
           },
           { tags: { mode, wallet_path: wrapper, attempt } }
@@ -572,6 +582,9 @@ export const executeDestinationSwap = async (
       });
       return;
     } catch (error) {
+      if (attemptedDispatch) {
+        addRouterExclusions(routerExclusions, [currentSwap.tokenSwap, currentSwap.gasSwap]);
+      }
       lastError = error;
       logger.debug('swap.execute.destination.attempt.failed', {
         chainId: destination.chainId,

--- a/src/swap/execution/direct-destination.ts
+++ b/src/swap/execution/direct-destination.ts
@@ -19,7 +19,7 @@ import { createSourceSwapStepId } from '../../services/step-ids';
 import { equalFold } from '../../services/strings';
 import { withTimingSpan } from '../../services/timing';
 import { aggregatorService } from '../aggregators';
-import type { QuoteResponse } from '../aggregators/types';
+import type { QuoteResponse, RouterExclusions } from '../aggregators/types';
 import {
   makeConvergenceExtraRaw,
   sizeDirectDestinationExactOut,
@@ -37,6 +37,7 @@ import type {
 import { buildPreparedTransfer } from '../wallet/prepared-transfer';
 import { resolvePreparedFundingTransferCalls } from './eoa-to-ephemeral';
 import { getParsedQuote } from './parsed-quote';
+import { addRouterExclusions } from './router-exclusions';
 import { type DispatchedSourceBatch, dispatchSourceChainBatch } from './source-swaps';
 
 const logger = getLogger();
@@ -347,6 +348,7 @@ export const executeDirectDestinationExactOut = async (
     routeTimeInputs.set(key, (routeTimeInputs.get(key) ?? 0n) + swap.quote.input.amountRaw);
   }
   let swaps = route.source.swaps;
+  const routerExclusions: RouterExclusions = new Map();
   const currentTimeMs = Date.now();
   const quoteAgeMs = currentTimeMs - route.source.creationTime;
   let forceRequote = quoteAgeMs > DIRECT_DST_QUOTE_TTL_MS;
@@ -379,6 +381,7 @@ export const executeDirectDestinationExactOut = async (
               userAddressByChain: new Map([[chainId, targetAddress]]),
               recipientAddressByChain: new Map([[chainId, ctx.eoaAddress]]),
               convergenceExtraRaw: makeConvergenceExtraRaw(route.extras.oraclePrices, chainId),
+              ...(routerExclusions.size > 0 ? { routerExclusions } : {}),
             }),
           { tags: { attempt: dispatchAttempts + 1, route_path: 'direct_destination' } }
         );
@@ -464,6 +467,7 @@ export const executeDirectDestinationExactOut = async (
         isRetryableDispatchFailure(normalized, dispatched) &&
         dispatchAttempts < MAX_DISPATCH_ATTEMPTS
       ) {
+        addRouterExclusions(routerExclusions, swaps);
         forceRequote = true;
         continue;
       }

--- a/src/swap/execution/router-exclusions.ts
+++ b/src/swap/execution/router-exclusions.ts
@@ -1,0 +1,15 @@
+import type { QuoteResponse, RouterExclusions } from '../aggregators/types';
+
+export const addRouterExclusions = (
+  exclusions: RouterExclusions,
+  quotes: readonly (QuoteResponse | null)[]
+) => {
+  for (const quote of quotes) {
+    const routerId = quote?.quote.routerId;
+    if (!routerId) continue;
+    const current = exclusions.get(quote.aggregator) ?? [];
+    if (!current.includes(routerId)) {
+      exclusions.set(quote.aggregator, [...current, routerId]);
+    }
+  }
+};

--- a/src/swap/execution/source-swaps.ts
+++ b/src/swap/execution/source-swaps.ts
@@ -389,9 +389,9 @@ const requoteFailedChains = async (
 
       const requoted = await Promise.all(
         chainSwaps.map(async (swap) => {
-          const [requote] = await swap.aggregator.getQuotes([
+          const requests = [
             {
-              type: QuoteType.EXACT_IN,
+              type: QuoteType.EXACT_IN as const,
               seriousness: QuoteSeriousness.SERIOUS,
               chainId: swap.chainID,
               inputToken: swap.quote.input.contractAddress,
@@ -400,7 +400,10 @@ const requoteFailedChains = async (
               userAddress,
               recipientAddress: sourceRecipient,
             },
-          ]);
+          ];
+          const [requote] = swap.quote.routerId
+            ? await swap.aggregator.getQuotes(requests, [swap.quote.routerId])
+            : await swap.aggregator.getQuotes(requests);
 
           if (!requote) {
             throw new ExternalServiceError(

--- a/src/swap/routing/exact-in.ts
+++ b/src/swap/routing/exact-in.ts
@@ -6,6 +6,7 @@ import { divDecimals, mulDecimals } from '../../services/math';
 import { MAYAN_MIN_USD_PER_LEG, selectMayanQuoteOutput } from '../../services/mayan';
 import { equalFold } from '../../services/strings';
 import { withTimingSpan } from '../../services/timing';
+import type { RouterExclusions } from '../aggregators';
 import { destinationSwapWithExactIn } from '../algorithms/destination';
 import { liquidateInputHoldings } from '../algorithms/liquidate';
 import { resolveExactInAmountBasis, selectExactInQuoteOutput } from '../amount-basis';
@@ -505,7 +506,10 @@ export async function _exactInRoute(data: ExactInData, options: RouteOptions): P
   // Shared EXACT_IN destination-swap quote at a given COT input (human units), used by the initial
   // route and both execution-time requote paths. No rate-tolerance guard — a requote is accepted
   // whatever it returns.
-  const quoteDstSwapAtInput = async (inputHuman: Decimal): Promise<DestinationSwap | null> => {
+  const quoteDstSwapAtInput = async (
+    inputHuman: Decimal,
+    routerExclusions?: RouterExclusions
+  ): Promise<DestinationSwap | null> => {
     if (!needsTokenSwap) return null;
     const quote = await withTimingSpan(
       options.timing,
@@ -523,6 +527,7 @@ export async function _exactInRoute(data: ExactInData, options: RouteOptions): P
             aggregators,
             userAddress: destinationQuoteAddress,
             recipientAddress: options.eoaAddress,
+            routerExclusions,
           },
         }),
       { tags: { mode: SwapMode.EXACT_IN } }
@@ -600,9 +605,9 @@ export async function _exactInRoute(data: ExactInData, options: RouteOptions): P
         // floor and no upper clamp — `actual` IS the real on-chain balance, and Exact In must consume
         // it completely so settlement-token dust is not returned to the user. The source reclaim can
         // deliver above the route estimate and that surplus is converted here too.
-        getDstSwap: (actualCotRaw: bigint) => {
+        getDstSwap: (actualCotRaw: bigint, routerExclusions?: RouterExclusions) => {
           const actual = divDecimals(actualCotRaw, dstCOT.decimals);
-          return quoteDstSwapAtInput(actual);
+          return quoteDstSwapAtInput(actual, routerExclusions);
         },
       },
       // EXACT_IN has no buffer (no source buffer, no dst buffer).

--- a/src/swap/routing/exact-out.ts
+++ b/src/swap/routing/exact-out.ts
@@ -7,6 +7,7 @@ import { convertGasToToken } from '../../services/intent';
 import { divDecimals, mulDecimals } from '../../services/math';
 import { equalFold } from '../../services/strings';
 import { withTimingSpan } from '../../services/timing';
+import type { RouterExclusions } from '../aggregators';
 import { autoSelectSources, type SourceHolding } from '../algorithms/auto-select';
 import { destinationGasSwapExactIn, determineDestinationSwaps } from '../algorithms/destination';
 import {
@@ -71,6 +72,7 @@ const quoteExactOutDestination = async (input: {
   needsGasSwap: boolean;
   needsTokenSwap: boolean;
   estimatedInputAmountRaw?: Decimal;
+  routerExclusions?: RouterExclusions;
   timingSpan: 'flow.swap.route.quote_destination_requirement' | 'flow.swap.route.quote_destination';
 }) => {
   const [tokenSwapQuote, gasSwapQuote] = await withTimingSpan(
@@ -94,6 +96,7 @@ const quoteExactOutDestination = async (input: {
                 estimatedInputAmountRaw: input.estimatedInputAmountRaw,
                 userAddress: input.destinationQuoteAddress,
                 recipientAddress: input.options.eoaAddress,
+                routerExclusions: input.routerExclusions,
               },
             })
           : Promise.resolve(null),
@@ -107,6 +110,7 @@ const quoteExactOutDestination = async (input: {
                 cotCurrencyID: input.options.cotCurrencyId,
                 userAddress: input.destinationQuoteAddress,
                 recipientAddress: input.options.eoaAddress,
+                routerExclusions: input.routerExclusions,
               },
             })
           : Promise.resolve(null),
@@ -830,7 +834,7 @@ export async function _exactOutRoute(
             : null,
         inputAmount: dstInputAmount,
         swap: dstSwap,
-        getDstSwap: async (actualCotRaw: bigint) => {
+        getDstSwap: async (actualCotRaw: bigint, routerExclusions?: RouterExclusions) => {
           const {
             tokenSwapQuote: nextTokenSwap,
             gasSwapQuote: nextGasSwap,
@@ -843,6 +847,7 @@ export async function _exactOutRoute(
             gasInCotBudgetRaw,
             needsGasSwap,
             needsTokenSwap,
+            routerExclusions,
             timingSpan: 'flow.swap.route.quote_destination',
           });
 

--- a/src/swap/swap.md
+++ b/src/swap/swap.md
@@ -545,7 +545,7 @@ destinationGasSwapExactIn(cot → EADDRESS, EXACT_IN, input=gasAmountInCotRaw)  
 ## 7. Aggregators
 
 ```text
-aggregateAggregators(requests, aggregators, mode):
+aggregateAggregators(requests, aggregators, mode, routerExclusions?):
   per request: selectForChain picks ≤ 2 aggregators by TIER (supportsChain static lists):
     TIER_1 = [Relay, Bebop, Fibrous, Mystic]; TIER_2 = [0x, LiFi]      # priority = array order
     tier-1 supporters first, top up from tier 2 to reach 2 (Citrea → Fibrous + Mystic, both tier-1); a lone supporter runs alone
@@ -554,6 +554,8 @@ aggregateAggregators(requests, aggregators, mode):
       deliberately ungated in fetchQuote, probes live)
   round 1 quotes the PRIMARY selection; if every primary adapter returns null/error for a request, a
     round 2 FALLBACK quotes the REMAINING supporters (next ≤ 2 by tier)
+  optional routerExclusions are keyed by Aggregator instance; only that exact adapter instance
+    receives its own provider-internal router IDs
   each aggregator receives ONLY its selected requests (the network-call reduction); results scatter
   back into the full matrix, then per request pick the best non-null quote among the selected:
     MaximizeOutput → max output.amountRaw   (tie → first aggregator)
@@ -588,6 +590,9 @@ are requested as executable quotes from the outset so a fully consumed holding r
 Fibrous price surveys are reserved for indicative convergence seeds: they use the lighter `/v2/route`
 response, apply the configured slippage floor to `outputAmount` locally, and never enter execution;
 serious Fibrous requests use `/v2/routeAndCallData`.
+Relay also normalizes `details.route.origin.router` into optional `Quote.routerId`. After a dispatched
+swap fails, retry paths return that ID only to the same Relay instance; Relay merges it into
+`excludedSwapSources` with its global deny list. Other adapters ignore the optional input.
 LiFi/Bebop surface a per-token `priceUsd`;
 **0x and Mystic report amounts + tx only (no decimals/symbol/price)** — filled from a sibling quote in
 `aggregateAggregators`, or, when a leg is only 0x/Mystic, from a token endpoint (0x → LiFi `/v1/token`;
@@ -607,6 +612,7 @@ route-scoped keyed-promise cache described in §5.
 | **Fibrous** | survey: slippage-floored `outputAmount`; serious: `min_received` | serious: `destination` | survey: `/v2/route`; serious: `/v2/routeAndCallData`; `excludeProtocols='3'` | **EXACT_IN only** (EXACT_OUT → `null`); Citrea 4114; native input (`swap_type===0`) → `approvalAddress=zeroAddress`, `tx.value=amount_in` |
 | **0x** | `minBuyAmount` (EXACT_IN) / exact `buyAmount`, input capped at `maxSellAmount` (EXACT_OUT) | `recipient` | allowance‑holder via proxy; survey (`!SERIOUS`) → indicative `/price`, SERIOUS → `/quote` (executable tx); `taker=userAddress`; `slippageBps`; `allowanceTarget` → `approvalAddress` (`zeroAddress` when null/native) | EXACT_IN **and** EXACT_OUT; `liquidityAvailable=false` → `null`; **no decimals/symbol/price** (backfilled from a sibling) |
 | **Mystic** | `minBuyAmount` (slippage‑protected floor, like 0x) | `recipient` | two‑step: POST `/v1/swap/quote` then `/v1/swap/build`; `slippageBps`; survey (`!SERIOUS`) skips the simulating build call; native sell → `approvalAddress=zeroAddress` | **EXACT_IN only**; Citrea 4114 only; **no decimals/symbol/price** (backfilled from a sibling, mirrors 0x) |
+| **Relay** | `currencyOut.minimumAmount` (EXACT_IN) / exact `currencyOut.amount` (EXACT_OUT) | `recipient` | same-chain `/quote/v2`; `excludedSwapSources=['magpie', ...failedRouterIds]`; route ID from `details.route.origin.router` | EXACT_IN and EXACT_OUT; native mapped to Relay's zero address; ungated request fallback |
 
 ---
 
@@ -718,6 +724,8 @@ executeDirectDestinationExactOut(route, ctx, meta):
     confirmed → meta.src += the confirmed batch and return
     confirmed revert / explicit no-broadcast result → fresh re-size, then retry
     wallet submission failure with no hash → assume unsubmitted, fresh re-size, then retry
+    each retry excludes every Relay internal router returned by previously failed dispatches,
+      keyed by the Relay aggregator instance across token and gas legs
     wallet rejection / receipt timeout with a known hash → terminal; never blindly redispatch
   cached authorization capacity is exact for canonical/Polygon-EMT permits and paid approvals,
   MAX_UINT256 for DAI/Polygon-2612 allowed=true, or the actual pre-existing allowance. A mined paid
@@ -743,6 +751,7 @@ executeSourceSwaps(source, ctx, meta) -> BridgeAsset[]:
   on chain failure: requote that chain ONCE (EXACT_IN; taker remains the chain's executor;
                     receiver = ephemeral for a remote chain, EOA for a direct-COT dst chain,
                     or the destination wrapper when another dst swap follows)
+    # Relay requotes exclude that failed quote's internal router ID
     # EXACT_OUT: require Σ(output drop) ≤ srcBuffer, pooled across that route's source legs
     #   (directDestination EXACT_OUT never reaches this shared retry; its dedicated executor is above)
     # EXACT_IN:  srcBuffer = null → no guard; accept the re-quote and proceed (Seam 2 re-sizes the dst swap)
@@ -818,6 +827,8 @@ executeDestinationSwap(destination, dstTokenInfo, ctx, meta):
   #   lands at the EOA (receiver=EOA) → its dust sweep is skipped;
   #   native output NEVER swept (EADDRESS → approveNative at the Safe → GS013). gas-swap approve+swap ride the same batch
   retry: twice (3 attempts, forced requotes) then rethrow            # no fallback sweep
+    after each dispatched failure, accumulate each Relay token/gas quote's router ID and pass the
+    aggregator-keyed exclusions through getDstSwap; stale-only refreshes do not blacklist a router
   meta.dst = {chid, tx_hash, swaps[]}
 ```
 
@@ -1089,9 +1100,12 @@ fixed-plus-bps model and reapplies it to `Σ(executed)` when building the bridge
   `srcBuffer` (boundary inclusive), pooled across the route's source legs; otherwise
   `EXTERNAL_RATES_DRIFT_EXCEEDED`. EXACT_IN has no guard and accepts the re-quote. Still failing means
   re-throw, with no sweep at this layer. Path A EXACT_OUT does not enter this code; its exact-target,
-  three-dispatch policy and silent-input growth guard are described above.
+  three-dispatch policy and silent-input growth guard are described above. A Relay retry excludes
+  the failed quote's internal router from that same Relay instance.
 - **Destination re‑quote twice** (`MAX_RETRIES`; 3 attempts), then re‑throw without a fallback sweep.
   EXACT_IN has no rate‑tolerance guard on the re‑quote; EXACT_OUT keeps its frozen `[floor, ceiling]`.
+  Router exclusions are recorded only after a dispatched failure, accumulated across token/gas legs
+  and attempts, and keyed by aggregator instance.
 - **Aggregator failures non‑fatal** at the aggregation layer.
 - **EOA single‑chain & serialized**; **all chains dispatched before receipts** (source stage).
 - **Fail loud at routing** (see §5) — never emit an inconsistent plan.

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -16,7 +16,13 @@ import type {
   MiddlewareSwapClient,
   MiddlewareSwapExecutionClient,
 } from '../transport';
-import type { Aggregator, Holding, Quote, QuoteResponse } from './aggregators/types';
+import type {
+  Aggregator,
+  Holding,
+  Quote,
+  QuoteResponse,
+  RouterExclusions,
+} from './aggregators/types';
 import type { ExactInAmountBasis } from './amount-basis';
 import type { CurrencyID } from './cot';
 import type { SwapCache } from './wallet/cache';
@@ -285,7 +291,10 @@ export type SwapRoute = {
     // Re-quote the dst swap against the COT that actually arrived at the wrapper (raw). Each mode's
     // closure interprets it: EXACT_IN grows the input toward it (more output); EXACT_OUT keeps the
     // output fixed but lifts its max-input budget to it (so the srcBuffer covers destination drift).
-    getDstSwap: (actualCotRaw: bigint) => Promise<DestinationSwap | null>;
+    getDstSwap: (
+      actualCotRaw: bigint,
+      routerExclusions?: RouterExclusions
+    ) => Promise<DestinationSwap | null>;
   };
   buffer: { amount: string }; // human decimal string
   dstTokenInfo: Pick<TokenInfo, 'symbol' | 'decimals' | 'contractAddress'>;

--- a/tests/swap/aggregators/aggregate.test.ts
+++ b/tests/swap/aggregators/aggregate.test.ts
@@ -150,6 +150,19 @@ describe('aggregateAggregators', () => {
     expect(results[0].quote).toBeNull();
   });
 
+  it('forwards excluded router ids to selected aggregators', async () => {
+    const aggregator = makeAggregator([makeQuote(950000n)]);
+
+    await aggregateAggregators(
+      [makeRequest()],
+      [aggregator],
+      AggregateMode.MaximizeOutput,
+      new Map([[aggregator, ['uniswap-v3']]])
+    );
+
+    expect(aggregator.getQuotes).toHaveBeenCalledWith(expect.any(Array), ['uniswap-v3']);
+  });
+
   it('picks first aggregator on tie in MaximizeOutput', async () => {
     const aggA = makeAggregator([makeQuote(950000n)]);
     const aggB = makeAggregator([makeQuote(950000n)]);

--- a/tests/swap/aggregators/relay.test.ts
+++ b/tests/swap/aggregators/relay.test.ts
@@ -64,6 +64,9 @@ const makeResponse = () => ({
       amountUsd: '1.2',
       minimumAmount: '399000000000000',
     },
+    route: {
+      origin: { router: 'uniswap-v3' },
+    },
   },
 });
 
@@ -101,6 +104,7 @@ describe('RelayAggregator', () => {
       amount: '0.0004',
       value: 1.2,
     });
+    expect(quote!.routerId).toBe('uniswap-v3');
     // tx comes from the 'swap' step, never 'approve'.
     expect(quote!.txData.tx.to).toBe(ROUTER);
     expect(quote!.txData.tx.data).toBe('0xswapdata');
@@ -108,6 +112,17 @@ describe('RelayAggregator', () => {
     // approvalAddress is the spender the approve step encodes, not the swap tx `to`
     // (decodeFunctionData returns it checksummed; addresses compare case-insensitively).
     expect(quote!.txData.approvalAddress.toLowerCase()).toBe(SPENDER);
+  });
+
+  it('excludes previously failed internal routers when requoting', async () => {
+    const getQuote = vi.fn<RelayProxy>().mockResolvedValue(makeResponse());
+    await new RelayAggregator(getQuote).getQuotes([makeRequest()], ['uniswap-v3', 'odos']);
+
+    expect(getQuote.mock.calls[0][0].excludedSwapSources).toEqual([
+      'magpie',
+      'uniswap-v3',
+      'odos',
+    ]);
   });
 
   it('EXACT_OUT: delivers the exact requested output (currencyOut.amount), EXACT_OUTPUT trade type', async () => {

--- a/tests/swap/algorithms/destination.test.ts
+++ b/tests/swap/algorithms/destination.test.ts
@@ -452,6 +452,7 @@ describe('destinationSwapWithExactIn', () => {
       supportsChain: () => true,
       getQuotes: vi.fn().mockResolvedValue([makeQuote(500000000000000000n, 1000000000n)]),
     };
+    const routerExclusions = new Map([[agg, ['uniswap-v3']]]);
 
     const result = await destinationSwapWithExactIn({
       chainId: BASE_CHAIN,
@@ -465,12 +466,14 @@ describe('destinationSwapWithExactIn', () => {
         userAddress: '0xaaaa000000000000000000000000000000000001' as Hex,
         recipientAddress: '0xe0a0000000000000000000000000000000000a02' as Hex,
         chainList: makeSwapChainList(),
+        routerExclusions,
       },
     });
 
     expect(result).not.toBeNull();
     expect(result!.quote.output.amountRaw).toBe(500000000000000000n);
     expect(result!.chainID).toBe(BASE_CHAIN);
+    expect(agg.getQuotes).toHaveBeenCalledWith(expect.any(Array), ['uniswap-v3']);
   });
 
   it('returns null when quote fails', async () => {

--- a/tests/swap/algorithms/direct-destination-size.test.ts
+++ b/tests/swap/algorithms/direct-destination-size.test.ts
@@ -75,6 +75,8 @@ describe('sizeDirectDestinationExactOut', () => {
   });
 
   it('tags the token pass and skips gas selection when the gas target is zero', async () => {
+    const aggregator = {} as Aggregator;
+    const routerExclusions = new Map([[aggregator, ['uniswap-v3']]]);
     vi.mocked(selectDirectDestinationSwaps).mockResolvedValue({
       quoteResponses: [quote(100_000_000n)],
       usedCOTs: [],
@@ -91,11 +93,15 @@ describe('sizeDirectDestinationExactOut', () => {
       userAddressByChain: new Map([[CHAIN_ID, USER]]),
       recipientAddressByChain: new Map([[CHAIN_ID, RECIPIENT]]),
       convergenceExtraRaw: () => undefined,
+      routerExclusions,
     });
 
     expect(selectDirectDestinationSwaps).toHaveBeenCalledTimes(1);
     expect(vi.mocked(selectDirectDestinationSwaps).mock.calls[0][0].outputRequired.toFixed()).toBe(
       '100'
+    );
+    expect(selectDirectDestinationSwaps).toHaveBeenCalledWith(
+      expect.objectContaining({ routerExclusions })
     );
     expect(swaps).toEqual([expect.objectContaining({ outputRole: 'token' })]);
   });

--- a/tests/swap/execution/destination-contracts.test.ts
+++ b/tests/swap/execution/destination-contracts.test.ts
@@ -305,6 +305,43 @@ describe('executeDestinationSwap contracts', () => {
     expect(destination.getDstSwap).toHaveBeenCalledWith(3_000_000_000n);
   });
 
+  it('excludes failed destination routers when requoting after dispatch failure', async () => {
+    const relay = {} as Aggregator;
+    const planned = makeQuote(3_000_000_000n, { aggregator: relay });
+    planned.quote.routerId = 'uniswap-v3';
+    const refreshed = makeQuote(3_000_000_000n, { aggregator: relay });
+    refreshed.quote.routerId = 'odos';
+    const getDstSwap = vi
+      .fn()
+      .mockResolvedValue({ tokenSwap: refreshed, gasSwap: null });
+    const destination = makeDestination(
+      { tokenSwap: planned, gasSwap: null },
+      getDstSwap
+    );
+    const { context, submitSBCs } = makeContext();
+    submitSBCs.mockResolvedValueOnce([
+      {
+        chainId: CHAIN_ID,
+        address: EPH,
+        errored: true,
+        message: 'router reverted',
+      },
+    ]);
+
+    await executeDestinationSwap(
+      destination,
+      SwapMode.EXACT_OUT,
+      dstToken,
+      context,
+      metadata()
+    );
+
+    expect(getDstSwap).toHaveBeenCalledWith(
+      3_000_000_000n,
+      new Map([[relay, ['uniswap-v3']]])
+    );
+  });
+
   it('rejects a non-null Exact Out requote that drops a required leg', async () => {
     const expiredToken = makeQuote(2_000_000_000n, {
       expiry: Math.floor(Date.now() / 1000) - 60,

--- a/tests/swap/execution/direct-destination.test.ts
+++ b/tests/swap/execution/direct-destination.test.ts
@@ -296,10 +296,15 @@ describe('executeDirectDestinationExactOut', () => {
   });
 
   it('reuses an exact permit after a confirmed revert and requotes before retrying', async () => {
+    const relay = {} as Aggregator;
     const swaps = [
       makeSwap(500_000_000n, WETH, 200_000_000_000_000_000n, 'token'),
       makeSwap(25_000_000n, EADDRESS, 10_000_000_000_000_000n, 'gas'),
     ];
+    swaps[0].aggregator = relay;
+    swaps[1].aggregator = relay;
+    swaps[0].quote.routerId = 'uniswap-v3';
+    swaps[1].quote.routerId = 'odos';
     const route = makeRoute(swaps);
     const ctx = makeContext(makePreparedExecution(swaps));
     const metadata = makeMetadata();
@@ -309,6 +314,11 @@ describe('executeDirectDestinationExactOut', () => {
 
     expect(dispatchSourceChainBatch).toHaveBeenCalledTimes(2);
     expect(sizeDirectDestinationExactOut).toHaveBeenCalledTimes(1);
+    expect(sizeDirectDestinationExactOut).toHaveBeenCalledWith(
+      expect.objectContaining({
+        routerExclusions: new Map([[relay, ['uniswap-v3', 'odos']]]),
+      })
+    );
     expect(buildTransferAuthorization).toHaveBeenCalledTimes(1);
     expect(vi.mocked(dispatchSourceChainBatch).mock.calls[1][0].calls[0].data).toBe('0x9999');
   });

--- a/tests/swap/execution/source-swap-requote.test.ts
+++ b/tests/swap/execution/source-swap-requote.test.ts
@@ -107,6 +107,7 @@ describe('native EOA source swap dispatches the fresh re-quote on retry', () => 
     const requoted = makeNativeQuote('0xbbbbbbbb', 45000000n); // fresh order, EQUAL output (inside buffer)
     const aggregator = { supportsChain: () => true, getQuotes: vi.fn().mockResolvedValue([requoted.quote]) } as unknown as Aggregator;
     const original = makeNativeQuote('0xaaaaaaaa', 45000000n, aggregator);
+    original.quote.routerId = 'uniswap-v3';
 
     // prepared parsedQuote mirrors what prepare() builds from the ORIGINAL quote
     const prepared = {
@@ -134,6 +135,7 @@ describe('native EOA source swap dispatches the fresh re-quote on retry', () => 
 
     const sends = sendTransaction.mock.calls.map((c) => innerData(c[0].data as Hex));
     expect(aggregator.getQuotes).toHaveBeenCalledTimes(1); // re-quote happened, in-buffer
+    expect(aggregator.getQuotes).toHaveBeenCalledWith(expect.any(Array), ['uniswap-v3']);
     expect(sends).toEqual(['0xaaaaaaaa', '0xbbbbbbbb']); // attempt-0 prepared, attempt-1 the FRESH re-quote
   });
 

--- a/tests/swap/route.test.ts
+++ b/tests/swap/route.test.ts
@@ -1591,9 +1591,15 @@ describe('determineSwapRoute', () => {
     );
     // Input scales with the actual delivered balance and is NOT capped at the route estimate — the
     // source reclaim can over-deliver, and all of that surplus must be converted here.
-    await route.destination.getDstSwap(5000000000n);
+    const routerExclusions = new Map<Aggregator, string[]>([
+      [{} as Aggregator, ['uniswap-v3']],
+    ]);
+    await route.destination.getDstSwap(5000000000n, routerExclusions);
     expect(vi.mocked(destinationSwapWithExactIn)).toHaveBeenLastCalledWith(
-      expect.objectContaining({ input: expect.objectContaining({ amountRaw: 5000000000n }) })
+      expect.objectContaining({
+        input: expect.objectContaining({ amountRaw: 5000000000n }),
+        options: expect.objectContaining({ routerExclusions }),
+      })
     );
   });
 
@@ -3815,7 +3821,15 @@ describe('determineSwapRoute', () => {
       })
     );
     expect(route.destination.inputAmount.max.toString()).toBe('3102');
-    await route.destination.getDstSwap(0n);
+    const routerExclusions = new Map<Aggregator, string[]>([
+      [{} as Aggregator, ['uniswap-v3']],
+    ]);
+    await route.destination.getDstSwap(0n, routerExclusions);
+    expect(determineDestinationSwaps).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({ routerExclusions }),
+      })
+    );
     // min tracks the fresh requote; max stays pinned at the original buffered ceiling.
     expect(route.destination.inputAmount.min.toString()).toBe('3101');
     expect(route.destination.inputAmount.max.toString()).toBe('3102');


### PR DESCRIPTION
## Summary

This PR prevents swap retries from repeatedly selecting a Relay internal router that has already failed execution.

Relay quotes now retain the provider's internal router identifier. After a failed execution attempt, source and destination requotes exclude that router while keeping exclusions scoped to the exact aggregator instance.

## Changes

- Normalize Relay's `details.route.origin.router` response field into the optional internal `Quote.routerId`.
- Add optional aggregator-scoped router exclusions to quote aggregation and thread them through Exact In, Exact Out, convergence, and direct-destination sizing.
- Merge failed Relay router IDs into `excludedSwapSources` alongside the existing global deny list, without changing other aggregator adapters.
- Exclude the failed router when requoting source swaps after execution failure.
- Accumulate failed token-swap and gas-swap router IDs across ordinary and direct-destination retry attempts.
- Record destination exclusions only after execution reaches dispatch, so stale quote refreshes and pre-dispatch failures do not blacklist a router.
- Centralize failed-router collection in the destination execution layer and document the requote behavior.
- Add regression coverage for Relay response normalization, aggregator scoping, source retries, ordinary destination retries, and direct-destination retries.

## Testing

- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run typecheck`

## Risk / Impact

- No public SDK methods, package-root exports, or user inputs change.
- Retry behavior changes only after a failed execution attempt; initial quotes and stale-only refreshes retain their existing behavior.
- Router exclusions are keyed by aggregator instance, preventing provider-internal identifiers from leaking to another adapter or separately configured instance.
- Aggregators other than Relay continue to ignore the optional exclusion input, and Relay behavior is unchanged when its response omits the router identifier.