### PR TITLE
swap: limit funding permit validity

### DIFF
--- a/src/swap/swap.md
+++ b/src/swap/swap.md
@@ -666,6 +666,7 @@ per transfer (reason: source | destination | bridge):
   elif permit supported:
     source | bridge → LAZY  {kind:'permit', call:null, signature:null}   # materialized at execution
     destination     → EAGER  signPermitForAddressAndValue(spender=target)
+    EIP-2612 / DAI-style permit deadline = signing time + 15 minutes
   else: authorization = {kind:'approve'}                            # EOA approve(target), mined before the batch
   transferCall = transferFrom(eoa, recipient, amount)               # called by target; bridge recipient may differ
 # bridge EOA balances converted human → raw

--- a/src/swap/wallet/transfer-authorization.ts
+++ b/src/swap/wallet/transfer-authorization.ts
@@ -11,10 +11,14 @@ import { ERC20PermitABI } from '../../abi/erc20';
 import { type Chain, getLogger } from '../../domain';
 import { PermitVariant } from '../../domain/permits';
 import { signPermitForAddressAndValue } from '../../services/allowance-utils';
+import { minutesToMs } from '../../services/time';
 import type { PreparedAuthorizationCall, PublicClientList } from '../types';
 import type { SwapCache } from './cache';
 
 const logger = getLogger();
+// Destination permits are signed before source + bridge execution, whose fill wait alone can take
+// five minutes. Match the SBC validity window so the signature stays finite without expiring mid-flow.
+const TRANSFER_PERMIT_DEADLINE_MS = minutesToMs(15);
 
 const DAI_PERMIT_ABI = [
   {
@@ -72,6 +76,7 @@ const buildPermitCall = async (input: {
   permitVariant: PermitVariant;
   permitContractVersion: number;
 }): Promise<Extract<PreparedAuthorizationCall, { kind: 'permit' }>> => {
+  const deadline = BigInt(Math.floor((Date.now() + TRANSFER_PERMIT_DEADLINE_MS) / 1000));
   const signature = parseSignature(
     await signPermitForAddressAndValue(
       {
@@ -85,11 +90,11 @@ const buildPermitCall = async (input: {
       input.publicClient,
       { address: input.eoaAddress, type: 'json-rpc' } as Account,
       input.ephemeralAddress,
-      input.amount
+      input.amount,
+      deadline
     )
   );
   const signatureV = getSignatureV(signature);
-  const deadline = 2n ** 256n - 1n;
   let call: Extract<PreparedAuthorizationCall, { kind: 'permit' }>['call'];
 
   switch (input.permitVariant) {

--- a/tests/swap/prepare.test.ts
+++ b/tests/swap/prepare.test.ts
@@ -327,7 +327,8 @@ describe('prepareSwapExecution', () => {
       expect.anything(),
       expect.objectContaining({ address: EOA }),
       EPH,
-      500000000n
+      500000000n,
+      expect.anything()
     );
   });
 

--- a/tests/swap/wallet/transfer-authorization.test.ts
+++ b/tests/swap/wallet/transfer-authorization.test.ts
@@ -1,5 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { parseSignature, type Hex, type PublicClient, type WalletClient } from 'viem';
+import {
+  decodeFunctionData,
+  parseSignature,
+  type Hex,
+  type PublicClient,
+  type WalletClient,
+} from 'viem';
+import { ERC20PermitABI } from '../../../src/abi/erc20';
 import { PermitVariant } from '../../../src/domain/permits';
 
 vi.mock('../../../src/services/allowance-utils', () => ({
@@ -104,8 +111,53 @@ describe('materializePermitAuthorizationCall', () => {
       expect.anything(),
       expect.objectContaining({ address: EOA }),
       EPH,
-      1n
+      1n,
+      expect.anything()
     );
+  });
+
+  it('uses the same 15-minute deadline for signing and canonical permit calldata', async () => {
+    vi.mocked(signPermitForAddressAndValue).mockResolvedValueOnce(
+      (`0x${'0'.repeat(63)}1${'0'.repeat(63)}2${'1b'}`) as Hex
+    );
+    vi.mocked(parseSignature).mockReturnValueOnce({
+      r: `0x${'11'.repeat(32)}` as Hex,
+      s: `0x${'22'.repeat(32)}` as Hex,
+      v: 27n,
+      yParity: 0,
+    });
+    const before = BigInt(Math.floor(Date.now() / 1000));
+
+    const call = await materializePermitAuthorizationCall({
+      chain: CHAIN,
+      authorization: {
+        kind: 'permit',
+        call: null,
+        permit: {
+          signature: null,
+          permitVariant: PermitVariant.EIP2612Canonical,
+          permitContractVersion: 1,
+        },
+      },
+      tokenAddress: TOKEN,
+      tokenDecimals: 6,
+      amount: 1n,
+      eoaAddress: EOA,
+      eoaWallet: {} as WalletClient,
+      ephemeralAddress: EPH,
+      publicClient: {} as PublicClient,
+    });
+    const after = BigInt(Math.floor(Date.now() / 1000));
+    const deadline = vi.mocked(signPermitForAddressAndValue).mock.calls[0]?.[7];
+
+    expect(deadline).toBeTypeOf('bigint');
+    expect(deadline).toBeGreaterThanOrEqual(before + 900n);
+    expect(deadline).toBeLessThanOrEqual(after + 900n);
+    expect(call).not.toBeNull();
+    if (!call) throw new Error('Expected canonical permit calldata');
+    const decoded = decodeFunctionData({ abi: ERC20PermitABI, data: call.data });
+    expect(decoded.functionName).toBe('permit');
+    expect(decoded.args[3]).toBe(deadline);
   });
 });
 


### PR DESCRIPTION
## Summary

This PR replaces the effectively infinite deadline on swap funding permit signatures with a 15-minute validity window.

The window keeps unused signatures short-lived while leaving enough time for eagerly signed destination permits to survive source execution and the bridge's five-minute fulfilment wait.

## Changes

- Derive the transfer-permit deadline from `minutesToMs(15)` and convert the final timestamp to Unix seconds for the permit contract.
- Pass the same deadline into typed-data signing and the encoded EIP-2612 / DAI-style permit calldata.
- Apply the finite deadline to both eager destination permits and permits materialized lazily during execution through the shared transfer-authorization builder.
- Document the 15-minute swap funding permit window.
- Add regression coverage that verifies the deadline range and ensures signing and calldata use the identical value.

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

## Risk / Impact

- An unused swap funding permit signature now expires after 15 minutes instead of remaining valid indefinitely.
- A flow that delays permit submission beyond 15 minutes will need a newly signed permit; the window includes headroom over the default five-minute bridge fulfilment timeout.
- The deadline limits when the permit signature can be submitted, not the lifetime of an allowance after the permit executes.
- Polygon meta-transactions and the legacy sponsored-approval middleware flow remain unchanged because their current payloads do not carry a permit deadline.
- No public methods, types, or package-root exports change.