### PR TITLE
swap: use one receipt confirmation on all chains

### DIFF
--- a/src/services/evm.ts
+++ b/src/services/evm.ts
@@ -164,18 +164,13 @@ export const waitForTxReceipt = async (
   return [receipt, receipt.status === 'reverted' ? Errors.transactionReverted(hash) : null];
 };
 
-/**
- * Chain-aware blocks: wait extra confirmations so a lagging RPC has synced the tx's effects before
- * the next call/tx reads them (avoids the follow-up tx failing on stale state). Faster chains' RPCs
- * can sit a block behind head, so wait 2; Ethereum mainnet (chainId 1) stays in sync within 1.
- * Same `[receipt, error]` contract as waitForTxReceipt.
- */
+/** Wait one confirmation on every chain. Same `[receipt, error]` contract as waitForTxReceipt. */
 export const waitForTxReceiptByChain = (
   hash: `0x${string}`,
   publicClient: TransactionReceiptPublicClient,
-  chainId: number,
+  _chainId: number,
   timeout = TRANSACTION_RECEIPT_WAIT_TIMEOUT_MS
-) => waitForTxReceipt(hash, publicClient, chainId === 1 ? 1 : 2, timeout);
+) => waitForTxReceipt(hash, publicClient, 1, timeout);
 
 /**
  * Waits (chain-aware) for an execution step's receipt and, on revert, throws a step-tagged

--- a/src/services/fulfilment.ts
+++ b/src/services/fulfilment.ts
@@ -23,10 +23,8 @@ export const waitForIntentFulfilment = async (
       onLogs: async (logs) => {
         logger.debug('waitForIntentFulfilment', { logs });
         const fillTxHash = logs[0]?.transactionHash;
-        // The Fulfilment log means the fill is mined (~1 confirmation). Wait the chain-aware
-        // confirmation count (1 on mainnet, 2 elsewhere) so a lagging dst RPC has the fill synced
-        // before any follow-up tx (e.g. a bridge-and-execute call) reads stale state. The event
-        // already proves the fill, so a transient receipt-wait hiccup must not fail the bridge.
+        // The Fulfilment log means the fill is mined. Confirm its receipt once before any follow-up
+        // transaction; a transient receipt-wait hiccup must not fail the bridge.
         if (fillTxHash) {
           await waitForTxReceiptByChain(fillTxHash, publicClient, chainId).catch(() => undefined);
         }

--- a/src/swap/swap.md
+++ b/src/swap/swap.md
@@ -695,7 +695,7 @@ executeSwapRoute(route, ctx) -> SwapMetadata:                  # execution/orche
   return metadata
 
 receipt confirmation (shared):
-  wait up to 60s for the requested confirmations (1 on Ethereum, 2 on other chains)
+  wait up to 60s for 1 confirmation on every chain
   waiter error → getTransactionReceipt(hash) once as a final inclusion check
     found success → accept it even if the normal confirmation count was not reached
     found revert  → preserve the on-chain-revert classification for the caller's retry policy

--- a/tests/services/evm.test.ts
+++ b/tests/services/evm.test.ts
@@ -86,7 +86,7 @@ describe('confirmStepReceipt', () => {
     });
   });
 
-  it('waits 1 block on Ethereum mainnet, 2 on other chains', async () => {
+  it('waits 1 block on every chain', async () => {
     let confirmations: number | undefined;
     const capture = (a: { confirmations: number }) => {
       confirmations = a.confirmations;
@@ -94,7 +94,7 @@ describe('confirmStepReceipt', () => {
     await confirmStepReceipt(makeClient('success', capture), TX, 1, step);
     expect(confirmations).toBe(1);
     await confirmStepReceipt(makeClient('success', capture), TX, 42161, step);
-    expect(confirmations).toBe(2);
+    expect(confirmations).toBe(1);
   });
 });
 

--- a/tests/services/fulfilment.test.ts
+++ b/tests/services/fulfilment.test.ts
@@ -48,7 +48,7 @@ describe('waitForIntentFulfilment', () => {
       },
     }) as unknown as PublicClient;
 
-  it('waits 2 confirmations of the fill tx on a non-mainnet destination', async () => {
+  it('waits 1 confirmation of the fill tx on a non-mainnet destination', async () => {
     let confirmations: number | undefined;
     await waitForIntentFulfilment(
       makeClient((c) => {
@@ -59,7 +59,7 @@ describe('waitForIntentFulfilment', () => {
       new AbortController(),
       42161
     );
-    expect(confirmations).toBe(2);
+    expect(confirmations).toBe(1);
   });
 
   it('waits 1 confirmation on Ethereum mainnet', async () => {


### PR DESCRIPTION
## Summary

This PR reduces the shared transaction receipt wait from two confirmations to one on non-Ethereum chains.

Ethereum already used one confirmation, so execution-step and fulfilment receipt waits now use one confirmation consistently across all supported chains.

## Changes

- Make `waitForTxReceiptByChain` request one confirmation on every chain.
- Apply the same confirmation count to on-chain intent fulfilment receipt waits through the shared helper.
- Preserve the existing receipt fallback, timeout, revert classification, and step-scoped error behavior.
- Update swap execution documentation and focused service tests for the new confirmation count.

## Testing

- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run typecheck`

## Risk / Impact

- Non-Ethereum follow-up operations may begin one block earlier than before, reducing latency while removing the additional RPC synchronization margin.
- Ethereum receipt behavior is unchanged.
- Public `requiredConfirmations` inputs remain unchanged; this only affects the SDK's shared internal receipt waits.
- No public methods, types, or package-root exports change.