### PR TITLE
swap: handle native balance drift and low bridge amounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1932,6 +1932,7 @@ Codes follow `category/specific_noun_suffix`. Suffixes: `_failed`, `_timeout`, `
 | `user_action/ephemeral_key_denied` | User rejected the ephemeral-key derivation signature | None — user cancelled |
 | **validation/*** | | |
 | `validation/insufficient_balance` | Not enough tokens for operation | Show balance, suggest deposit |
+| `validation/amount_too_low` | Amount cannot cover bridge fees | Increase the source amount |
 | `validation/no_balance_for_address` | No balance found for address | Verify address |
 | `validation/invalid_input` | Invalid parameters provided | Check input values |
 | `validation/invalid_address_length` | Address has wrong length | Verify address format |

--- a/skills/nexus-core/SKILL.md
+++ b/skills/nexus-core/SKILL.md
@@ -648,6 +648,7 @@ Codes follow `category/specific_noun_suffix`. Suffixes: `_failed`, `_timeout`, `
 
 **Validation (`ValidationError`, no service):**
 - `validation/insufficient_balance`
+- `validation/amount_too_low` — source amount cannot cover bridge fees
 - `validation/no_balance_for_address`
 - `validation/invalid_input`, `validation/invalid_address_length`, `validation/invalid_allowance_hook`
 - `validation/token_not_supported`, `validation/chain_not_found`, `validation/chain_data_not_found`, `validation/asset_not_found`

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -131,6 +131,7 @@ export const ERROR_CODES = {
   ENVIRONMENT_NOT_KNOWN: 'validation/environment_not_known',
   INSUFFICIENT_BALANCE: 'validation/insufficient_balance',
   NO_BALANCE_FOR_ADDRESS: 'validation/no_balance_for_address',
+  AMOUNT_TOO_LOW: 'validation/amount_too_low',
   SDK_NOT_INITIALIZED: 'validation/sdk_not_initialized',
   SDK_INIT_STATE_NOT_EXPECTED: 'validation/sdk_init_state_unexpected',
   WALLET_NOT_CONNECTED: 'validation/wallet_not_connected',
@@ -460,6 +461,8 @@ export const Errors = {
       `Insufficient balance to proceed. ${msg ?? ''}`.trim(),
       { context: {} }
     ),
+  amountTooLow: (msg: string): ValidationError =>
+    new ValidationError(ERROR_CODES.AMOUNT_TOO_LOW, msg, { context: {} }),
 
   walletNotConnected: (walletType: string): ValidationError =>
     new ValidationError(

--- a/src/swap/routing/exact-in.ts
+++ b/src/swap/routing/exact-in.ts
@@ -1,6 +1,7 @@
 import Decimal from 'decimal.js';
 import { formatUnits, type Hex } from 'viem';
 import { Errors } from '../../domain/errors';
+import { formatTokenBalance } from '../../domain/utils/format';
 import { logger } from '../../domain/utils/logger';
 import { divDecimals, mulDecimals } from '../../services/math';
 import { MAYAN_MIN_USD_PER_LEG, selectMayanQuoteOutput } from '../../services/mayan';
@@ -221,7 +222,7 @@ const buildExactInBridge = async (input: {
       } = feeSummary;
       if (effectiveBridgedToDestination.lte(0)) {
         throw Errors.insufficientBalance(
-          `Bridge fees (${totalFeeAmount.toString()}) exceed bridged COT (${bridgedCOT.toString()})`
+          `Bridge fees (${formatTokenBalance(totalFeeAmount.toFixed())}) exceed bridged amount (${formatTokenBalance(bridgedCOT.toFixed())})`
         );
       }
 

--- a/src/swap/routing/exact-in.ts
+++ b/src/swap/routing/exact-in.ts
@@ -221,7 +221,7 @@ const buildExactInBridge = async (input: {
         nexusFeeModel,
       } = feeSummary;
       if (effectiveBridgedToDestination.lte(0)) {
-        throw Errors.insufficientBalance(
+        throw Errors.amountTooLow(
           `Bridge fees (${formatTokenBalance(totalFeeAmount.toFixed())}) exceed bridged amount (${formatTokenBalance(bridgedCOT.toFixed())})`
         );
       }

--- a/src/swap/routing/fast-paths.ts
+++ b/src/swap/routing/fast-paths.ts
@@ -3,6 +3,7 @@ import { formatUnits, type Hex } from 'viem';
 import type { ChainListType } from '../../domain';
 import { ZERO_ADDRESS } from '../../domain/constants/addresses';
 import { Errors } from '../../domain/errors';
+import { formatTokenBalance } from '../../domain/utils/format';
 import { logger } from '../../domain/utils/logger';
 import { isNativeAddress } from '../../services/addresses';
 import { divDecimals, mulDecimals } from '../../services/math';
@@ -612,7 +613,7 @@ export async function buildSameTokenBridgeRoute(
     deliveredFromBridge = deliveredAmount;
     if (deliveredFromBridge.lte(0)) {
       throw Errors.insufficientBalance(
-        `Bridge fees (${totalFee.toString()}) exceed bridged amount (${bridgedToken.toString()})`
+        `Bridge fees (${formatTokenBalance(totalFee.toFixed())}) exceed bridged amount (${formatTokenBalance(bridgedToken.toFixed())})`
       );
     }
     // The fast path participates in provider selection too, querying the server with the actual

--- a/src/swap/routing/fast-paths.ts
+++ b/src/swap/routing/fast-paths.ts
@@ -612,7 +612,7 @@ export async function buildSameTokenBridgeRoute(
     });
     deliveredFromBridge = deliveredAmount;
     if (deliveredFromBridge.lte(0)) {
-      throw Errors.insufficientBalance(
+      throw Errors.amountTooLow(
         `Bridge fees (${formatTokenBalance(totalFee.toFixed())}) exceed bridged amount (${formatTokenBalance(bridgedToken.toFixed())})`
       );
     }

--- a/src/swap/routing/holdings.ts
+++ b/src/swap/routing/holdings.ts
@@ -2,7 +2,9 @@ import Decimal from 'decimal.js';
 import { type Hex, parseUnits } from 'viem';
 import type { ChainListType } from '../../domain';
 import { Errors } from '../../domain/errors';
+import { formatTokenBalance } from '../../domain/utils/format';
 import { logger } from '../../domain/utils/logger';
+import { isNativeAddress } from '../../services/addresses';
 import { divDecimals } from '../../services/math';
 import { equalFold } from '../../services/strings';
 import { filterMayanSourcesByChain } from '../algorithms/mayan-floor';
@@ -269,14 +271,18 @@ export function resolveExactInHoldings(
         entry.chainID === source.chainId && equalFold(entry.tokenAddress, source.tokenAddress)
     );
     if (!balance || new Decimal(balance.amount).lte(0)) {
-      throw Errors.insufficientBalance('Requested source has no usable balance');
+      throw Errors.insufficientBalance(
+        `Requested source ${source.tokenAddress} on chain ${source.chainId} has no usable balance`
+      );
     }
 
     const availableRaw = parseUnits(balance.amount, balance.decimals);
     const amountRaw = source.amountRaw ?? availableRaw;
 
-    if (amountRaw > availableRaw) {
-      throw Errors.insufficientBalance('Requested source amount exceeds available balance');
+    if (!isNativeAddress(source.tokenAddress) && amountRaw > availableRaw) {
+      throw Errors.insufficientBalance(
+        `Requested source (${balance.symbol}) amount (${formatTokenBalance(divDecimals(amountRaw, balance.decimals).toFixed())}) exceeds available balance (${formatTokenBalance(divDecimals(availableRaw, balance.decimals).toFixed())})`
+      );
     }
 
     return amountRaw > 0n

--- a/src/swap/routing/holdings.ts
+++ b/src/swap/routing/holdings.ts
@@ -281,7 +281,7 @@ export function resolveExactInHoldings(
 
     if (!isNativeAddress(source.tokenAddress) && amountRaw > availableRaw) {
       throw Errors.insufficientBalance(
-        `Requested source (${balance.symbol}) amount (${formatTokenBalance(divDecimals(amountRaw, balance.decimals).toFixed())}) exceeds available balance (${formatTokenBalance(divDecimals(availableRaw, balance.decimals).toFixed())})`
+        `Requested source (${balance.symbol}, ${source.chainId}) amount (${formatTokenBalance(divDecimals(amountRaw, balance.decimals).toFixed())}) exceeds available balance (${formatTokenBalance(divDecimals(availableRaw, balance.decimals).toFixed())})`
       );
     }
 


### PR DESCRIPTION
## Summary

Prevents an Exact-In native source from failing route reconstruction when its amount was previously calculated from the wallet balance minus reserved gas and the live balance changes before holdings are resolved again.

Insufficient-balance and bridge-fee errors now include human-readable token amounts and more useful source context. Bridge fees consuming the bridged amount are exposed separately as `validation/amount_too_low` so consumers can distinguish an uneconomical amount from an insufficient wallet balance.

## Changes

- Skip the refreshed `amountRaw > availableRaw` validation for native source tokens while retaining it for ERC-20 sources.
- Include the token address and chain ID when a requested source has no usable balance.
- Include the token symbol and formatted requested and available amounts when an ERC-20 source exceeds its balance.
- Add `ERROR_CODES.AMOUNT_TOO_LOW` and `Errors.amountTooLow(...)` for routes whose bridge fees consume the bridged amount.
- Throw `validation/amount_too_low` with formatted bridge-fee and bridged-amount values from the standard Exact-In and fast-path routes.
- Import `formatTokenBalance` directly from its domain formatting module.
- Document the new public error code in the README and Nexus skill error catalog.

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

## Risk / Impact

- A genuinely excessive native source amount is no longer rejected by the refreshed holdings check and may fail later during transaction preparation or execution.
- ERC-20 source balance validation remains unchanged.
- Consumers that currently treat bridge fees exceeding the bridged amount as `validation/insufficient_balance` must handle the new `validation/amount_too_low` code instead.
- `ERROR_CODES.AMOUNT_TOO_LOW` additively extends the public `ERROR_CODES` object and `ErrorCode` union; existing codes and method signatures are unchanged.