### PR TITLE
swap: fix exact-out COT direct routing and destination buffering

### DIFF
--- a/src/swap/routing/exact-out.ts
+++ b/src/swap/routing/exact-out.ts
@@ -488,7 +488,10 @@ export async function _exactOutRoute(
     data.toNativeAmountRaw != null && data.toNativeAmountRaw > 0n ? data.toNativeAmountRaw : 0n;
   const dstHoldings = holdings.filter((holding) => holding.chainID === data.toChainId);
   const canTryDirectDestination =
-    !options.skipFastPaths && data.toAmountRaw > 0n && dstHoldings.length > 0;
+    !options.skipFastPaths &&
+    data.toAmountRaw > 0n &&
+    (data.toNativeAmountRaw ?? 0n) >= 0n &&
+    dstHoldings.length > 0;
   const nativePricePromise =
     canTryDirectDestination && requestedNativeAmountRaw > 0n
       ? priceResolver.resolve(data.toChainId, EADDRESS)

--- a/src/swap/routing/exact-out.ts
+++ b/src/swap/routing/exact-out.ts
@@ -482,21 +482,20 @@ export async function _exactOutRoute(
     { tags: { mode: SwapMode.EXACT_OUT } }
   );
   const priceResolver = createTokenPriceResolver(options);
-  const directNeedsTokenSwap =
-    data.toAmountRaw > 0n && !equalFold(data.toTokenAddress, dstCOT.address);
   const destinationPricePromise = priceResolver.resolve(data.toChainId, data.toTokenAddress);
   const cotPricePromise = priceResolver.resolve(data.toChainId, dstCOT.address as Hex);
   const requestedNativeAmountRaw =
     data.toNativeAmountRaw != null && data.toNativeAmountRaw > 0n ? data.toNativeAmountRaw : 0n;
+  const dstHoldings = holdings.filter((holding) => holding.chainID === data.toChainId);
+  const canTryDirectDestination =
+    !options.skipFastPaths && data.toAmountRaw > 0n && dstHoldings.length > 0;
   const nativePricePromise =
-    !options.skipFastPaths && directNeedsTokenSwap && requestedNativeAmountRaw > 0n
+    canTryDirectDestination && requestedNativeAmountRaw > 0n
       ? priceResolver.resolve(data.toChainId, EADDRESS)
       : Promise.resolve<ResolvedTokenPrice | null>(null);
-  const dstHoldings = holdings.filter((holding) => holding.chainID === data.toChainId);
-  const dstHoldingPricePromises =
-    !options.skipFastPaths && directNeedsTokenSwap
-      ? dstHoldings.map((holding) => priceResolver.resolve(holding.chainID, holding.tokenAddress))
-      : [];
+  const dstHoldingPricePromises = canTryDirectDestination
+    ? dstHoldings.map((holding) => priceResolver.resolve(holding.chainID, holding.tokenAddress))
+    : [];
 
   const [destinationPrice, nativePrice] = await Promise.all([
     destinationPricePromise,
@@ -538,12 +537,7 @@ export async function _exactOutRoute(
     hasUnpricedDstHolding,
     passed: directPriceGatePassed,
   });
-  if (
-    !options.skipFastPaths &&
-    directNeedsTokenSwap &&
-    dstHoldings.length > 0 &&
-    directPriceGatePassed
-  ) {
+  if (canTryDirectDestination && directPriceGatePassed) {
     const direct = await tryFastPath('direct', () =>
       buildDirectDestinationExactOutRoute(data, holdings, options)
     );

--- a/src/swap/routing/exact-out.ts
+++ b/src/swap/routing/exact-out.ts
@@ -614,14 +614,17 @@ export async function _exactOutRoute(
     roughlyEstimatedSources
   );
 
-  const destinationBuffer = applyBuffer(
-    inputAmount,
-    DST_BUFFER_PCT,
-    DST_BUFFER_MAX_USD,
-    oraclePrices,
-    data.toChainId,
-    dstCOT.address
-  );
+  const destinationBuffer =
+    needsTokenSwap || needsGasSwap
+      ? applyBuffer(
+          inputAmount,
+          DST_BUFFER_PCT,
+          DST_BUFFER_MAX_USD,
+          oraclePrices,
+          data.toChainId,
+          dstCOT.address
+        )
+      : new Decimal(0);
   const destinationBufferedInput = inputAmount.plus(destinationBuffer);
   const originalDestinationMaxInput = new Decimal(destinationBufferedInput);
   const sourceBuffer = applyBuffer(

--- a/src/swap/swap.md
+++ b/src/swap/swap.md
@@ -353,7 +353,7 @@ determineSwapRoute(input, opts) -> SwapRoute:
     # Path A gets the first attempt, before any COT→toToken sizing quote:
     directRequiredUsd = toAmount × toTokenPrice + nativeAmount × nativePrice
     directCapacityUsd = Σ(dstHolding.amount × cachedPrice)
-    if needTokenSwap ∧ dstHoldings non-empty ∧
+    if toAmountRaw > 0 ∧ dstHoldings non-empty ∧
        (required/capacity unknown ∨ directCapacityUsd ≥ directRequiredUsd):
       try buildDirectDestinationExactOutRoute                       # authoritative quotes/coverage
       success → return immediately                                  # no destination requirement quote

--- a/src/swap/swap.md
+++ b/src/swap/swap.md
@@ -388,7 +388,10 @@ determineSwapRoute(input, opts) -> SwapRoute:
     #     Null F-quote / insufficient F ⇒ fall back to the USDC COT flow.
     provider, minOutputUsdPerSource = resolveBridgeProviderDecision(  # ← AFTER fast-path attempts
                         dstCOT, RES.filter(non-dst))                   # same immutable RES snapshot
-    inputAmount.max = inputAmount + min(DST_BUFFER_PCT·in, DST_BUFFER_MAX_USD)
+    destinationBuffer = (needTokenSwap ∨ needGasSwap)
+                      ? min(DST_BUFFER_PCT·in, DST_BUFFER_MAX_USD)
+                      : 0
+    inputAmount.max = inputAmount + destinationBuffer
     outputRequired  = max         + min(SRC_BUFFER_PCT·max, SRC_BUFFER_MAX_USD)
     source = autoSelectSources(holdings, outputRequired, minOutputUsdPerSource)   # §6 (floor drops sub-$1.10 chains)
 
@@ -990,8 +993,8 @@ fixed-plus-bps model and reapplies it to `Σ(executed)` when building the bridge
 
 ### 12.2 Invariants
 
-- **Buffers applied once.** The default EXACT_OUT swap path has a dst buffer `min(10%, $2)` +
-  source buffer `min(2%, $1)`;
+- **Buffers applied once.** The default EXACT_OUT swap path has a dst buffer `min(10%, $2)` only
+  when a destination token or gas swap runs, plus a source buffer `min(2%, $1)`;
   EXACT_IN has **no buffer** (no source buffer, no dst buffer). (Values: `DST_BUFFER_PCT`/`DST_BUFFER_MAX_USD`,
   `SRC_BUFFER_PCT`/`SRC_BUFFER_MAX_USD` —
   pinned in `tests/swap/constants.test.ts`.) `getDstSwap` never lets the EXACT_OUT max ceiling

--- a/tests/swap/characterization/swap.test.ts
+++ b/tests/swap/characterization/swap.test.ts
@@ -683,7 +683,7 @@ describe('swap execution characterization', () => {
     expect(sentTxs).toHaveLength(0);
   });
 
-  it('EXACT_OUT · Nexus · 7702 source → COT dst (derived amounts, per-leg consistency)', async () => {
+  it('EXACT_OUT · Nexus · COT dst skips the destination buffer when no destination swap runs', async () => {
     // EXACT_OUT: ask for exactly N USDC on BASE. Source amounts are routing-derived, so we assert
     // the call SHAPE + receivers exactly and the amounts for CONSISTENCY across a leg (the same
     // value threads permit→transferFrom→approve→swap-input; swap-output == bridge approve/deposit).
@@ -726,6 +726,8 @@ describe('swap execution characterization', () => {
     eq(EPH)(source[3].args[4]); // taker = wrapper
     eq(EPH)(source[3].args[5]); // receiver = wrapper (cross-chain leg)
     const usdcOut = source[3].args[3] as bigint; // swap outputAmount (USDC)
+    // The COT destination needs no destination swap, so only the $1 source buffer is added.
+    expect(usdcOut).toBe(501n * 10n ** 6n);
 
     // BRIDGE deposit: approve(vault) + deposit; approve amount == produced COT.
     expect(bridge.map((c) => c.fn)).toEqual(['approve', 'deposit']);
@@ -2490,7 +2492,9 @@ describe('EXACT_OUT coverage expansion', () => {
     eq(EPH)(swp.args[5]); // wrapper receives the COT for the bridge
     expect(eoaTx.value, 'tx value carries the derived native input').toBe(swp.args[2]);
     const produced = swp.args[3] as bigint;
-    expect(produced, 'covers the target + buffers').toBeGreaterThanOrEqual(503n * 10n ** 6n);
+    expect(produced, 'covers the target + source buffer').toBeGreaterThanOrEqual(
+      501n * 10n ** 6n
+    );
     // Bridge leg: approve(vault, produced) → deposit; the RFF bridges exactly the produced COT.
     const arb = sbcBatchesForChain(middlewareClient, ARB_CHAIN);
     expect(arb.map((b) => b.map((c) => c.fn))).toEqual([['approve', 'deposit']]);
@@ -2723,10 +2727,10 @@ describe('amount flow under a source drift', () => {
   });
 
   // ── EXACT_OUT drift twins (D1-D3, ai-exact-out-coverage-plan.md §2 P3) ──
-  // want 500 USDC on BASE → target = 500 + dstBuffer(min(10%·500,$2)=2) + srcBuffer(min(2%·502,$1)=1)
-  // = 503 USDC planned source COT (P'). fees are 0 in the harness.
-  const PLANNED_OUT = 503n * 10n ** 6n;
-  const SLIPPED_OUT = 504n * 10n ** 6n; // A' > P' actually lands at the source wrapper
+  // want 500 USDC on BASE with no destination swap → target = 500 + srcBuffer($1)
+  // = 501 USDC planned source COT (P'). fees are 0 in the harness.
+  const PLANNED_OUT = 501n * 10n ** 6n;
+  const SLIPPED_OUT = 502n * 10n ** 6n; // A' > P' actually lands at the source wrapper
 
   it('D1 · positive slippage · EXACT_OUT · Nexus — reclaim bridges the ACTUAL COT, delivery re-derives', async () => {
     const { promise, middlewareClient: mw } = runExactOut({ provider: 'nexus', toAmountRaw: 500n * 10n ** 6n, wrapperCot: SLIPPED_OUT });
@@ -2739,7 +2743,7 @@ describe('amount flow under a source drift', () => {
   });
 
   it('D2 · requote DOWN within srcBuffer · EXACT_OUT · Nexus — re-dispatch carries the fresh quote and completes', async () => {
-    // −0.05% on ~503 ≈ $0.25 loss < the $1 srcBuffer → the kept EXACT_OUT guard must let it through.
+    // −0.05% on ~501 ≈ $0.25 loss < the $1 srcBuffer → the kept EXACT_OUT guard must let it through.
     const drift = makeRequoteDrift({ chainId: ARB_CHAIN, sourceToken: SOURCE_DAI, factor: 0.9995 });
     const { promise, middlewareClient: mw } = runExactOut({ provider: 'nexus', toAmountRaw: 500n * 10n ** 6n, wrapperCot: PLANNED_OUT, drift });
     await promise;
@@ -2754,7 +2758,7 @@ describe('amount flow under a source drift', () => {
   });
 
   it('D3 · requote DOWN beyond srcBuffer · EXACT_OUT · Nexus — the kept guard aborts, nothing deposits', async () => {
-    // −5% on ~503 ≈ $25 loss ≫ the $1 srcBuffer → EXACT_OUT (unlike EXACT_IN) must abort.
+    // −5% on ~501 ≈ $25 loss ≫ the $1 srcBuffer → EXACT_OUT (unlike EXACT_IN) must abort.
     const drift = makeRequoteDrift({ chainId: ARB_CHAIN, sourceToken: SOURCE_DAI, factor: 0.95 });
     const { promise, middlewareClient: mw } = runExactOut({ provider: 'nexus', toAmountRaw: 500n * 10n ** 6n, wrapperCot: PLANNED_OUT, drift });
 

--- a/tests/swap/characterization/swap.test.ts
+++ b/tests/swap/characterization/swap.test.ts
@@ -2097,6 +2097,58 @@ describe('EXACT_OUT coverage expansion', () => {
     expect(sentTxs).toHaveLength(0); // ERC20 input → ephemeral SBC, no EOA native send
   });
 
+  it('A7 · COT exact out uses a covering destination-chain asset directly despite a remote source', async () => {
+    const balances: FlatBalance[] = [
+      dai(BASE_CHAIN, '1000'),
+      {
+        amount: '1',
+        chainID: ARB_CHAIN,
+        decimals: 18,
+        symbol: 'WETH',
+        tokenAddress: WETH,
+        value: 2500,
+        name: 'Wrapped Ether',
+        logo: '',
+      },
+    ];
+    const middlewareClient = makeCharMiddleware({ balances, provider: 'nexus' });
+    const { wallet } = makeRealEoaWallet();
+
+    await flowSwap(
+      {
+        mode: SwapMode.EXACT_OUT as const,
+        data: {
+          sources: [
+            { chainId: BASE_CHAIN, tokenAddress: SOURCE_DAI },
+            { chainId: ARB_CHAIN, tokenAddress: WETH },
+          ],
+          toChainId: BASE_CHAIN,
+          toTokenAddress: USDC_BASE,
+          toAmountRaw: 500n * 10n ** 6n,
+        },
+      },
+      deps(middlewareClient, wallet),
+      allow
+    );
+
+    expect(middlewareClient.submitRFF).not.toHaveBeenCalled();
+    expect(sbcBatchesForChain(middlewareClient, ARB_CHAIN)).toEqual([]);
+
+    const base = sbcBatchesForChain(middlewareClient, BASE_CHAIN);
+    expect(base).toHaveLength(1);
+    expect(base[0].map((call) => call.fn)).toEqual([
+      'permit',
+      'transferFrom',
+      'approve',
+      'swap',
+    ]);
+    const swap = base[0][3];
+    eq(SOURCE_DAI)(swap.args[0]);
+    eq(USDC_BASE)(swap.args[1]);
+    eq(EOA)(swap.args[5]);
+    expect(swap.args[3]).toBe(500n * 10n ** 6n);
+  });
+
   // ── B · gas-only with a bridged source ──
 
   it('B1 · gas-only funding from a cross-chain COT source → bridge fills the wrapper, gas swap runs', async () => {

--- a/tests/swap/route.test.ts
+++ b/tests/swap/route.test.ts
@@ -4600,7 +4600,8 @@ describe('determineSwapRoute — bridge provider parity', () => {
     // Before the real source quoting, the route rough-selects ~110% of the 1000 USDC requirement,
     // quotes Mayan, and folds the haircut (a flat $22 on the 1100 rough leg) into the target that
     // autoSelectSources must cover — so the real selection produces enough COT to survive the bridge
-    // fee. Net dst-need + buffers is 1003; with the fee, autoSelect is asked for 1025.
+    // fee. With no destination swap, net dst-need + source buffer is 1001; with the fee,
+    // autoSelect is asked for 1023.
     const mayanMw = {
       getBridgeProvider: vi.fn().mockResolvedValue({ provider: 'mayan' }),
       getMayanQuotes: vi.fn().mockImplementation(
@@ -4644,7 +4645,7 @@ describe('determineSwapRoute — bridge provider parity', () => {
     );
     expect(autoSelectSources).toHaveBeenCalled();
     const { outputRequired } = vi.mocked(autoSelectSources).mock.calls[0][0];
-    expect(outputRequired.toFixed()).toBe('1025');
+    expect(outputRequired.toFixed()).toBe('1023');
   });
 
   it('EXACT_OUT Mayan: estimatedFees records the haircut (gross − Σ minReceived), not Nexus fees', async () => {


### PR DESCRIPTION
## Summary

Correct two EXACT_OUT routing and sizing issues for destination COT outputs (USDC by default).

Destination-chain holdings can now use the direct-destination path even when remote source assets also exist, and default routes no longer add a destination buffer when no destination token or gas swap runs.

## Changes

- Replace the destination-token-swap eligibility check with a direct-destination candidate check based on fast-path availability, a positive exact output, and destination-chain holdings.
- Resolve destination-holding prices for COT outputs so the existing USD capacity gate can evaluate local coverage accurately.
- Apply the destination buffer only when a destination token or gas swap runs; retain the source buffer for source-swap requote protection.
- Keep quote and coverage failures inside the existing fast-path fallback envelope.
- Add end-to-end characterization coverage for DAI on Base plus WETH on Arbitrum targeting exactly 500 USDC on Base.
- Assert that the local route delivers exactly 500 USDC, submits no bridge request, and leaves the remote source unused.
- Characterize a remote DAI source targeting 500 USDC and prove the no-destination-swap route selects 501 USDC instead of 503 USDC: the target plus only the $1 source buffer.
- Update Mayan fee-selection and source-drift expectations to use the corrected no-destination-buffer amount.
- Update the swap routing documentation to match the corrected Path A and buffer rules.

## Testing
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test

## Risk / Impact

Low and limited to internal EXACT_OUT route selection and buffer sizing. Positive COT-output requests with destination-chain holdings may now attempt the direct path before the default route. The USD price gate still rejects known insufficient local capacity, and quote or coverage failures still fall back.

Default COT-output routes without a destination swap now omit the destination buffer while retaining the source buffer when source swaps need requote protection. COT-plus-gas routes still apply the destination buffer because a destination gas swap runs.

`skipFastPaths`, zero or negative output sentinels, remote fallback holdings, and public SDK APIs are unchanged.