### PR TITLE
swap: increase receipt timeout to three minutes

### DIFF
--- a/src/services/evm.ts
+++ b/src/services/evm.ts
@@ -18,7 +18,7 @@ import { minutesToMs } from './time';
 
 const logger = getLogger();
 
-const TRANSACTION_RECEIPT_WAIT_TIMEOUT_MS = 60_000;
+const TRANSACTION_RECEIPT_WAIT_TIMEOUT_MS = minutesToMs(3);
 
 type TransactionReceiptPublicClient = Pick<
   PublicClient,

--- a/src/swap/swap.md
+++ b/src/swap/swap.md
@@ -696,7 +696,7 @@ executeSwapRoute(route, ctx) -> SwapMetadata:                  # execution/orche
   return metadata
 
 receipt confirmation (shared):
-  wait up to 60s for 1 confirmation on every chain
+  wait up to 3 minutes for 1 confirmation on every chain
   waiter error → getTransactionReceipt(hash) once as a final inclusion check
     found success → accept it even if the normal confirmation count was not reached
     found revert  → preserve the on-chain-revert classification for the caller's retry policy

--- a/tests/services/evm.test.ts
+++ b/tests/services/evm.test.ts
@@ -101,7 +101,7 @@ describe('confirmStepReceipt', () => {
 describe('waitForTxReceipt', () => {
   const TX = '0xabc0000000000000000000000000000000000000000000000000000000000001' as const;
 
-  it('falls back to a direct receipt lookup when the confirmation waiter fails', async () => {
+  it('uses the 3-minute default and falls back to a direct receipt lookup when waiting fails', async () => {
     const waitError = new Error('receipt wait timed out');
     const waitForTransactionReceipt = vi.fn().mockRejectedValue(waitError);
     const receipt = { status: 'success' } as const;
@@ -120,7 +120,7 @@ describe('waitForTxReceipt', () => {
     expect(waitForTransactionReceipt).toHaveBeenCalledWith({
       confirmations: 1,
       hash: TX,
-      timeout: 60_000,
+      timeout: 180_000,
     });
     expect(getTransactionReceipt).toHaveBeenCalledWith({ hash: TX });
   });


### PR DESCRIPTION
## Summary

Increase the shared transaction receipt wait from one minute to three minutes so swaps have more time to reach one confirmation before being treated as failed.

## Changes
- Set the shared receipt timeout with `minutesToMs(3)`.
- Update the focused receipt-wait test to lock the three-minute default.
- Synchronize the swap execution documentation with the new timeout.

## Testing
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run typecheck:tests`
- [x] `npm test`

## Risk / Impact

Low. The longer default applies to all callers of the shared receipt helper, including swap, bridge, allowance, and execute-approval waits. The main execute transaction retains its existing configurable five-minute default. No public API signatures change.