### PR TITLE
bridge: scope deposit fee quotes to eligible sources

### DIFF
--- a/src/bridge/bridge.md
+++ b/src/bridge/bridge.md
@@ -118,10 +118,10 @@ executeBridge({toTokenSymbol:USDC, toAmountRaw:100e6, toChainId:Base}, deps, opt
       balances      = getBalancesForBridge(eoa)
       oraclePrices  = getOraclePrices()
       provider      = resolveBridgeProvider(mw, {dst:USDC@Base, amount:100e6}, false) # → 'nexus'  ◄ seam
-    quoteSources  = explicit sources ?? positive eligible USDC balance chains
+    quoteSources  = positive eligible USDC balance chains ∩ (explicit sources ?? all)
     quoteResponse = getQuote(buildQuoteRequest(USDC, Base, quoteSources)) # scoped deposit + fulfilment fees
     createBridgeIntent(provider='nexus'):                                             (§5)
-      availableSources  = balances on every chain ≠ Base                # depositFee via 'deposit'
+      availableSources  = selected-source balances with a deposit quote # depositFee via 'deposit'
       baseAmount        = 100 + gasInToken                              # gasInToken=0 here
       payableAmount     = baseAmount × (1 + fulfillmentBps/1e4) + fulfillmentFeeToken
       allowedSources    = filter by `sources` allowlist; sort Ethereum-last, then balance DESC
@@ -197,21 +197,26 @@ leg**.
 ## 5. Intent build reference
 
 `buildBridgeIntent` (`intent/builder.ts`) fetches balances, oracle prices, and provider selection in
-parallel. It then scopes `getQuote` to caller-provided source chains, or to positive eligible
-same-currency balances after the existing native-gas reservation when no source allowlist was
-provided. The balance-derived USD resolver still prefers balance pricing before its oracle fallback
-(`bridge-intent-values.test.ts`).
+parallel. It then scopes `getQuote` to positive eligible same-currency balances after the existing
+native-gas reservation, intersected with caller-provided source chains when an allowlist exists.
+Zero-balance chains are never quoted. The balance-derived USD resolver still prefers balance pricing
+before its oracle fallback (`bridge-intent-values.test.ts`).
 
 `buildQuoteRequest` (`quote-request.ts`) requires explicit source chain IDs and resolves the
 same-currency token only on those chains (currencyId first, symbol fallback, native skipped). The
 destination remains present on the first call so middleware can calculate the fulfillment fee; the
 source entries supply the applicable per-source deposit fees without contacting unrelated chains.
+Intent creation applies the same source allowlist before fee lookup and drops any ERC-20 source
+whose deposit fee is missing or zero instead of failing the whole bridge. Native sources remain
+eligible with an internal zero deposit fee and do not require a source quote entry.
+`calculateMaxForBridge` applies the same rule before sizing the provider-selection request.
 
 `createBridgeIntent` (`intent/creator.ts`) branches on `provider`:
 
 ```text
 NEXUS:
-  availableSources = balances(chain ≠ dst), depositFee = lookupDepositFee('deposit')   # native ⇒ 0
+  candidates       = balances(chain ≠ dst) filtered by source allowlist before fee lookup
+  availableSources = candidates with depositFee('deposit'); missing/zero fee ⇒ omit, native ⇒ 0
   baseAmount    = requiredAmount + gasInToken
   payableAmount = baseAmount × (1 + fulfillmentBps/1e4) + fulfillmentFeeToken
   allowedSources= allowlist-filtered; sortSourcesForFeeAllocation = Ethereum(id 1) LAST, then balance DESC
@@ -221,7 +226,8 @@ NEXUS:
   fees = { caGas: Σdeposit + fulfillmentFee, deposit: Σdeposit,
            fulfillment: fulfillmentFee, protocol: baseAmount × bps/1e4, solver: 0 }
 
-MAYAN: createMayanBridgeIntent  (§4) — mayanEnabled gating, $1.10 per-leg floor, quote-once + swing-leg
+MAYAN: createMayanBridgeIntent  (§4) — source allowlist + missing/zero-fee omission, mayanEnabled gating,
+       $1.10 per-leg floor, quote-once + swing-leg
        convergence (one batched getMayanQuotes at full usable, then trim the last leg), gas drop inside
        the route. On ANY throw → falls back to createBridgeIntent({…, provider:'nexus'}); if THAT throws
        too → "Mayan failed: … Nexus fallback failed: …"
@@ -352,8 +358,8 @@ address (`bridge-pipeline.test.ts`, "padded token address").
 | `solver` | `0` | `fulfillment − protocol` |
 
 Deposit fee per source comes from the deploy quote: `depositFeeToken` (Nexus) vs
-`depositMayanFeeToken` (Mayan); native sources are always `0`. The public `total` is
-`caGas + protocol + solver`.
+`depositMayanFeeToken` (Mayan). Quoted ERC-20 fees must be positive; native sources are absent from
+the quote source list and use an internal fee of `0`. The public `total` is `caGas + protocol + solver`.
 
 ---
 

--- a/src/bridge/intent/builder.ts
+++ b/src/bridge/intent/builder.ts
@@ -27,6 +27,7 @@ import {
   buildBridgeProviderRequest,
   buildQuoteRequest,
   resolveBridgeProvider,
+  selectQuoteSourceChainIds,
 } from './quote-request';
 
 type CreateIntentInput = {
@@ -139,19 +140,16 @@ export const buildBridgeIntent = async (
   });
 
   const userAssets = createUserAssets(assets);
-  const quoteSourceChainIds =
-    sourceChains.length > 0
-      ? sourceChains
-      : (
-          await userAssets
-            .find({
-              currencyId: input.dstToken.currencyId,
-              symbol: input.dstToken.symbol,
-            })
-            .iterate(deps.chainList)
-        )
-          .filter((entry) => entry.chain.id !== input.dstChainId && entry.balance.gt(0))
-          .map((entry) => entry.chain.id);
+  const quoteSourceChainIds = selectQuoteSourceChainIds(
+    await userAssets
+      .find({
+        currencyId: input.dstToken.currencyId,
+        symbol: input.dstToken.symbol,
+      })
+      .iterate(deps.chainList),
+    input.dstChainId,
+    sourceChains
+  );
   const quoteResponse = await deps.middlewareClient.getQuote(
     buildQuoteRequest(deps.chainList, input.dstToken, input.dstChainId, quoteSourceChainIds)
   );

--- a/src/bridge/intent/creator.ts
+++ b/src/bridge/intent/creator.ts
@@ -60,22 +60,18 @@ export const lookupDepositFee = (
   quoteResponse: QuoteResponse,
   decimals: number,
   type: 'deposit' | 'depositMayan' = 'deposit'
-): { amount: Decimal; raw: bigint } => {
+): { amount: Decimal; raw: bigint } | null => {
   if (isNativeAddress(tokenContract)) return { amount: new Decimal(0), raw: 0n };
   const match = quoteResponse.sources.find(
     (s) => s.chainId === chainId && equalFold(s.tokenAddress, tokenContract)
   );
-  if (!match) {
-    throw Errors.internal(
-      `Quote response missing deposit fee for chain ${chainId} token ${tokenContract}`
-    );
-  }
+  if (!match) return null;
+  const feeToken = type === 'depositMayan' ? match.depositMayanFeeToken : match.depositFeeToken;
+  const raw = BigInt(feeToken);
+  if (raw === 0n) return null;
   return {
-    amount: divDecimals(
-      type === 'depositMayan' ? match.depositMayanFeeToken : match.depositFeeToken,
-      decimals
-    ),
-    raw: BigInt(type === 'depositMayan' ? match.depositMayanFeeToken : match.depositFeeToken),
+    amount: divDecimals(feeToken, decimals),
+    raw,
   };
 };
 
@@ -153,8 +149,12 @@ export const createBridgeIntent = async (
   }
 
   intent.availableSources = (await asset.iterate(chainList))
-    .filter((entry) => entry.chain.id !== input.dstChainId)
-    .map((entry) => {
+    .filter(
+      (entry) =>
+        entry.chain.id !== input.dstChainId &&
+        (input.sourceChains.length === 0 || input.sourceChains.includes(entry.chain.id))
+    )
+    .flatMap((entry) => {
       const sourceToken = chainList.getTokenByAddress(entry.chain.id, entry.contractAddress);
       const depositFee = lookupDepositFee(
         entry.chain.id,
@@ -162,22 +162,25 @@ export const createBridgeIntent = async (
         input.quoteResponse,
         entry.decimals
       );
-      return {
-        amount: entry.balance,
-        amountRaw: mulDecimals(entry.balance, entry.decimals),
-        balance: entry.balance,
-        chain: entry.chain,
-        holderAddress: retrieveAddress(entry.universe, { evm: { address: evmAddress } }),
-        depositFee: depositFee.amount,
-        depositFeeRaw: depositFee.raw,
-        token: toBridgeIntentToken({
-          ...sourceToken,
-          contractAddress: entry.contractAddress,
-          decimals: entry.decimals,
-        }),
-        universe: entry.universe,
-        value: entry.value,
-      };
+      if (!depositFee) return [];
+      return [
+        {
+          amount: entry.balance,
+          amountRaw: mulDecimals(entry.balance, entry.decimals),
+          balance: entry.balance,
+          chain: entry.chain,
+          holderAddress: retrieveAddress(entry.universe, { evm: { address: evmAddress } }),
+          depositFee: depositFee.amount,
+          depositFeeRaw: depositFee.raw,
+          token: toBridgeIntentToken({
+            ...sourceToken,
+            contractAddress: entry.contractAddress,
+            decimals: entry.decimals,
+          }),
+          universe: entry.universe,
+          value: entry.value,
+        },
+      ];
     })
     .map(({ balance: _balance, ...source }) => source);
 
@@ -191,14 +194,7 @@ export const createBridgeIntent = async (
   const bpsMultiplier = Decimal.add(1, Decimal.div(fulfillmentBps, 10_000));
   const payableAmount = Decimal.add(Decimal.mul(baseAmount, bpsMultiplier), fulfillmentFee);
   const allowedSources = sortSourcesForFeeAllocation(
-    intent.availableSources
-      .map((source) => ({ ...source, balance: source.amount }))
-      .filter((source) => {
-        if (input.sourceChains.length > 0 && !input.sourceChains.includes(source.chain.id)) {
-          return false;
-        }
-        return true;
-      })
+    intent.availableSources.map((source) => ({ ...source, balance: source.amount }))
   );
 
   if (allowedSources.length === 0) {
@@ -350,6 +346,10 @@ const createMayanBridgeIntent = async (
           return false;
         }
 
+        if (input.sourceChains.length > 0 && !input.sourceChains.includes(entry.chain.id)) {
+          return false;
+        }
+
         const sourceChain = chainList.getChainByID(entry.chain.id);
         if (!sourceChain.mayanEnabled) {
           return false;
@@ -358,7 +358,7 @@ const createMayanBridgeIntent = async (
         const sourceToken = chainList.getTokenByAddress(entry.chain.id, entry.contractAddress);
         return sourceToken.mayanEnabled === true;
       })
-      .map((entry) => {
+      .flatMap((entry) => {
         const sourceToken = chainList.getTokenByAddress(entry.chain.id, entry.contractAddress);
         const depositFee = lookupDepositFee(
           entry.chain.id,
@@ -367,22 +367,25 @@ const createMayanBridgeIntent = async (
           entry.decimals,
           'depositMayan'
         );
-        return {
-          amount: entry.balance,
-          amountRaw: mulDecimals(entry.balance, entry.decimals),
-          balance: entry.balance,
-          chain: entry.chain,
-          holderAddress: retrieveAddress(entry.universe, { evm: { address: evmAddress } }),
-          depositFee: depositFee.amount,
-          depositFeeRaw: depositFee.raw,
-          token: toBridgeIntentToken({
-            ...sourceToken,
-            contractAddress: entry.contractAddress,
-            decimals: entry.decimals,
-          }),
-          universe: entry.universe,
-          value: entry.value,
-        };
+        if (!depositFee) return [];
+        return [
+          {
+            amount: entry.balance,
+            amountRaw: mulDecimals(entry.balance, entry.decimals),
+            balance: entry.balance,
+            chain: entry.chain,
+            holderAddress: retrieveAddress(entry.universe, { evm: { address: evmAddress } }),
+            depositFee: depositFee.amount,
+            depositFeeRaw: depositFee.raw,
+            token: toBridgeIntentToken({
+              ...sourceToken,
+              contractAddress: entry.contractAddress,
+              decimals: entry.decimals,
+            }),
+            universe: entry.universe,
+            value: entry.value,
+          },
+        ];
       })
       .map(({ balance: _balance, ...source }) => source);
 
@@ -414,9 +417,6 @@ const createMayanBridgeIntent = async (
         };
       })
       .filter((source) => {
-        if (input.sourceChains.length > 0 && !input.sourceChains.includes(source.chain.id)) {
-          return false;
-        }
         return source.usableUsd.gte(minimumPerLegUsd) && source.usable.gte(source.minimumAmount);
       })
       .sort((a, b) => Decimal.sub(b.usableUsd, a.usableUsd).toNumber());

--- a/src/bridge/intent/quote-request.ts
+++ b/src/bridge/intent/quote-request.ts
@@ -1,9 +1,24 @@
 import type { BridgeProvider, BridgeProviderRequest } from '@avail-project/nexus-types';
+import type Decimal from 'decimal.js';
 import { type Hex, toHex } from 'viem';
 import type { ChainListType, TokenInfo } from '../../domain';
 import { Errors } from '../../domain/errors';
 import { isNativeAddress } from '../../services/addresses';
 import type { MiddlewareBridgeProviderClient, QuoteRequest } from '../../transport';
+
+export const selectQuoteSourceChainIds = (
+  entries: Array<{ balance: Decimal; chain: { id: number } }>,
+  dstChainId: number,
+  sourceChainIds: number[]
+): number[] =>
+  entries
+    .filter(
+      (entry) =>
+        entry.chain.id !== dstChainId &&
+        entry.balance.gt(0) &&
+        (sourceChainIds.length === 0 || sourceChainIds.includes(entry.chain.id))
+    )
+    .map((entry) => entry.chain.id);
 
 export const buildQuoteRequest = (
   chainList: ChainListType,

--- a/src/bridge/max.ts
+++ b/src/bridge/max.ts
@@ -83,11 +83,16 @@ export async function calculateMaxForBridge(
       entries.map((entry) => entry.chain.id)
     )
   );
+  const quotedEntries = entries.filter(
+    (entry) =>
+      lookupDepositFee(entry.chain.id, entry.contractAddress, quoteResponse, entry.decimals) !==
+      null
+  );
 
   // Provider decision: hand the middleware the summed bridge amount (in destination token
   // units) so it applies the same Mayan threshold the real bridge would.
   const bridgeAmountRaw = mulDecimals(
-    entries.reduce((sum, entry) => Decimal.add(sum, entry.balance), new Decimal(0)),
+    quotedEntries.reduce((sum, entry) => Decimal.add(sum, entry.balance), new Decimal(0)),
     dstToken.decimals
   );
   let provider = await resolveBridgeProvider(
@@ -100,7 +105,7 @@ export async function calculateMaxForBridge(
   let selected: SourceEntry[];
   if (provider === 'mayan') {
     const mayan = await computeMayanBridgeMax({
-      entries,
+      entries: quotedEntries,
       dstToken,
       dstChainId: input.toChainId,
       quoteResponse,
@@ -111,12 +116,20 @@ export async function calculateMaxForBridge(
     // per-leg minimum, the real bridge runs on Nexus, so the max should too.
     if (mayan.selected.length === 0) {
       provider = 'nexus';
-      ({ maxToken, selected } = computeNexusBridgeMax({ entries, dstToken, quoteResponse }));
+      ({ maxToken, selected } = computeNexusBridgeMax({
+        entries: quotedEntries,
+        dstToken,
+        quoteResponse,
+      }));
     } else {
       ({ maxToken, selected } = mayan);
     }
   } else {
-    ({ maxToken, selected } = computeNexusBridgeMax({ entries, dstToken, quoteResponse }));
+    ({ maxToken, selected } = computeNexusBridgeMax({
+      entries: quotedEntries,
+      dstToken,
+      quoteResponse,
+    }));
   }
 
   return {
@@ -150,12 +163,14 @@ const computeNexusBridgeMax = (args: {
   let totalUsable = new Decimal(0);
 
   for (const entry of entries) {
-    const depositFee = lookupDepositFee(
+    const depositFeeQuote = lookupDepositFee(
       entry.chain.id,
       entry.contractAddress,
       quoteResponse,
       entry.decimals
-    ).amount;
+    );
+    if (!depositFeeQuote) continue;
+    const depositFee = depositFeeQuote.amount;
     if (depositFee.gte(entry.balance)) continue;
     totalUsable = Decimal.add(totalUsable, Decimal.sub(entry.balance, depositFee));
     selected.push(entry);
@@ -193,14 +208,16 @@ const computeMayanBridgeMax = async (args: {
         chainList.getTokenByAddress(entry.chain.id, entry.contractAddress).mayanEnabled === true
       );
     })
-    .map((entry) => {
-      const depositFee = lookupDepositFee(
+    .flatMap((entry) => {
+      const depositFeeQuote = lookupDepositFee(
         entry.chain.id,
         entry.contractAddress,
         quoteResponse,
         entry.decimals,
         'depositMayan'
-      ).amount;
+      );
+      if (!depositFeeQuote) return [];
+      const depositFee = depositFeeQuote.amount;
       const usable = Decimal.sub(entry.balance, depositFee);
       const usdPerToken = entry.balance.gt(0) ? entry.value.div(entry.balance) : new Decimal(0);
       const minimumAmount = usdPerToken.gt(0)
@@ -209,7 +226,7 @@ const computeMayanBridgeMax = async (args: {
             dstChainId === 1 && isNativeAddress(dstToken.contractAddress) ? 2 : 1
           )
         : new Decimal(Number.POSITIVE_INFINITY);
-      return { entry, usable, usableUsd: Decimal.mul(usable, usdPerToken), minimumAmount };
+      return [{ entry, usable, usableUsd: Decimal.mul(usable, usdPerToken), minimumAmount }];
     })
     .filter((leg) => leg.usableUsd.gte(minPerLeg) && leg.usable.gte(leg.minimumAmount));
 

--- a/src/flows/bridge-and-execute.ts
+++ b/src/flows/bridge-and-execute.ts
@@ -2,7 +2,7 @@ import Decimal from 'decimal.js';
 import { type Hex, type PublicClient, toHex } from 'viem';
 import { z } from 'zod';
 import { createBridgeIntent } from '../bridge/intent/creator';
-import { buildQuoteRequest } from '../bridge/intent/quote-request';
+import { buildQuoteRequest, selectQuoteSourceChainIds } from '../bridge/intent/quote-request';
 import { type BridgePreviewState, buildBridgePreviewState } from '../bridge/preview';
 import {
   type BeforeExecuteHook,
@@ -312,19 +312,16 @@ const buildCompositePreviewState = async (
   }
 
   const assets = createUserAssets(input.unifiedBalances);
-  const quoteSourceChainIds =
-    input.sourceChains && input.sourceChains.length > 0
-      ? input.sourceChains
-      : (
-          await assets
-            .find({
-              currencyId: input.token.currencyId,
-              symbol: input.token.symbol,
-            })
-            .iterate(deps.chainList)
-        )
-          .filter((entry) => entry.chain.id !== input.dstChain.id && entry.balance.gt(0))
-          .map((entry) => entry.chain.id);
+  const quoteSourceChainIds = selectQuoteSourceChainIds(
+    await assets
+      .find({
+        currencyId: input.token.currencyId,
+        symbol: input.token.symbol,
+      })
+      .iterate(deps.chainList),
+    input.dstChain.id,
+    input.sourceChains ?? []
+  );
   const quoteResponse = await deps.middlewareClient.getQuote(
     buildQuoteRequest(deps.chainList, input.token, input.dstChain.id, quoteSourceChainIds)
   );

--- a/tests/bridge/max.test.ts
+++ b/tests/bridge/max.test.ts
@@ -64,16 +64,16 @@ const makeAsset = (input: {
     currencyId: input.currencyId ?? USDC.currencyId,
   }) as BridgeTokenBalance;
 
-// Quote with zero deposit + fulfillment fees for the listed source chains.
-const zeroFeeQuote = (srcChainIds: number[], dstChainId: number, tokenAddress = USDC.contractAddress) => ({
+// Quote with the smallest valid deposit fee and zero fulfillment fees.
+const feeQuote = (srcChainIds: number[], dstChainId: number, tokenAddress = USDC.contractAddress) => ({
   fulfillmentBps: 0,
   sources: srcChainIds.map((chainId) => ({
     chainId,
     tokenAddress,
-    depositFeeUsd: '0',
-    depositFeeToken: '0',
-    depositMayanFeeUsd: '0',
-    depositMayanFeeToken: '0',
+    depositFeeUsd: '0.000001',
+    depositFeeToken: '1',
+    depositMayanFeeUsd: '0.000001',
+    depositMayanFeeToken: '1',
   })),
   destination: {
     chainId: dstChainId,
@@ -106,7 +106,7 @@ const rateMayanQuotes =
 
 const makeOptions = (overrides: {
   provider?: BridgeProvider;
-  quote?: ReturnType<typeof zeroFeeQuote>;
+  quote?: ReturnType<typeof feeQuote>;
   mayanQuotes?: ReturnType<typeof rateMayanQuotes>;
   forceMayan?: boolean;
   token?: TokenInfo;
@@ -125,7 +125,7 @@ const makeOptions = (overrides: {
     evmAddress: '0x000000000000000000000000000000000000aaaa' as `0x${string}`,
     forceMayan: overrides.forceMayan,
     middlewareClient: makeMiddlewareClient({
-      getQuote: async () => overrides.quote ?? zeroFeeQuote([], 0),
+      getQuote: async () => overrides.quote ?? feeQuote([], 0),
       getBridgeProvider: async () => ({ provider: overrides.provider ?? 'nexus' }),
       ...(overrides.mayanQuotes ? { getMayanQuotes: overrides.mayanQuotes as never } : {}),
     }),
@@ -150,11 +150,11 @@ describe('calculateMaxForBridge', () => {
     ]);
 
     const input: BridgeMaxParams = { toChainId: 137, toTokenSymbol: 'USDC' };
-    const result = await calculateMaxForBridge(input, makeOptions({ quote: zeroFeeQuote([1, 10], 137) }));
+    const result = await calculateMaxForBridge(input, makeOptions({ quote: feeQuote([1, 10], 137) }));
 
     expect(result.provider).toBe('nexus');
-    expect(result.maxAmount).toBe('150.000000');
-    expect(result.maxAmountRaw).toBe(150_000_000n);
+    expect(result.maxAmount).toBe('149.999998');
+    expect(result.maxAmountRaw).toBe(149_999_998n);
     expect(result.symbol).toBe('USDC');
     expect(result.decimals).toBe(6);
     expect(result.sources.map((s) => s.chainId).sort()).toEqual([1, 10]);
@@ -171,11 +171,11 @@ describe('calculateMaxForBridge', () => {
 
     const result = await calculateMaxForBridge(
       { toChainId: 137, toTokenSymbol: 'USDC' },
-      makeOptions({ quote: zeroFeeQuote([1], 137) })
+      makeOptions({ quote: feeQuote([1], 137) })
     );
 
-    expect(result.maxAmount).toBe('50.000000');
-    expect(result.maxAmountRaw).toBe(50_000_000n);
+    expect(result.maxAmount).toBe('49.999999');
+    expect(result.maxAmountRaw).toBe(49_999_999n);
   });
 
   it('nexus path: returns the full usable amount for non-stables', async () => {
@@ -211,10 +211,10 @@ describe('calculateMaxForBridge', () => {
 
     const result = await calculateMaxForBridge(
       { toChainId: 137, toTokenSymbol: 'WETH' },
-      makeOptions({ token: WETH, quote: zeroFeeQuote([1], 137, WETH.contractAddress) })
+      makeOptions({ token: WETH, quote: feeQuote([1], 137, WETH.contractAddress) })
     );
 
-    expect(result.maxAmount).toBe('1.000000000000000000');
+    expect(result.maxAmount).toBe('0.999999999999999999');
     expect(result.decimals).toBe(18);
     expect(result.symbol).toBe('WETH');
   });
@@ -235,15 +235,41 @@ describe('calculateMaxForBridge', () => {
       { toChainId: 10, toTokenSymbol: 'USDC' },
       makeOptions({
         provider: 'mayan',
-        quote: zeroFeeQuote([42161, 8453], 10),
+        quote: feeQuote([42161, 8453], 10),
         mayanQuotes: rateMayanQuotes(0.99),
       })
     );
 
     expect(result.provider).toBe('mayan');
-    expect(result.maxAmount).toBe('198.000000');
-    expect(result.maxAmountRaw).toBe(198_000_000n);
+    expect(result.maxAmount).toBe('197.999998');
+    expect(result.maxAmountRaw).toBe(197_999_999n);
     expect(result.sources.map((s) => s.chainId).sort((a, b) => a - b)).toEqual([8453, 42161]);
+  });
+
+  it('mayan path: ignores source chains missing a deposit fee quote', async () => {
+    vi.mocked(getBalancesForBridge).mockResolvedValue([
+      makeAsset({
+        balance: '200',
+        value: '200.00',
+        chainBalances: [
+          makeChainBalance({ balance: '100', value: '100.00', chainId: 42161, chainName: 'Arbitrum' }),
+          makeChainBalance({ balance: '100', value: '100.00', chainId: 8453, chainName: 'Base' }),
+        ],
+      }),
+    ]);
+
+    const result = await calculateMaxForBridge(
+      { toChainId: 10, toTokenSymbol: 'USDC' },
+      makeOptions({
+        provider: 'mayan',
+        quote: feeQuote([8453], 10),
+        mayanQuotes: rateMayanQuotes(0.99),
+      })
+    );
+
+    expect(result.provider).toBe('mayan');
+    expect(result.maxAmount).toBe('98.999999');
+    expect(result.sources.map((source) => source.chainId)).toEqual([8453]);
   });
 
   it('restricts to the requested source chains', async () => {
@@ -258,20 +284,50 @@ describe('calculateMaxForBridge', () => {
       }),
     ]);
 
-    const options = makeOptions({ quote: zeroFeeQuote([1, 10], 137) });
+    const options = makeOptions({ quote: feeQuote([1, 10], 137) });
     const getQuote = vi.spyOn(options.middlewareClient, 'getQuote');
     const result = await calculateMaxForBridge(
       { toChainId: 137, toTokenSymbol: 'USDC', sources: [1] },
       options
     );
 
-    expect(result.maxAmount).toBe('100.000000');
+    expect(result.maxAmount).toBe('99.999999');
     expect(result.sources.map((s) => s.chainId)).toEqual([1]);
     expect(getQuote).toHaveBeenCalledWith({
       sources: [{ chain_id: toHex(1), contract_address: USDC.contractAddress }],
       destination: {
         chain_id: toHex(137),
         contract_address: USDC.contractAddress,
+      },
+    });
+  });
+
+  it('ignores source chains missing a deposit fee quote', async () => {
+    vi.mocked(getBalancesForBridge).mockResolvedValue([
+      makeAsset({
+        balance: '150',
+        value: '150.00',
+        chainBalances: [
+          makeChainBalance({ balance: '100', value: '100.00', chainId: 1, chainName: 'Ethereum' }),
+          makeChainBalance({ balance: '50', value: '50.00', chainId: 10, chainName: 'Optimism' }),
+        ],
+      }),
+    ]);
+
+    const options = makeOptions({ quote: feeQuote([1], 137) });
+    const getBridgeProvider = vi.spyOn(options.middlewareClient, 'getBridgeProvider');
+    const result = await calculateMaxForBridge(
+      { toChainId: 137, toTokenSymbol: 'USDC' },
+      options
+    );
+
+    expect(result.maxAmount).toBe('99.999999');
+    expect(result.sources.map((source) => source.chainId)).toEqual([1]);
+    expect(getBridgeProvider).toHaveBeenCalledWith({
+      destination: {
+        chain_id: toHex(137),
+        contract_address: USDC.contractAddress,
+        amount: '100000000',
       },
     });
   });
@@ -290,13 +346,13 @@ describe('calculateMaxForBridge', () => {
       makeOptions({
         provider: 'nexus', // middleware says nexus...
         forceMayan: true, // ...but force wins
-        quote: zeroFeeQuote([42161], 10),
+        quote: feeQuote([42161], 10),
         mayanQuotes: rateMayanQuotes(0.99),
       })
     );
 
     expect(result.provider).toBe('mayan');
-    expect(result.maxAmount).toBe('99.000000');
+    expect(result.maxAmount).toBe('98.999999');
   });
 
   it('falls back to nexus when no source clears the Mayan per-leg minimum', async () => {
@@ -312,7 +368,7 @@ describe('calculateMaxForBridge', () => {
       { toChainId: 10, toTokenSymbol: 'USDC' },
       makeOptions({
         provider: 'mayan', // middleware picks mayan, but the only leg is below the $1.10 floor
-        quote: zeroFeeQuote([42161], 10),
+        quote: feeQuote([42161], 10),
         mayanQuotes: rateMayanQuotes(0.99),
       })
     );

--- a/tests/flows/bridge-intent-creator.test.ts
+++ b/tests/flows/bridge-intent-creator.test.ts
@@ -7,7 +7,7 @@ import type {
   TokenInfo,
 } from '../../src/domain';
 import { Universe } from '../../src/domain/chain-abstraction';
-import { createBridgeIntent } from '../../src/bridge/intent/creator';
+import { createBridgeIntent, lookupDepositFee } from '../../src/bridge/intent/creator';
 import { createUserAssets } from '../../src/services/balances';
 import type { MayanQuote, MayanQuoteRequest } from '../../src/transport';
 import { makeChain, makeChainList } from '../helpers/chains';
@@ -67,19 +67,20 @@ describe('createBridgeIntent', () => {
 
   const zeroUsdValue = () => new Decimal(0);
 
-  const zeroFeeQuote = (
+  const feeQuote = (
     srcChainIds: number[],
     dstChainId: number,
-    tokenAddress = token.contractAddress
+    tokenAddress = token.contractAddress,
+    depositFeeToken = '1'
   ) => ({
     fulfillmentBps: 0,
     sources: srcChainIds.map((chainId) => ({
       chainId,
       tokenAddress,
-      depositFeeUsd: '0',
-      depositFeeToken: '0',
-      depositMayanFeeUsd: '0',
-      depositMayanFeeToken: '0',
+      depositFeeUsd: '0.000001',
+      depositFeeToken,
+      depositMayanFeeUsd: '0.000001',
+      depositMayanFeeToken: depositFeeToken,
     })),
     destination: {
       chainId: dstChainId,
@@ -87,6 +88,12 @@ describe('createBridgeIntent', () => {
       fulfillmentFeeUsd: '0',
       fulfillmentFeeToken: '0',
     },
+  });
+
+  it('treats a zero ERC-20 deposit fee quote as missing', () => {
+    expect(
+      lookupDepositFee(1, token.contractAddress, feeQuote([1], 10, token.contractAddress, '0'), token.decimals)
+    ).toBeNull();
   });
 
   const makeChainBalance = (input: {
@@ -157,7 +164,7 @@ describe('createBridgeIntent', () => {
         dstChainUniverse: Universe.ETHEREUM,
         dstChainNativeDecimals: 18,
         recipient: options.evm.address,
-        quoteResponse: zeroFeeQuote([1], 10),
+        quoteResponse: feeQuote([1], 10),
         provider: 'nexus',
       },
       createIntentContext(options)
@@ -173,6 +180,100 @@ describe('createBridgeIntent', () => {
     expect(intent.destination.amount.toFixed()).toBe('6');
     expect(intent.destination.value.toFixed(2)).toBe('0.00');
     expect(intent.destination.nativeAmountValue.toFixed(2)).toBe('0.00');
+  });
+
+  it('looks up deposit fees only for explicitly selected source chains', async () => {
+    const selectedChain = makeChain(1, 'Ethereum');
+    const unselectedChain = makeChain(42161, 'Arbitrum');
+    const dstChain = makeChain(10, 'Optimism');
+    const assets: TokenBalance[] = [
+      makeTokenBalance({
+        balance: '20',
+        chainBalances: [
+          makeChainBalance({
+            balance: '10',
+            chainId: selectedChain.id,
+            chainName: selectedChain.name,
+          }),
+          makeChainBalance({
+            balance: '10',
+            chainId: unselectedChain.id,
+            chainName: unselectedChain.name,
+          }),
+        ],
+      }),
+    ];
+    const chainList = makeChainList([selectedChain, unselectedChain, dstChain], token);
+    const options = makeOptions(chainList);
+
+    const intent = await createBridgeIntent(
+      {
+        amount: new Decimal('6'),
+        assets: createUserAssets(assets),
+        gas: new Decimal('0'),
+        gasInToken: new Decimal('0'),
+        resolveUsdValue: zeroUsdValue,
+        sourceChains: [selectedChain.id],
+        token,
+        dstChainId: dstChain.id,
+        dstChainUniverse: Universe.ETHEREUM,
+        dstChainNativeDecimals: 18,
+        recipient: options.evm.address,
+        quoteResponse: feeQuote([selectedChain.id], dstChain.id),
+        provider: 'nexus',
+      },
+      createIntentContext(options)
+    );
+
+    expect(intent.availableSources.map((source) => source.chain.id)).toEqual([selectedChain.id]);
+    expect(intent.selectedSources.map((source) => source.chain.id)).toEqual([selectedChain.id]);
+  });
+
+  it('ignores source chains missing a deposit fee quote', async () => {
+    const missingFeeChain = makeChain(1, 'Ethereum');
+    const quotedChain = makeChain(42161, 'Arbitrum');
+    const dstChain = makeChain(10, 'Optimism');
+    const assets: TokenBalance[] = [
+      makeTokenBalance({
+        balance: '20',
+        chainBalances: [
+          makeChainBalance({
+            balance: '10',
+            chainId: missingFeeChain.id,
+            chainName: missingFeeChain.name,
+          }),
+          makeChainBalance({
+            balance: '10',
+            chainId: quotedChain.id,
+            chainName: quotedChain.name,
+          }),
+        ],
+      }),
+    ];
+    const chainList = makeChainList([missingFeeChain, quotedChain, dstChain], token);
+    const options = makeOptions(chainList);
+
+    const intent = await createBridgeIntent(
+      {
+        amount: new Decimal('6'),
+        assets: createUserAssets(assets),
+        gas: new Decimal('0'),
+        gasInToken: new Decimal('0'),
+        resolveUsdValue: zeroUsdValue,
+        sourceChains: [],
+        token,
+        dstChainId: dstChain.id,
+        dstChainUniverse: Universe.ETHEREUM,
+        dstChainNativeDecimals: 18,
+        recipient: options.evm.address,
+        quoteResponse: feeQuote([quotedChain.id], dstChain.id),
+        provider: 'nexus',
+      },
+      createIntentContext(options)
+    );
+
+    expect(intent.availableSources.map((source) => source.chain.id)).toEqual([quotedChain.id]);
+    expect(intent.selectedSources.map((source) => source.chain.id)).toEqual([quotedChain.id]);
   });
 
   it('excludes Mayan-disabled source chains and source tokens from Mayan source selection', async () => {
@@ -246,7 +347,7 @@ describe('createBridgeIntent', () => {
         dstChainUniverse: Universe.ETHEREUM,
         dstChainNativeDecimals: 18,
         recipient: '0x0000000000000000000000000000000000000002',
-        quoteResponse: zeroFeeQuote([usableChain.id], dstChain.id),
+        quoteResponse: feeQuote([usableChain.id], dstChain.id),
         provider: 'mayan',
       },
       {
@@ -261,6 +362,78 @@ describe('createBridgeIntent', () => {
     expect(quotedSources.map((source) => Number(BigInt(source.chain_id)))).toEqual([
       usableChain.id,
     ]);
+  });
+
+  it('keeps Mayan routing when a source is missing a deposit fee quote', async () => {
+    const missingFeeChain = makeChain(42161, 'Arbitrum');
+    const quotedChain = makeChain(8453, 'Base');
+    const dstChain = makeChain(10, 'Optimism');
+    const assets: TokenBalance[] = [
+      makeTokenBalance({
+        balance: '20',
+        value: '20.00',
+        chainBalances: [
+          makeChainBalance({
+            balance: '10',
+            value: '10.00',
+            chainId: missingFeeChain.id,
+            chainName: missingFeeChain.name,
+          }),
+          makeChainBalance({
+            balance: '10',
+            value: '10.00',
+            chainId: quotedChain.id,
+            chainName: quotedChain.name,
+          }),
+        ],
+      }),
+    ];
+    const chainList = makeChainList([missingFeeChain, quotedChain, dstChain], token);
+    const quotedSourceChains: number[][] = [];
+    const middlewareClient = makeMiddlewareClient({
+      getMayanQuotes: async (request) => {
+        quotedSourceChains.push(
+          request.sources.map((source) => Number(BigInt(source.chain_id)))
+        );
+        return {
+          destination: { chainId: dstChain.id, tokenAddress: token.contractAddress },
+          quotes: request.sources.map((source) => ({
+            source: {
+              chainId: Number(BigInt(source.chain_id)),
+              tokenAddress: source.contract_address as `0x${string}`,
+              amount: source.amount,
+            },
+            mayanQuote: { minReceived: 5, protocolBps: 0 } as MayanQuote,
+          })),
+        };
+      },
+    });
+
+    const intent = await createBridgeIntent(
+      {
+        amount: new Decimal('5'),
+        assets: createUserAssets(assets),
+        gas: new Decimal('0'),
+        gasInToken: new Decimal('0'),
+        resolveUsdValue: ({ amount }) => amount,
+        sourceChains: [],
+        token,
+        dstChainId: dstChain.id,
+        dstChainUniverse: Universe.ETHEREUM,
+        dstChainNativeDecimals: 18,
+        recipient: '0x0000000000000000000000000000000000000002',
+        quoteResponse: feeQuote([quotedChain.id], dstChain.id),
+        provider: 'mayan',
+      },
+      {
+        ...createIntentContext(makeOptions(chainList)),
+        middlewareClient,
+      }
+    );
+
+    expect(intent.provider).toBe('mayan');
+    expect(intent.availableSources.map((source) => source.chain.id)).toEqual([quotedChain.id]);
+    expect(quotedSourceChains).toEqual([[quotedChain.id]]);
   });
 
   describe('Mayan exact-out convergence', () => {
@@ -332,7 +505,7 @@ describe('createBridgeIntent', () => {
           dstChainUniverse: Universe.ETHEREUM,
           dstChainNativeDecimals: 18,
           recipient: options.evm.address,
-          quoteResponse: zeroFeeQuote([bigChain.id, swingChain.id], dstChain.id),
+          quoteResponse: feeQuote([bigChain.id, swingChain.id], dstChain.id),
           provider: 'mayan',
         },
         { ...createIntentContext(options), middlewareClient: makeRateMayanClient(0.5) }
@@ -341,14 +514,14 @@ describe('createBridgeIntent', () => {
       expect(intent.provider).toBe('mayan');
       const big = intent.selectedSources.find((s) => s.chain.id === bigChain.id)!;
       const swing = intent.selectedSources.find((s) => s.chain.id === swingChain.id)!;
-      // big leg (out 6 at full 12) can't cover 7 alone, so it stays at full usable
-      expect(big.amount.toFixed()).toBe('12');
+      // big leg can't cover 7 alone, so it stays at its full balance-minus-fee usable amount
+      expect(big.amount.toFixed()).toBe('11.999999');
       // swing covers residual output 1. The 50% mock is a steep *proportional* fee, so the
       // absolute-haircut seed (which models a FIXED fee) over-sizes here: seed = need 1 +
       // fullHaircut (10−5)=5 → 6 in → 3 out, delivering 9 vs the 7 requested. Pins the known
       // trade-off (real Mayan is mostly fixed — see the fixed-fee test below for clean convergence).
       expect(swing.amount.toFixed()).toBe('6');
-      expect(intent.destination.amount.toFixed()).toBe('9');
+      expect(intent.destination.amount.toFixed()).toBe('8.9999995');
     });
 
     it('over-sizes a single source on a steep proportional rate (the absolute-haircut trade-off)', async () => {
@@ -386,7 +559,7 @@ describe('createBridgeIntent', () => {
           dstChainUniverse: Universe.ETHEREUM,
           dstChainNativeDecimals: 18,
           recipient: options.evm.address,
-          quoteResponse: zeroFeeQuote([srcChain.id], dstChain.id),
+          quoteResponse: feeQuote([srcChain.id], dstChain.id),
           provider: 'mayan',
         },
         { ...createIntentContext(options), middlewareClient: makeRateMayanClient(0.5) }
@@ -397,7 +570,7 @@ describe('createBridgeIntent', () => {
       // Steep 50% *proportional* mock: the absolute-haircut seed (modelling a FIXED fee) over-sizes —
       // seed = need 30 + fullHaircut (100−50)=50 → 80 in → 40 out, delivering 40 vs 30 requested.
       // The documented trade-off; on a mostly-fixed real Mayan fee it converges clean (test below).
-      expect(intent.selectedSources[0]!.amount.toFixed()).toBe('80');
+      expect(intent.selectedSources[0]!.amount.toFixed()).toBe('79.9999995');
       expect(intent.destination.amount.toFixed()).toBe('40');
     });
 
@@ -445,7 +618,7 @@ describe('createBridgeIntent', () => {
           dstChainUniverse: Universe.ETHEREUM,
           dstChainNativeDecimals: 18,
           recipient: options.evm.address,
-          quoteResponse: zeroFeeQuote([bigChain.id, swingChain.id], dstChain.id),
+          quoteResponse: feeQuote([bigChain.id, swingChain.id], dstChain.id),
           provider: 'mayan',
         },
         { ...createIntentContext(options), middlewareClient: makeRateMayanClient(0.5) }
@@ -524,7 +697,7 @@ describe('createBridgeIntent', () => {
           dstChainUniverse: Universe.ETHEREUM,
           dstChainNativeDecimals: 18,
           recipient: options.evm.address,
-          quoteResponse: zeroFeeQuote([srcChain.id], dstChain.id),
+          quoteResponse: feeQuote([srcChain.id], dstChain.id),
           provider: 'mayan',
         },
         { ...createIntentContext(options), middlewareClient: makeFixedFeeMayanClient(1.0) }
@@ -589,7 +762,7 @@ describe('createBridgeIntent', () => {
         dstChainUniverse: Universe.ETHEREUM,
         dstChainNativeDecimals: 18,
         recipient: options.evm.address,
-        quoteResponse: zeroFeeQuote([1], 10),
+        quoteResponse: feeQuote([1], 10),
         provider: 'nexus',
       },
       createIntentContext(options)
@@ -628,7 +801,7 @@ describe('createBridgeIntent', () => {
           dstChainUniverse: Universe.ETHEREUM,
           dstChainNativeDecimals: 18,
           recipient: options.evm.address,
-          quoteResponse: zeroFeeQuote([], 10),
+          quoteResponse: feeQuote([], 10),
           provider: 'nexus',
         },
         createIntentContext(options)
@@ -656,7 +829,7 @@ describe('createBridgeIntent', () => {
           dstChainUniverse: Universe.ETHEREUM,
           dstChainNativeDecimals: 18,
           recipient: options.evm.address,
-          quoteResponse: zeroFeeQuote([], 10),
+          quoteResponse: feeQuote([], 10),
           provider: 'nexus',
         },
         createIntentContext(options)
@@ -696,7 +869,7 @@ describe('createBridgeIntent', () => {
           dstChainUniverse: Universe.ETHEREUM,
           dstChainNativeDecimals: 18,
           recipient: options.evm.address,
-          quoteResponse: zeroFeeQuote([1], 10),
+          quoteResponse: feeQuote([1], 10),
           provider: 'nexus',
         },
         createIntentContext(options)
@@ -736,7 +909,7 @@ describe('createBridgeIntent', () => {
           dstChainUniverse: Universe.ETHEREUM,
           dstChainNativeDecimals: 18,
           recipient: options.evm.address,
-          quoteResponse: zeroFeeQuote([1], 10),
+          quoteResponse: feeQuote([1], 10),
           provider: 'nexus',
         },
         createIntentContext(options)
@@ -874,9 +1047,9 @@ describe('createBridgeIntent', () => {
       fulfillmentBps: 0,
       fulfillmentFeeToken: '0',
       sources: [
-        { chainId: ethChain.id, tokenAddress: token.contractAddress, depositFeeToken: '0' },
-        { chainId: arbChain.id, tokenAddress: token.contractAddress, depositFeeToken: '0' },
-        { chainId: baseChain.id, tokenAddress: token.contractAddress, depositFeeToken: '0' },
+        { chainId: ethChain.id, tokenAddress: token.contractAddress, depositFeeToken: '1' },
+        { chainId: arbChain.id, tokenAddress: token.contractAddress, depositFeeToken: '1' },
+        { chainId: baseChain.id, tokenAddress: token.contractAddress, depositFeeToken: '1' },
       ],
       dstChainId: dstChain.id,
     });
@@ -900,15 +1073,14 @@ describe('createBridgeIntent', () => {
       createIntentContext(options)
     );
 
-    // Sort: Base(20) before Arb(10) before Eth(30) — amount DESC, Eth last
-    // Need 55: Base 20 + Arb 10 + Eth 25
+    // Sort: Base before Arb before Eth — balance DESC, Eth last. Each full leg pays one raw fee.
     expect(intent.selectedSources).toHaveLength(3);
     expect(intent.selectedSources[0]!.chain.id).toBe(baseChain.id);
-    expect(intent.selectedSources[0]!.amount.toFixed()).toBe('20');
+    expect(intent.selectedSources[0]!.amount.toFixed()).toBe('19.999999');
     expect(intent.selectedSources[1]!.chain.id).toBe(arbChain.id);
-    expect(intent.selectedSources[1]!.amount.toFixed()).toBe('10');
+    expect(intent.selectedSources[1]!.amount.toFixed()).toBe('9.999999');
     expect(intent.selectedSources[2]!.chain.id).toBe(ethChain.id);
-    expect(intent.selectedSources[2]!.amount.toFixed()).toBe('25');
+    expect(intent.selectedSources[2]!.amount.toFixed()).toBe('25.000002');
   });
 
   it('skips sources where deposit fee exceeds balance', async () => {
@@ -1221,7 +1393,7 @@ describe('createBridgeIntent', () => {
           dstChainUniverse: Universe.ETHEREUM,
           dstChainNativeDecimals: 18,
           recipient: options.evm.address,
-          quoteResponse: zeroFeeQuote([], 10),
+          quoteResponse: feeQuote([], 10),
           provider: 'nexus',
         },
         createIntentContext(options)

--- a/tests/flows/bridge-intent-values.test.ts
+++ b/tests/flows/bridge-intent-values.test.ts
@@ -45,6 +45,15 @@ const USDC_ASSET: TokenBalance = {
       symbol: 'USDC',
       universe: Universe.ETHEREUM,
     },
+    {
+      balance: '0',
+      value: '0.00',
+      chain: { id: 137, logo: '', name: 'Polygon' },
+      contractAddress: TOKEN_ADDRESS,
+      decimals: 6,
+      symbol: 'USDC',
+      universe: Universe.ETHEREUM,
+    },
   ],
   decimals: 6,
   logo: '',
@@ -128,6 +137,7 @@ describe('buildBridgeIntent value resolver', () => {
       dstChainId: chain2.id,
       dstChainUniverse: Universe.ETHEREUM,
       dstChainNativeDecimals: 18,
+      sourceChains: [chain1.id, unrelatedChain.id],
       forceMayan: false,
       deps: {
         chainList,

--- a/tests/flows/characterization/bridge-and-execute-pipeline.test.ts
+++ b/tests/flows/characterization/bridge-and-execute-pipeline.test.ts
@@ -296,8 +296,8 @@ const makeMiddlewareClient = (
         {
           chainId: SOURCE_CHAIN_ID,
           tokenAddress: TOKEN_ADDRESS,
-          depositFeeUsd: '0',
-          depositFeeToken: '0',
+          depositFeeUsd: '0.000001',
+          depositFeeToken: '1',
         },
       ],
       destination: {

--- a/tests/helpers/bridge-characterization.ts
+++ b/tests/helpers/bridge-characterization.ts
@@ -199,14 +199,14 @@ export const makeBridgeCharacterizationHarness = (_options?: {
         {
           chainId: primarySourceChain.id,
           tokenAddress: primarySourceToken.contractAddress,
-          depositFeeUsd: '0',
-          depositFeeToken: '0',
+          depositFeeUsd: '0.000001',
+          depositFeeToken: '1',
         },
         {
           chainId: alternateSourceChain.id,
           tokenAddress: alternateSourceToken.contractAddress,
-          depositFeeUsd: '0',
-          depositFeeToken: '0',
+          depositFeeUsd: '0.000001',
+          depositFeeToken: '1',
         },
       ],
       destination: {


### PR DESCRIPTION
## Summary

This PR scopes bridge deposit-fee quotes to eligible source balances and makes incomplete quote responses non-fatal.

Standalone bridge and bridge-and-execute now quote only positive same-currency balances that satisfy the caller's source-chain allowlist. ERC-20 sources with missing or zero deposit fees are ignored, while native sources remain unquoted and retain their internal zero-fee handling.

## Changes

- Centralize bridge quote-source selection so standalone bridge and bridge-and-execute intersect explicit source chains with positive eligible balances before calling `/quote`.
- Keep destination, unsupported-token, duplicate, and native-token sources out of deposit-fee quote requests.
- Treat missing or zero `depositFeeToken` / `depositMayanFeeToken` values as ineligible ERC-20 sources instead of throwing an internal error.
- Preserve native-source behavior by assigning the internal zero fee without requiring a quote source entry.
- Apply the same missing/zero-fee filtering to Nexus and Mayan bridge max calculations before provider selection.
- Update the bridge flow reference and add regression coverage for source scoping, missing fees, zero fees, Mayan routing, and max calculation.

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

## Risk / Impact

- Bridge quote requests may contain fewer source entries because explicitly selected zero-balance chains are no longer quoted.
- An ERC-20 chain omitted from the quote response, or returned with a zero deposit fee, is no longer selectable. If no eligible sources remain, the existing validation or insufficient-balance error is returned.
- Native sources remain eligible without a deposit-fee quote and continue to use an internal zero fee.
- Bridge max provider selection now excludes sources that cannot supply a valid positive deposit fee.
- No public methods, types, or package-root exports change.