### PR TITLE
bridge: limit sponsored permit validity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -345,6 +345,31 @@
         "node": ">=14.21.3"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
@@ -352,6 +377,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1593,7 +1619,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1750,7 +1775,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3055,7 +3079,6 @@
       "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.8",
@@ -4712,7 +4735,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
       "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -4767,7 +4789,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -5729,7 +5750,6 @@
       "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.3",
         "@babel/types": "^7.29.0",
@@ -6475,8 +6495,7 @@
       "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
       "integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/rc9": {
       "version": "3.0.1",
@@ -6693,7 +6712,6 @@
       "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -7315,7 +7333,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7449,7 +7466,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7528,7 +7544,6 @@
       "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.8",
         "@vitest/mocker": "4.1.8",
@@ -7758,7 +7773,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7826,7 +7840,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
-        "@avail-project/nexus-types": "0.1.21",
+        "@avail-project/nexus-types": "0.1.25",
         "@opentelemetry/api-logs": "0.219.0",
         "@opentelemetry/exporter-logs-otlp-http": "0.219.0",
         "@opentelemetry/resources": "2.8.0",
@@ -78,12 +78,12 @@
       "license": "MIT"
     },
     "node_modules/@avail-project/nexus-types": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@avail-project/nexus-types/-/nexus-types-0.1.21.tgz",
-      "integrity": "sha512-GMn36KmRa71qZDgZ505eWHDxsfxPEBJcXuafe3/8EVRdCzdXXT/2xVkCaAC61pyUAnktSP2oL7sLHWoA6r+6Gg==",
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@avail-project/nexus-types/-/nexus-types-0.1.25.tgz",
+      "integrity": "sha512-KDEFVSjfGmCW0tKiNGS/zrB8yl9m8IPt+HBvIlgYk1G4Nh45fxCEfi0vKHyfzdmy7Ya44HNZglf+R/l6YkGM5A==",
       "dependencies": {
         "@mayanfinance/swap-sdk": "^13.3.0",
-        "viem": "^2.48.2"
+        "viem": "^2.50.3"
       },
       "peerDependencies": {
         "zod": ">=4.0.0"
@@ -343,29 +343,6 @@
       ],
       "engines": {
         "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1616,6 +1593,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1772,6 +1750,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3042,6 +3021,7 @@
       "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.8",
@@ -4698,6 +4678,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
       "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -4752,6 +4733,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -5713,6 +5695,7 @@
       "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.3",
         "@babel/types": "^7.29.0",
@@ -6458,7 +6441,8 @@
       "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
       "integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/rc9": {
       "version": "3.0.1",
@@ -6675,6 +6659,7 @@
       "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -7296,6 +7281,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7429,6 +7415,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7507,6 +7494,7 @@
       "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.8",
         "@vitest/mocker": "4.1.8",
@@ -7736,6 +7724,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7803,6 +7792,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -346,9 +346,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2198,6 +2198,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@avail-project/nexus-types": "0.1.21",
+    "@avail-project/nexus-types": "0.1.25",
     "@opentelemetry/api-logs": "0.219.0",
     "@opentelemetry/exporter-logs-otlp-http": "0.219.0",
     "@opentelemetry/resources": "2.8.0",

--- a/src/bridge/bridge.md
+++ b/src/bridge/bridge.md
@@ -277,7 +277,7 @@ depositFeeRaw`; flag when it exceeds the current allowance (keyed by chain + tok
 `onAllowance({sources, allow, deny})`; `allow(selections)` requires `selections.length ===
 sources.length` else `invalidAllowance`; `deny()` → `userRejectedAllowance`.
 `prepareBridgeExecution` (`allowances/prepare.ts`) then `approve`s the vault per source (EOA tx /
-sponsored).
+sponsored). Sponsored permit variants with an expiry field expire 15 minutes after signing.
 
 **Plan** (`steps.ts createBridgePlan`), deterministic ids:
 ```text

--- a/src/services/allowance-utils.ts
+++ b/src/services/allowance-utils.ts
@@ -159,7 +159,7 @@ export async function signPermitForAddressAndValue(
   account: Account,
   spender: Address,
   value: bigint,
-  ddl?: bigint
+  ddl: bigint
 ) {
   await switchChain(client, chain);
 
@@ -170,7 +170,7 @@ export async function signPermitForAddressAndValue(
   });
 
   const walletAddress = account.address;
-  const deadline = ddl ?? 2n ** 256n - 1n;
+  const deadline = ddl;
   const tokenNameRequest = contract.read.name().catch(() => {
     logger.error(
       'signPermit:failed to read token name',

--- a/src/services/allowances.ts
+++ b/src/services/allowances.ts
@@ -23,6 +23,7 @@ import { divDecimals, mulDecimals } from './math';
 import { getPermitVariantAndVersion } from './permits';
 import { createAllowanceApprovalStepId } from './step-ids';
 import { equalFold } from './strings';
+import { minutesFromNow } from './time';
 
 const logger = getLogger();
 
@@ -273,7 +274,8 @@ export const executeAllowances = async (input: AllowanceExecutionInput): Promise
           publicClient,
           account,
           vaultContract,
-          source.amount
+          source.amount,
+          minutesFromNow(15)
         ).catch((cause) => {
           const error =
             cause instanceof NexusError

--- a/src/services/allowances.ts
+++ b/src/services/allowances.ts
@@ -266,6 +266,7 @@ export const executeAllowances = async (input: AllowanceExecutionInput): Promise
         ...amount,
       });
 
+      const deadline = minutesFromNow(15);
       const signed = parseSignature(
         await signPermitForAddressAndValue(
           currency,
@@ -275,7 +276,7 @@ export const executeAllowances = async (input: AllowanceExecutionInput): Promise
           account,
           vaultContract,
           source.amount,
-          minutesFromNow(15)
+          deadline
         ).catch((cause) => {
           const error =
             cause instanceof NexusError
@@ -309,6 +310,7 @@ export const executeAllowances = async (input: AllowanceExecutionInput): Promise
         },
       ];
       sponsoredApprovals[chain.id][0].ops.push({
+        deadline: deadline.toString(),
         signature: {
           v: signed.yParity < 27 ? signed.yParity + 27 : signed.yParity,
           r: signed.r,

--- a/src/services/time.ts
+++ b/src/services/time.ts
@@ -1,1 +1,4 @@
 export const minutesToMs = (min: number) => min * 60 * 1000;
+
+export const minutesFromNow = (min: number): bigint =>
+  BigInt(Math.floor((Date.now() + minutesToMs(min)) / 1000));

--- a/src/swap/execution/bridge.ts
+++ b/src/swap/execution/bridge.ts
@@ -33,6 +33,7 @@ import {
   createBridgeDepositStepId,
   createEoaToEphemeralTransferStepId,
 } from '../../services/step-ids';
+import { minutesFromNow } from '../../services/time';
 import { withTimingSpan } from '../../services/timing';
 import { createSwapBridgeIntent } from '../bridge-intent';
 import type { BridgeAsset, ExecutionContext, SwapMetadata, SwapRoute } from '../types';
@@ -63,7 +64,6 @@ const resolveBridgeRecipient = (input: {
 
 // 5 minute window — matches v1's BRIDGE_VAULT_PERMIT_DEADLINE_MINUTES. Permit deadline expiry
 // has historically been a source of flake; do not drop below 3 minutes.
-const BRIDGE_VAULT_PERMIT_DEADLINE_SECONDS = 5n * 60n;
 const MAX_BRIDGE_FUNDING_ATTEMPTS = 3;
 
 const isRetryableFundingPreparationError = (
@@ -440,7 +440,7 @@ const runMayanEphemeralBridge = async (
       const publicClient = ctx.publicClientList.get(asset.chainID);
       const { safeAddress } = ctx;
       await requireSafeDeployment(ctx.safeDeploymentPromises, asset.chainID);
-      const deadline = BigInt(Math.floor(Date.now() / 1000)) + BRIDGE_VAULT_PERMIT_DEADLINE_SECONDS;
+      const deadline = minutesFromNow(5);
       const safeCalls = [
         ...fundingCalls,
         ...(await resolveSafeVaultAllowanceCalls({
@@ -942,8 +942,7 @@ const executeEphemeralBridgePath = async (
         const publicClient = ctx.publicClientList.get(asset.chainID);
         const { safeAddress } = ctx;
         await requireSafeDeployment(ctx.safeDeploymentPromises, asset.chainID);
-        const deadline =
-          BigInt(Math.floor(Date.now() / 1000)) + BRIDGE_VAULT_PERMIT_DEADLINE_SECONDS;
+        const deadline = minutesFromNow(5);
         const safeCalls = [
           ...fundingCalls,
           ...(await buildSafeBridgeDepositCalls({

--- a/src/swap/execution/failure-cleanup.ts
+++ b/src/swap/execution/failure-cleanup.ts
@@ -6,13 +6,13 @@ import {
   type SweepContext,
   type SweepGroup,
 } from '../../services/init-refund-sweep';
+import { minutesFromNow } from '../../services/time';
 import { type CurrencyID, resolveCOT } from '../cot';
 import type { ExecutionContext, SwapRoute } from '../types';
 import { buildEphemeralPermitCall } from '../wallet/ephemeral-permit';
 import { readSettlementBalanceRaw } from './settlement-balance';
 
 const logger = getLogger();
-const CLEANUP_PERMIT_DEADLINE_SECONDS = 5n * 60n;
 
 /**
  * The currency the on-failure cleanup should sweep, or `null` to skip it. A Nexus same-token bridge
@@ -89,7 +89,7 @@ export const cleanupStrandedCot = async (input: {
 
       if (balance <= 0n) continue;
       if (sourceAtEphemeral) {
-        const deadline = BigInt(Math.floor(Date.now() / 1000)) + CLEANUP_PERMIT_DEADLINE_SECONDS;
+        const deadline = minutesFromNow(5);
         const permitCall = await buildEphemeralPermitCall({
           tokenAddress,
           amount: balance,

--- a/src/swap/wallet/transfer-authorization.ts
+++ b/src/swap/wallet/transfer-authorization.ts
@@ -11,14 +11,13 @@ import { ERC20PermitABI } from '../../abi/erc20';
 import { type Chain, getLogger } from '../../domain';
 import { PermitVariant } from '../../domain/permits';
 import { signPermitForAddressAndValue } from '../../services/allowance-utils';
-import { minutesToMs } from '../../services/time';
+import { minutesFromNow } from '../../services/time';
 import type { PreparedAuthorizationCall, PublicClientList } from '../types';
 import type { SwapCache } from './cache';
 
 const logger = getLogger();
 // Destination permits are signed before source + bridge execution, whose fill wait alone can take
-// Five minutes keeps the signature finite without expiring mid-flow.
-const TRANSFER_PERMIT_DEADLINE_MS = minutesToMs(15);
+// five minutes. A 15-minute window keeps the signature finite without expiring mid-flow.
 
 const DAI_PERMIT_ABI = [
   {
@@ -76,7 +75,7 @@ const buildPermitCall = async (input: {
   permitVariant: PermitVariant;
   permitContractVersion: number;
 }): Promise<Extract<PreparedAuthorizationCall, { kind: 'permit' }>> => {
-  const deadline = BigInt(Math.floor((Date.now() + TRANSFER_PERMIT_DEADLINE_MS) / 1000));
+  const deadline = minutesFromNow(15);
   const signature = parseSignature(
     await signPermitForAddressAndValue(
       {

--- a/tests/fixtures/deployment.ts
+++ b/tests/fixtures/deployment.ts
@@ -23,6 +23,7 @@ export const testDeployment: DeploymentResponse = {
         currencyId: 3,
       },
       sponsored: false,
+      swapSupported: true,
       explorerUrl: 'https://etherscan.io',
       logo: 'https://example.com/eth-chain/logo.png',
       tokens: [
@@ -61,6 +62,7 @@ export const testDeployment: DeploymentResponse = {
         currencyId: 3,
       },
       sponsored: true,
+      swapSupported: true,
       explorerUrl: 'https://sepolia.etherscan.io',
       logo: 'https://example.com/sepolia/logo.png',
       tokens: [

--- a/tests/flows/characterization/swap-and-execute-funding.test.ts
+++ b/tests/flows/characterization/swap-and-execute-funding.test.ts
@@ -118,6 +118,7 @@ const DEPLOYMENT: DeploymentResponse = {
       multicallAddress: '0x00000000000000000000000000000000000000aa',
       nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18, logo: '', currencyId: 3 },
       sponsored: false,
+      swapSupported: true,
       explorerUrl: 'https://arbiscan.io',
       logo: '',
       tokens: [

--- a/tests/services/allowance-utils.test.ts
+++ b/tests/services/allowance-utils.test.ts
@@ -85,13 +85,20 @@ describe('signPermitForAddressAndValue', () => {
     );
   });
 
-  it('uses a 15-minute deadline for bridge allowance permits', async () => {
+  it('uses the same 15-minute deadline for permit signing and sponsored approval', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-08-04T00:00:00.000Z'));
 
     const signTypedData = vi.fn().mockResolvedValue(
       `0x${'0'.repeat(63)}1${'0'.repeat(63)}2${'1b'}` as Hex
     );
+    const createApprovals = vi.fn().mockResolvedValue([
+      {
+        chainId: SOURCE_CHAIN.id,
+        address: OWNER,
+        errored: false,
+      },
+    ]);
     const walletClient = {
       getChainId: vi.fn().mockResolvedValue(SOURCE_CHAIN.id),
       signTypedData,
@@ -111,19 +118,15 @@ describe('signPermitForAddressAndValue', () => {
       options: {
         evm: { address: OWNER, client: walletClient },
         chainList: makeChainList([SOURCE_CHAIN], token),
-        middlewareClient: makeMiddlewareClient({
-          createApprovals: vi.fn().mockResolvedValue([
-            {
-              chainId: SOURCE_CHAIN.id,
-              address: OWNER,
-              errored: false,
-            },
-          ]),
-        }),
+        middlewareClient: makeMiddlewareClient({ createApprovals }),
       },
       dstChain: SOURCE_CHAIN,
     });
 
-    expect(signTypedData.mock.calls[0]?.[0]?.message.deadline).toBe(minutesFromNow(15));
+    const deadline = minutesFromNow(15);
+    expect(signTypedData.mock.calls[0]?.[0]?.message.deadline).toBe(deadline);
+    expect(
+      createApprovals.mock.calls[0]?.[0]?.[SOURCE_CHAIN.id]?.[0]?.ops[0]?.deadline
+    ).toBe(deadline.toString());
   });
 });

--- a/tests/services/allowance-utils.test.ts
+++ b/tests/services/allowance-utils.test.ts
@@ -1,8 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Account, Hex, PublicClient, WalletClient } from 'viem';
+import type { TokenInfo } from '../../src/domain';
 import { PermitVariant } from '../../src/domain/permits';
 import { signPermitForAddressAndValue } from '../../src/services/allowance-utils';
-import { makeChain } from '../helpers/chains';
+import { executeAllowances } from '../../src/services/allowances';
+import { minutesFromNow } from '../../src/services/time';
+import { makeChain, makeChainList } from '../helpers/chains';
+import { makeMiddlewareClient } from '../helpers/middleware-client';
 
 const contractReads = vi.hoisted(() => ({
   name: vi.fn(),
@@ -26,6 +30,10 @@ const SPENDER = '0x0000000000000000000000000000000000000003' as Hex;
 const SOURCE_CHAIN = makeChain(42161, 'Arbitrum');
 
 describe('signPermitForAddressAndValue', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     contractReads.name.mockResolvedValue('USD Coin');
@@ -61,7 +69,8 @@ describe('signPermitForAddressAndValue', () => {
       {} as PublicClient,
       { address: OWNER, type: 'json-rpc' } as Account,
       SPENDER,
-      123n
+      123n,
+      456n
     );
 
     expect(walletClient.switchChain).toHaveBeenCalledWith({ id: SOURCE_CHAIN.id });
@@ -74,5 +83,47 @@ describe('signPermitForAddressAndValue', () => {
     expect(walletClient.switchChain.mock.invocationCallOrder[0]).toBeLessThan(
       walletClient.signTypedData.mock.invocationCallOrder[0]
     );
+  });
+
+  it('uses a 15-minute deadline for bridge allowance permits', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-04T00:00:00.000Z'));
+
+    const signTypedData = vi.fn().mockResolvedValue(
+      `0x${'0'.repeat(63)}1${'0'.repeat(63)}2${'1b'}` as Hex
+    );
+    const walletClient = {
+      getChainId: vi.fn().mockResolvedValue(SOURCE_CHAIN.id),
+      signTypedData,
+    } as unknown as WalletClient;
+    const token: TokenInfo = {
+      contractAddress: TOKEN,
+      decimals: 6,
+      logo: '',
+      name: 'USD Coin',
+      symbol: 'USDC',
+      permitVariant: PermitVariant.EIP2612Canonical,
+      permitVersion: 2,
+    };
+
+    await executeAllowances({
+      sources: [{ chainID: SOURCE_CHAIN.id, tokenContract: TOKEN, amount: 123n }],
+      options: {
+        evm: { address: OWNER, client: walletClient },
+        chainList: makeChainList([SOURCE_CHAIN], token),
+        middlewareClient: makeMiddlewareClient({
+          createApprovals: vi.fn().mockResolvedValue([
+            {
+              chainId: SOURCE_CHAIN.id,
+              address: OWNER,
+              errored: false,
+            },
+          ]),
+        }),
+      },
+      dstChain: SOURCE_CHAIN,
+    });
+
+    expect(signTypedData.mock.calls[0]?.[0]?.message.deadline).toBe(minutesFromNow(15));
   });
 });

--- a/tests/services/chain-list.test.ts
+++ b/tests/services/chain-list.test.ts
@@ -25,6 +25,7 @@ const makeDeployment = (overrides?: Partial<DeploymentResponse>): DeploymentResp
         currencyId: 3,
       },
       sponsored: false,
+      swapSupported: true,
       tokens: [
         {
           symbol: 'USDC',

--- a/tests/services/time.test.ts
+++ b/tests/services/time.test.ts
@@ -1,0 +1,18 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { minutesFromNow } from '../../src/services/time';
+
+describe('minutesFromNow', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns a Unix timestamp the requested minutes from now', () => {
+    const now = new Date('2026-08-04T00:00:00.500Z');
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    expect(minutesFromNow(15)).toBe(
+      BigInt(Math.floor((now.getTime() + 15 * 60 * 1000) / 1000))
+    );
+  });
+});

--- a/tests/transport/middleware-swap-supported-schema.test.ts
+++ b/tests/transport/middleware-swap-supported-schema.test.ts
@@ -16,6 +16,7 @@ const wireChain = (overrides: Record<string, unknown> = {}): Record<string, unkn
     currencyId: 100,
   },
   sponsored: false,
+  swapSupported: true,
   explorerUrl: 'https://hyperliquid.cloud.blockscout.com',
   logo: 'https://example.com/chain.png',
   tokens: [],
@@ -45,7 +46,7 @@ describe('deploymentResponseSchema parses swapSupported independently of executi
   });
 
   it('leaves swapSupported undefined when wire field omitted', () => {
-    const parsed = deploymentResponseSchema.parse(wirePayload());
+    const parsed = deploymentResponseSchema.parse(wirePayload({ swapSupported: undefined }));
 
     expect(parsed.chains[0].swapSupported).toBeUndefined();
   });

--- a/tests/transport/middleware.test.ts
+++ b/tests/transport/middleware.test.ts
@@ -217,6 +217,7 @@ describe('createMiddlewareClient', () => {
               currencyId: 3,
             },
             sponsored: false,
+            swapSupported: true,
             explorerUrl: 'https://sepolia.etherscan.io',
             logo: 'https://example.com/chain.png',
             tokens: [
@@ -269,6 +270,7 @@ describe('createMiddlewareClient', () => {
               logo: 'https://example.com/eth.png',
             },
             sponsored: false,
+            swapSupported: true,
             explorerUrl: 'https://sepolia.etherscan.io',
             logo: 'https://example.com/chain.png',
             tokens: [
@@ -322,6 +324,7 @@ describe('createMiddlewareClient', () => {
               currencyId: 3,
             },
             sponsored: false,
+            swapSupported: true,
             explorerUrl: 'https://sepolia.etherscan.io',
             logo: 'https://example.com/chain.png',
             tokens: [
@@ -375,6 +378,7 @@ describe('createMiddlewareClient', () => {
               currencyId: 3,
             },
             sponsored: false,
+            swapSupported: true,
             explorerUrl: 'https://sepolia.etherscan.io',
             logo: 'https://example.com/chain.png',
             tokens: [],


### PR DESCRIPTION
## Summary

This PR replaces the effectively infinite deadline on standalone bridge sponsored permit signatures with a 15-minute validity window and sends that exact deadline to the middleware for execution.

It upgrades `@avail-project/nexus-types` to the published version containing per-operation approval deadlines and aligns deployment parsing with the required `swapSupported` field.

## Changes

- Upgrade `@avail-project/nexus-types` from `0.1.21` to `0.1.25`.
- Add `minutesFromNow(minutes)` alongside `minutesToMs` for Unix-second deadlines.
- Require every `signPermitForAddressAndValue` caller to provide an explicit deadline instead of falling back to `uint256.max`.
- Sign standalone bridge sponsored permits with a deadline 15 minutes from signing.
- Include the same deadline as a decimal string in each sponsored EIP-2612 approval operation sent to `/api/v2/create-sponsored-approvals`.
- Reuse `minutesFromNow` for existing 15-minute swap funding/SBC deadlines and five-minute bridge-vault/cleanup permit deadlines without changing their validity windows.
- Require `swapSupported` in deployment responses to match the published deployment type and update deployment fixtures accordingly.
- Document the standalone bridge permit validity window.
- Add regression coverage proving the signed EIP-712 deadline and middleware approval deadline are identical.

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

## Risk / Impact

- The approval wire contract is additive: `@avail-project/nexus-types@0.1.25` accepts an optional integer deadline per operation, and the SDK now supplies the deadline used in its signature.
- An unused standalone bridge permit signature expires after 15 minutes instead of remaining valid indefinitely.
- A bridge approval delayed beyond 15 minutes will require a newly signed permit.
- The deadline limits when the permit can be submitted; it does not limit an allowance after the permit executes.
- Permit variants without an expiry field, including Polygon meta-transactions, remain unchanged.
- Existing swap funding, bridge-vault, cleanup, and SBC validity windows are unchanged by the helper refactor.
- Deployment responses missing `swapSupported` are now rejected at the transport boundary; current deployments already provide this required field.
- No public SDK methods, types, or package-root exports change.