### PR TITLE
swap: improve routing and execution efficiency

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,11 +160,16 @@ swap(params)
 `swapAndExecute` composes swap planning with an execution request on the destination chain.
 `calculateMaxForSwap` reuses swap preflight and route logic to estimate the maximum usable input.
 
-Swap preflight does not request bridge-fee quotes. Exact In requests one after its eligible remote
-holdings are finalized; Exact Out requests one from its rough eligible source prefix after resolving
-the destination requirement. Direct destination-only routes skip the request. Every bridge quote
-includes the destination fee calculation but lists only route-relevant source chains, isolating
-unrelated RPC failures.
+Swap preflight does not request bridge-fee quotes. After terminal direct/same-token paths, routing
+chooses between USDC and USDT by counting required source and destination swap legs; ties retain the
+current settlement family. Exact In scores selected holdings. Exact Out scores its priced
+rough source prefix while requiring the candidate on every usable source chain; unpriced requirements
+retain the current family. The selected family's bridge quote is fetched before its aggregator legs;
+if it is unavailable, routing fails. Direct destination-only routes skip the request.
+
+Exact In treats destination-chain holdings already equal to the requested output as terminal identity
+output. They remain in the EOA and in intent/max accounting, but never enter source swaps, bridge
+assets, destination swaps, or routing haircuts.
 
 Swap execution assumes the user's EOA wallet has one mutable active-chain context. Work that touches
 the EOA wallet must therefore be sequential across chains, including chain switching, wallet

--- a/package-lock.json
+++ b/package-lock.json
@@ -3976,9 +3976,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -5898,9 +5898,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/src/swap/constants.ts
+++ b/src/swap/constants.ts
@@ -22,8 +22,8 @@ export const DST_BUFFER_PCT = 0.05;
 export const DST_BUFFER_MAX_USD = 1;
 export const SRC_BUFFER_PCT = 0.02;
 export const SRC_BUFFER_MAX_USD = 1;
-export const MAX_SWAP_HAIRCUT_PCT = 0.03;
-export const MAX_SWAP_HAIRCUT_MIN_USDC = 3;
+export const MAX_SWAP_HAIRCUT_PCT = DST_BUFFER_PCT + SRC_BUFFER_PCT;
+export const MAX_SWAP_HAIRCUT_MIN_USDC = DST_BUFFER_MAX_USD + SRC_BUFFER_MAX_USD;
 
 // EXACT_OUT's start-of-route provider check surveys bridged source value with a rough
 // greedy walk over priority-ordered holdings; this overshoot fraction makes it count a

--- a/src/swap/constants.ts
+++ b/src/swap/constants.ts
@@ -18,8 +18,8 @@ export const DIRECT_DST_QUOTE_TTL_MS = 45_000;
 // Buffers
 // ---------------------------------------------------------------------------
 
-export const DST_BUFFER_PCT = 0.1;
-export const DST_BUFFER_MAX_USD = 2;
+export const DST_BUFFER_PCT = 0.05;
+export const DST_BUFFER_MAX_USD = 1;
 export const SRC_BUFFER_PCT = 0.02;
 export const SRC_BUFFER_MAX_USD = 1;
 export const MAX_SWAP_HAIRCUT_PCT = 0.03;

--- a/src/swap/constants.ts
+++ b/src/swap/constants.ts
@@ -32,14 +32,12 @@ export const MAX_SWAP_HAIRCUT_MIN_USDC = 3;
 export const EXACT_OUT_PROVIDER_BUFFER = 0.01;
 
 // ---------------------------------------------------------------------------
-// Fast-path settlement families
+// Stable settlement families
 // ---------------------------------------------------------------------------
 
-// B2 dynamic-COT selection re-settles a swap through whichever STABLE family ALL its sources already
-// hold (USDC or USDT), skipping the input↔USDC round-trip when the sources are USDT-everywhere, etc.
-// ETH is deliberately excluded: its volatility makes it a poor common settlement token for a route
-// that isn't already ETH-shaped (B1 same-token still bridges ETH↔ETH directly).
-export const B2_STABLE_CURRENCY_IDS: ReadonlySet<CurrencyID> = new Set([
+// General routing may settle through USDC or USDT, whichever requires fewer swap legs. ETH remains
+// eligible for same-token bridging but is deliberately excluded as a general settlement token.
+export const STABLE_SETTLEMENT_CURRENCY_IDS: ReadonlySet<CurrencyID> = new Set([
   CurrencyID.USDC,
   CurrencyID.USDT,
 ]);

--- a/src/swap/constants.ts
+++ b/src/swap/constants.ts
@@ -22,6 +22,8 @@ export const DST_BUFFER_PCT = 0.05;
 export const DST_BUFFER_MAX_USD = 1;
 export const SRC_BUFFER_PCT = 0.02;
 export const SRC_BUFFER_MAX_USD = 1;
+export const STABLE_SRC_BUFFER_PCT = 0.005;
+export const STABLE_SRC_BUFFER_MAX_USD = 0.25;
 export const MAX_SWAP_HAIRCUT_PCT = DST_BUFFER_PCT + SRC_BUFFER_PCT;
 export const MAX_SWAP_HAIRCUT_MIN_USDC = DST_BUFFER_MAX_USD + SRC_BUFFER_MAX_USD;
 

--- a/src/swap/execution/orchestrator.ts
+++ b/src/swap/execution/orchestrator.ts
@@ -86,7 +86,7 @@ export const executeSwapRoute = async (
           await executeDirectDestinationExactOut(route, context, metadata);
           return [];
         }
-        return executeSourceSwaps(route.source, context, metadata);
+        return executeSourceSwaps(route.source, context, metadata, route.extras.aggregators);
       }
     );
 

--- a/src/swap/execution/source-swaps.ts
+++ b/src/swap/execution/source-swaps.ts
@@ -19,8 +19,13 @@ import { requireSafeDeployment, type SafeCall } from '../../services/safe';
 import { createSourceSwapStepId } from '../../services/step-ids';
 import { equalFold } from '../../services/strings';
 import { withTimingSpan } from '../../services/timing';
-import { aggregatorService } from '../aggregators';
-import { type QuoteResponse, QuoteSeriousness, QuoteType } from '../aggregators/types';
+import { AggregateMode, aggregateAggregators, aggregatorService } from '../aggregators';
+import {
+  type Aggregator,
+  type QuoteResponse,
+  QuoteSeriousness,
+  QuoteType,
+} from '../aggregators/types';
 import type {
   BridgeAsset,
   ExecutionContext,
@@ -31,6 +36,7 @@ import type {
 } from '../types';
 import { resolvePreparedFundingTransferCalls } from './eoa-to-ephemeral';
 import { getParsedQuote } from './parsed-quote';
+import { addRouterExclusions } from './router-exclusions';
 import { dispatchSafeSource } from './safe-dispatch';
 import { readSettlementBalanceRaw } from './settlement-balance';
 
@@ -265,6 +271,7 @@ export const dispatchSourceChainBatch = async (input: {
 const requoteFailedChains = async (
   failedChains: Array<{ chainId: number; chainSwaps: QuoteResponse[] }>,
   srcBuffer: Decimal | null,
+  aggregators: Aggregator[],
   ctx: Pick<
     ExecutionContext,
     | 'cache'
@@ -289,45 +296,47 @@ const requoteFailedChains = async (
       const userAddress = ctx.safeAddress;
       const sourceRecipient = recipientForChain(chainId);
 
-      const requoted = await Promise.all(
-        chainSwaps.map(async (swap) => {
-          const requests = [
-            {
-              type: QuoteType.EXACT_IN as const,
-              seriousness: QuoteSeriousness.SERIOUS,
-              chainId: swap.chainID,
-              inputToken: swap.quote.input.contractAddress,
-              outputToken: swap.quote.output.contractAddress,
-              inputAmount: swap.holding.amountRaw,
-              userAddress,
-              recipientAddress: sourceRecipient,
-            },
-          ];
-          const [requote] = swap.quote.routerId
-            ? await swap.aggregator.getQuotes(requests, [swap.quote.routerId])
-            : await swap.aggregator.getQuotes(requests);
-
-          if (!requote) {
-            throw new ExternalServiceError(
-              ERROR_CODES.EXTERNAL_SOURCE_SWAP_QUOTE_FAILED,
-              `Source requote failed on chain ${swap.chainID}`,
-              {
-                context: {
-                  service: aggregatorService(swap.aggregator),
-                  stepId: createSourceSwapStepId(chainId),
-                  stepType: 'source_swap',
-                  chainId: swap.chainID,
-                },
-              }
-            );
-          }
-
-          return {
-            ...swap,
-            quote: requote,
-          };
-        })
+      const requests = chainSwaps.map((swap) => ({
+        type: QuoteType.EXACT_IN as const,
+        seriousness: QuoteSeriousness.SERIOUS,
+        chainId: swap.chainID,
+        inputToken: swap.quote.input.contractAddress,
+        outputToken: swap.quote.output.contractAddress,
+        inputAmount: swap.holding.amountRaw,
+        userAddress,
+        recipientAddress: sourceRecipient,
+      }));
+      const routerExclusions = new Map<Aggregator, string[]>();
+      addRouterExclusions(routerExclusions, chainSwaps);
+      const results = await aggregateAggregators(
+        requests,
+        aggregators,
+        AggregateMode.MaximizeOutput,
+        routerExclusions
       );
+      const requoted = results.map(({ quote, aggregator }, index) => {
+        const swap = chainSwaps[index];
+        if (!quote) {
+          throw new ExternalServiceError(
+            ERROR_CODES.EXTERNAL_SOURCE_SWAP_QUOTE_FAILED,
+            `Source requote failed on chain ${swap.chainID}`,
+            {
+              context: {
+                service: aggregatorService(swap.aggregator),
+                stepId: createSourceSwapStepId(chainId),
+                stepType: 'source_swap',
+                chainId: swap.chainID,
+              },
+            }
+          );
+        }
+
+        return {
+          ...swap,
+          quote,
+          aggregator,
+        };
+      });
 
       return [chainId, requoted] as const;
     })
@@ -425,7 +434,8 @@ export const executeSourceSwaps = async (
     | 'safeAddress'
     | 'safeDeploymentPromises'
   > & { destinationChainId: number },
-  metadata: SwapMetadata
+  metadata: SwapMetadata,
+  aggregators: Aggregator[]
 ): Promise<BridgeAsset[]> => {
   if (source.swaps.length === 0) return [];
 
@@ -592,6 +602,7 @@ export const executeSourceSwaps = async (
           requoteFailedChains(
             failedChains.map(({ chainId, chainSwaps }) => ({ chainId, chainSwaps })),
             source.srcBuffer,
+            aggregators,
             ctx
           ),
         { tags: { attempt, source_chain_count: failedChains.length } }

--- a/src/swap/execution/source-swaps.ts
+++ b/src/swap/execution/source-swaps.ts
@@ -264,10 +264,9 @@ export const dispatchSourceChainBatch = async (input: {
   };
 };
 
-// Re-quote source legs that reverted. For EXACT_OUT (`srcBuffer` non-null, COT units sizing
-// `min(SRC_BUFFER_PCT, SRC_BUFFER_MAX_USD)` of the destination-buffered input) the combined
-// output drop must fit inside that budget. EXACT_IN passes `null`: re-quote and proceed with
-// no drift guard — Seam 2 re-sizes the dst swap to whatever COT actually lands.
+// Re-quote source legs that reverted. For EXACT_OUT (`srcBuffer` non-null, in COT units) the
+// combined output drop must fit inside the route's source-risk budget. EXACT_IN passes `null`:
+// re-quote and proceed with no drift guard — Seam 2 re-sizes the dst swap to whatever COT lands.
 const requoteFailedChains = async (
   failedChains: Array<{ chainId: number; chainSwaps: QuoteResponse[] }>,
   srcBuffer: Decimal | null,

--- a/src/swap/intent.ts
+++ b/src/swap/intent.ts
@@ -2,8 +2,8 @@ import Decimal from 'decimal.js';
 import type { Hex } from 'viem';
 import type { ChainListType } from '../domain';
 import { equalFold } from '../services/strings';
-import { type SwapData, type SwapIntent, SwapMode, type SwapRoute } from './types';
 import { resolveExactInAmountBasis, selectExactInQuoteOutput } from './amount-basis';
+import { type SwapData, type SwapIntent, SwapMode, type SwapRoute } from './types';
 
 // ---------------------------------------------------------------------------
 // createSwapIntent
@@ -20,6 +20,14 @@ export const createSwapIntent = (
 ): SwapIntent => {
   const dstChainData = chainList.getChainByID(route.destination.chainId);
   const exactInAmountBasis = resolveExactInAmountBasis(route.exactInAmountBasis);
+  const identityAmount =
+    input.mode === SwapMode.EXACT_IN
+      ? (route.destination.identityOutput?.amount ?? new Decimal(0))
+      : new Decimal(0);
+  const identityValue =
+    input.mode === SwapMode.EXACT_IN
+      ? (route.destination.identityOutput?.value ?? new Decimal(0))
+      : new Decimal(0);
 
   // Destination amount. A non-positive `toAmountRaw` in EXACT_OUT is the reservation /
   // gas-only sentinel — no tokens are delivered to the user, so the amount is "0" rather
@@ -33,12 +41,13 @@ export const createSwapIntent = (
   } else {
     // EXACT_IN: use swap output if available, else inputAmount.min
     if (route.destination.swap.tokenSwap) {
-      destinationAmount = selectExactInQuoteOutput(
-        route.destination.swap.tokenSwap.quote,
-        exactInAmountBasis
-      ).amount;
+      destinationAmount = new Decimal(
+        selectExactInQuoteOutput(route.destination.swap.tokenSwap.quote, exactInAmountBasis).amount
+      )
+        .plus(identityAmount)
+        .toFixed();
     } else {
-      destinationAmount = route.destination.inputAmount.min.toString();
+      destinationAmount = route.destination.inputAmount.min.plus(identityAmount).toFixed();
     }
   }
 
@@ -51,10 +60,11 @@ export const createSwapIntent = (
   if (input.mode === SwapMode.EXACT_OUT && (input.data.toAmountRaw ?? 0n) <= 0n) {
     destinationValue = '0';
   } else if (route.destination.swap.tokenSwap) {
-    destinationValue = selectExactInQuoteOutput(
-      route.destination.swap.tokenSwap.quote,
-      exactInAmountBasis
-    ).value.toString();
+    destinationValue = new Decimal(
+      selectExactInQuoteOutput(route.destination.swap.tokenSwap.quote, exactInAmountBasis).value
+    )
+      .plus(identityValue)
+      .toString();
   } else {
     // No destination swap. Path A (directDestination) delivers the toToken via token-role SOURCE
     // swaps on the dst chain, so sum their aggregator-reported USD values — the direct analog of a
@@ -62,19 +72,16 @@ export const createSwapIntent = (
     // guarantees the toToken price is in `oraclePrices`). Falls through to the oracle/amount path
     // when that's unavailable: a non-Path-A route (toToken IS COT, ≈$1), an aggregator that reported
     // no price (value 0), or identity-only holdings with no swap leg.
-    // ponytail: EXACT_IN identity holdings (already-toToken, no quote) aren't priced into the sum —
-    // a display-only undercount; add their oracle-priced value if the intent USD must be exact there.
     const directSwapValue = route.directDestination
       ? route.source.swaps
           .filter((s) => s.chainID === route.destination.chainId && s.outputRole !== 'gas')
           .reduce(
-            (sum, s) =>
-              sum.plus(selectExactInQuoteOutput(s.quote, exactInAmountBasis).value),
+            (sum, s) => sum.plus(selectExactInQuoteOutput(s.quote, exactInAmountBasis).value),
             new Decimal(0)
           )
       : new Decimal(0);
     if (directSwapValue.gt(0)) {
-      destinationValue = directSwapValue.toString();
+      destinationValue = directSwapValue.plus(identityValue).toString();
     } else {
       const oraclePrice = route.extras.oraclePrices.find(
         (entry) =>

--- a/src/swap/max.ts
+++ b/src/swap/max.ts
@@ -83,6 +83,7 @@ export async function calculateMaxForSwap(
   });
   const resolvedTokenInfo = route.dstTokenInfo;
   const tokenSwap = route.destination.swap.tokenSwap;
+  const identityAmount = route.destination.identityOutput?.amount ?? new Decimal(0);
   const sources = route.extras.assetsUsed.map((a) => ({
     chainId: a.chainID,
     tokenAddress: a.tokenAddress,
@@ -100,10 +101,10 @@ export async function calculateMaxForSwap(
       cotAmount.mul(MAX_SWAP_HAIRCUT_PCT),
       new Decimal(MAX_SWAP_HAIRCUT_MIN_USDC)
     );
-    const adjusted = cotAmount.minus(haircut);
+    const adjusted = Decimal.max(cotAmount.minus(haircut), new Decimal(0));
     const quoteInput = new Decimal(tokenSwap.quote.input.amount);
     const quoteOutput = new Decimal(tokenSwap.quote.output.amount);
-    const adjustedOutput = quoteOutput.mul(adjusted.div(quoteInput));
+    const adjustedOutput = quoteOutput.mul(adjusted.div(quoteInput)).plus(identityAmount);
 
     return {
       toChainId: input.toChainId,
@@ -119,7 +120,7 @@ export async function calculateMaxForSwap(
   // No destination swap → `destination.inputAmount.max` is delivered in the DESTINATION token, which
   // is only USDC in the default COT-dst flow (Path A delivers toToken, a same-token bridge the family
   // token). Keep the haircut in USD space and convert the $3 floor into delivered-token units.
-  const adjustedDelivered = applyDeliveredTokenHaircut(route);
+  const adjustedDelivered = applyDeliveredTokenHaircut(route).plus(identityAmount);
   return {
     toChainId: input.toChainId,
     toTokenAddress: input.toTokenAddress,

--- a/src/swap/max.ts
+++ b/src/swap/max.ts
@@ -36,7 +36,7 @@ type SwapMaxExecutionParams = Pick<
  * Algorithm:
  * 1. Determine route using EXACT_IN mode with all available balances
  * 2. Extract total COT available (destination.inputAmount.max)
- * 3. Apply haircut: max(3% of cotAmount, 3 USDC)
+ * 3. Apply a haircut equal to the combined source and destination buffer budgets
  * 4. If destination has token swap: scale output proportionally
  * 5. If destination IS COT: use adjusted COT directly
  */
@@ -94,8 +94,8 @@ export async function calculateMaxForSwap(
 
   if (tokenSwap) {
     // A destination token swap exists → `destination.inputAmount.max` is COT (USDC). Take the
-    // max(3%, $3) haircut in COT space, then scale the adjusted COT to the output token via the
-    // dst swap's own input→output ratio.
+    // Combined source + destination buffer haircut in COT space, then scale the adjusted COT to the
+    // output token via the dst swap's own input→output ratio.
     const cotAmount = route.destination.inputAmount.max;
     const haircut = Decimal.max(
       cotAmount.mul(MAX_SWAP_HAIRCUT_PCT),
@@ -105,12 +105,15 @@ export async function calculateMaxForSwap(
     const quoteInput = new Decimal(tokenSwap.quote.input.amount);
     const quoteOutput = new Decimal(tokenSwap.quote.output.amount);
     const adjustedOutput = quoteOutput.mul(adjusted.div(quoteInput)).plus(identityAmount);
+    const maxAmountRaw = mulDecimals(adjustedOutput, resolvedTokenInfo.decimals);
 
     return {
       toChainId: input.toChainId,
       toTokenAddress: input.toTokenAddress,
-      maxAmount: adjustedOutput.toFixed(resolvedTokenInfo.decimals),
-      maxAmountRaw: mulDecimals(adjustedOutput, resolvedTokenInfo.decimals),
+      maxAmount: new Decimal(maxAmountRaw.toString())
+        .div(Decimal.pow(10, resolvedTokenInfo.decimals))
+        .toFixed(resolvedTokenInfo.decimals),
+      maxAmountRaw,
       symbol: resolvedTokenInfo.symbol,
       decimals: resolvedTokenInfo.decimals,
       sources,
@@ -119,7 +122,7 @@ export async function calculateMaxForSwap(
 
   // No destination swap → `destination.inputAmount.max` is delivered in the DESTINATION token, which
   // is only USDC in the default COT-dst flow (Path A delivers toToken, a same-token bridge the family
-  // token). Keep the haircut in USD space and convert the $3 floor into delivered-token units.
+  // token). Keep the haircut in USD space and convert the combined USD floor into token units.
   const adjustedDelivered = applyDeliveredTokenHaircut(route).plus(identityAmount);
   return {
     toChainId: input.toChainId,
@@ -132,14 +135,13 @@ export async function calculateMaxForSwap(
   };
 }
 
-// The max(3%, $3) safety haircut for a route with no destination swap, where
+// The combined source + destination buffer haircut for a route with no destination swap, where
 // `destination.inputAmount.max` is denominated in the destination token itself (USDC in the default
-// COT-dst flow, toToken for Path A, the family token for a same-token bridge). The 3% part is
-// unit-free; the $3 floor is converted to token units at the delivered token's price so a bare
-// subtraction can't mean "3 ETH" on an ETH route. Price source: quote-implied (Σ output.value over
-// the source swaps) when swaps exist, else the delivered token's oracle price; neither ⇒ pct-only.
-// Clamped at 0. For a USDC destination usdBasis ≈ delivered, so this stays byte-identical to the old
-// `delivered − max(3%, $3)`. See swap.md §5.
+// COT-dst flow, toToken for Path A, the family token for a same-token bridge). The percentage is
+// unit-free; the USD floor is converted to token units at the delivered token's price. Price source:
+// quote-implied (Σ output.value over the source swaps) when swaps exist, else the delivered token's
+// oracle price; neither ⇒ pct-only.
+// Clamped at 0. See swap.md §5.
 function applyDeliveredTokenHaircut(route: SwapRoute): Decimal {
   const delivered = route.destination.inputAmount.max;
   const clampToPositive = (value: Decimal): Decimal => Decimal.max(value, new Decimal(0));
@@ -148,7 +150,7 @@ function applyDeliveredTokenHaircut(route: SwapRoute): Decimal {
   const sourceSwaps = route.source.swaps;
   if (sourceSwaps.length > 0) {
     // Quote-implied price. Scaling `delivered` by (usdBasis − haircutUsd)/usdBasis subtracts the
-    // haircut converted at that price (algebraically `delivered − max(delivered×3%, $3/price)`).
+    // haircut converted at that price.
     const usdBasis = sourceSwaps.reduce(
       (sum, quote) => sum.plus(quote.quote.output.value),
       new Decimal(0)
@@ -163,7 +165,7 @@ function applyDeliveredTokenHaircut(route: SwapRoute): Decimal {
 
   // Same-token pure bridge: no quotes to imply a price → oracle price of the delivered token. Oracle
   // entries key native as ZERO_ADDRESS, but a native dst token carries EADDRESS — normalize so ETH↔ETH
-  // bridges hit the oracle floor (max(3%, $3/price)) instead of falling through to pct-only.
+  // bridges apply the USD-denominated floor instead of falling through to percentage-only.
   const priceUsd = findOraclePriceUsd(
     route.extras.oraclePrices,
     route.destination.chainId,

--- a/src/swap/route.ts
+++ b/src/swap/route.ts
@@ -1,6 +1,5 @@
 import type Decimal from 'decimal.js';
 import type { Hex } from 'viem';
-import { assertMayanSupportedDestination } from '../bridge/intent/quote-request';
 import type { ChainListType, TimingSpanHooks, TokenInfo } from '../domain';
 import { Errors } from '../domain/errors';
 import { logger } from '../domain/utils/logger';
@@ -11,7 +10,7 @@ import {
   resolveExactInAmountBasis,
   selectExactInQuoteOutput,
 } from './amount-basis';
-import { type CurrencyID, resolveCOT } from './cot';
+import type { CurrencyID } from './cot';
 import { _exactInRoute } from './routing/exact-in';
 import { _exactOutRoute } from './routing/exact-out';
 import type {
@@ -44,9 +43,7 @@ export type RouteOptions = {
   timing?: TimingSpanHooks;
   // Exact In only. Direct internal route callers default conservatively to protected minimums.
   exactInAmountBasis?: ExactInAmountBasis;
-  // Recursion stop for the B2 dynamic-COT re-entry: when a fast path re-enters `_exactInRoute` /
-  // `_exactOutRoute` with an overridden `cotCurrencyId`, it sets this so the re-entered call runs
-  // the default COT flow instead of re-classifying and looping. Never set by public callers.
+  // Internal test/diagnostic switch for bypassing terminal fast paths.
   skipFastPaths?: boolean;
 };
 
@@ -128,13 +125,6 @@ export const determineSwapRoute = async (
   }
   if (destinationChain.swapSupported === false) {
     throw Errors.invalidInput(`Destination chain ${input.data.toChainId} does not support swaps`);
-  }
-
-  // forceMayan: fail fast before any planning work if destination doesn't support Mayan.
-  // Bridge happens through USDC (the COT), so check the USDC token on the destination.
-  if (options.forceMayan) {
-    const dstCOT = resolveCOT(input.data.toChainId, options.chainList, options.cotCurrencyId);
-    assertMayanSupportedDestination(options.chainList, input.data.toChainId, dstCOT.address as Hex);
   }
 
   const route =

--- a/src/swap/routing/bridge.ts
+++ b/src/swap/routing/bridge.ts
@@ -46,6 +46,9 @@ export const resolveBridgeProviderDecision = async (
   },
   options: Pick<RouteOptions, 'middlewareClient' | 'chainList' | 'forceMayan'>
 ): Promise<{ provider: BridgeProvider; minOutputUsdPerSource?: Decimal }> => {
+  if (options.forceMayan) {
+    assertMayanSupportedDestination(options.chainList, params.dstChainId, params.dstTokenToCheck);
+  }
   const request = {
     destination: {
       chain_id: toHex(params.dstChainId),

--- a/src/swap/routing/exact-in.ts
+++ b/src/swap/routing/exact-in.ts
@@ -40,8 +40,10 @@ import {
   dropSubFloorMayanChains,
   resolveExactInHoldings,
   sumHoldingsUsd,
+  summarizeIdentityHoldings,
   throwMayanRouteShortfall,
 } from './holdings';
+import { selectStableSettlement } from './settlement';
 
 type ExactInData = {
   sources?: { chainId: number; amountRaw?: bigint; tokenAddress: Hex }[];
@@ -52,43 +54,6 @@ type ExactInData = {
 type ExactInHolding = Awaited<ReturnType<typeof resolveExactInHoldings>>[number];
 type ExactInSourceSwaps = Awaited<ReturnType<typeof liquidateInputHoldings>>;
 type ResolvedCot = ReturnType<typeof resolveCOT>;
-
-/**
- * B2 — dynamic COT (both modes). Every source shares one STABLE family F ≠ the destination family and
- * ≠ the current COT, and F resolves as a COT on the destination chain. Rather than settle through USDC
- * (source→USDC→bridge→USDC→output — two swap hops), re-enter the same route flow with `cotCurrencyId = F`
- * so the sources ARE the COT: zero source swaps, bridge F, one F→output destination swap. The re-entry
- * threads an F-denominated bridge-fee quote and sets `skipFastPaths` to stop the recursion. A null
- * F-quote or a re-entry throw (e.g. insufficient F) ⇒ the fast-path envelope falls back to the COT flow.
- */
-async function buildDynamicCotExactInRoute(
-  data: ExactInData,
-  holdings: ExactInHolding[],
-  options: RouteOptions,
-  familyId: number
-): Promise<SwapRoute | null> {
-  const sourceChainIds = [
-    ...new Set(
-      holdings
-        .filter((holding) => holding.chainID !== data.toChainId)
-        .map((holding) => holding.chainID)
-    ),
-  ];
-  const fQuote = await fetchBridgeQuoteForCurrency(
-    data.toChainId,
-    familyId,
-    sourceChainIds,
-    options
-  );
-  if (!fQuote) return null;
-  // EXACT_IN needs no source allowlist — the classifier already proved every holding is family F.
-  return _exactInRoute(data, {
-    ...options,
-    cotCurrencyId: familyId,
-    bridgeQuoteResponse: fQuote,
-    skipFastPaths: true,
-  });
-}
 
 const resolveExactInProviderAndHoldings = async (
   data: ExactInData,
@@ -296,9 +261,18 @@ export async function _exactInRoute(data: ExactInData, options: RouteOptions): P
   if (rawHoldings.length === 0) {
     throw Errors.insufficientBalance('No usable balances for swap route');
   }
+  const identityHoldings = rawHoldings.filter(
+    (holding) =>
+      holding.chainID === data.toChainId && equalFold(holding.tokenAddress, data.toTokenAddress)
+  );
+  const routedHoldings = rawHoldings.filter((holding) => !identityHoldings.includes(holding));
+  const identityOutput = summarizeIdentityHoldings(
+    identityHoldings,
+    options.balances,
+    oraclePrices
+  );
 
-  // ── Fast paths (skipped on the B2 re-entry, which sets skipFastPaths). Classified once; Path A
-  // gates before the same-token dispatch, B2 after it (see the ladder). ──
+  // Terminal fast paths run before general stable-settlement routing.
   const fastPathClass = options.skipFastPaths
     ? null
     : await withTimingSpan(
@@ -368,45 +342,51 @@ export async function _exactInRoute(data: ExactInData, options: RouteOptions): P
     return buildSameTokenBridgeRoute(data, rawHoldings, options, settlement.currencyId);
   }
 
-  // B2 — dynamic COT: gated AFTER the same-token dispatch (a same-family-as-dst set already returned
-  // above). Re-enters this flow with cotCurrencyId = F so the sources ARE the COT (zero source swaps).
-  if (fastPathClass?.kind === 'dynamic-cot') {
-    const b2 = await tryFastPath('dynamic-cot', () =>
-      buildDynamicCotExactInRoute(data, rawHoldings, options, fastPathClass.familyId)
+  const bridgeQuoteSourceChainIds = [
+    ...new Set(
+      routedHoldings
+        .filter((holding) => holding.chainID !== data.toChainId)
+        .map((holding) => holding.chainID)
+    ),
+  ];
+  const currencyId = selectStableSettlement({
+    chainList,
+    currentCurrencyId: settlement.currencyId,
+    destinationChainId: data.toChainId,
+    destinationTokenAddress: data.toTokenAddress,
+    scoreHoldings: rawHoldings,
+  });
+  let bridgeQuoteResponse = options.bridgeQuoteResponse;
+  if (bridgeQuoteSourceChainIds.length > 0 && currencyId !== options.cotCurrencyId) {
+    bridgeQuoteResponse = await fetchBridgeQuoteForCurrency(
+      data.toChainId,
+      currencyId,
+      bridgeQuoteSourceChainIds,
+      options
     );
-    if (b2) return b2;
+  } else if (bridgeQuoteSourceChainIds.length > 0 && !bridgeQuoteResponse) {
+    bridgeQuoteResponse = await fetchBridgeQuoteForCurrency(
+      data.toChainId,
+      currencyId,
+      bridgeQuoteSourceChainIds,
+      options
+    );
   }
-
-  // COT round-trip: settle in the COT. `settlement.currencyId === options.cotCurrencyId` here (any
-  // same-token case returned above); thread it so every resolveCOT in this flow uses one source.
-  const currencyId = settlement.currencyId;
+  const routeOptions = { ...options, cotCurrencyId: currencyId, bridgeQuoteResponse };
   const dstCOT = resolveCOT(data.toChainId, chainList, currencyId);
 
   const { bridgeProvider, holdings } = await resolveExactInProviderAndHoldings(
     data,
-    rawHoldings,
+    routedHoldings,
     dstCOT,
     currencyId,
-    options
+    routeOptions
   );
   const { cotHoldings, nonCotHoldings } = partitionExactInHoldings(holdings, options, currencyId);
 
   // Bridge check: any source not on destination chain?
   const allOnDstChain = holdings.every((h) => h.chainID === data.toChainId);
   const allChainIds = new Set(holdings.map((h) => h.chainID));
-  const bridgeQuoteSourceChainIds = [...allChainIds].filter(
-    (chainId) => chainId !== data.toChainId
-  );
-  const bridgeQuoteResponse =
-    options.bridgeQuoteResponse ??
-    (bridgeQuoteSourceChainIds.length > 0
-      ? await fetchBridgeQuoteForCurrency(
-          data.toChainId,
-          currencyId,
-          bridgeQuoteSourceChainIds,
-          options
-        )
-      : null);
   if (!allOnDstChain && !bridgeQuoteResponse) {
     throw Errors.internal('Bridge fee quote unavailable -- cannot route cross-chain swap');
   }
@@ -443,9 +423,7 @@ export async function _exactInRoute(data: ExactInData, options: RouteOptions): P
               holdings: nonCotHoldings,
               aggregators,
               chainList: options.chainList,
-              // Settlement currency (= options.cotCurrencyId in the default flow, = F on the B2 re-entry),
-              // NOT options.cotCurrencyId — matches the tryResolveCOT split above and keeps every COT read
-              // in this flow on one source.
+              // Every source and destination quote uses the selected stable settlement family.
               cotCurrencyId: currencyId,
               userAddressByChain,
               recipientAddressByChain,
@@ -493,7 +471,7 @@ export async function _exactInRoute(data: ExactInData, options: RouteOptions): P
     ? { bridge: null, cotAvailableForDestination: totalCOT }
     : await buildExactInBridge({
         data,
-        options: { ...options, bridgeQuoteResponse },
+        options: routeOptions,
         dstCOT,
         currencyId,
         sourceSwaps,
@@ -550,7 +528,7 @@ export async function _exactInRoute(data: ExactInData, options: RouteOptions): P
     dstSwap = quotedSwap;
   }
 
-  const assetsUsed: AssetsUsedEntry[] = holdings.map((h) => ({
+  const assetsUsed: AssetsUsedEntry[] = [...holdings, ...identityHoldings].map((h) => ({
     chainID: h.chainID,
     tokenAddress: h.tokenAddress,
     symbol: h.symbol,
@@ -581,6 +559,7 @@ export async function _exactInRoute(data: ExactInData, options: RouteOptions): P
       bridge,
       destination: {
         chainId: data.toChainId,
+        identityOutput,
         // Direct COT held at the EOA on the destination chain needs to land at the wrapper before
         // the dst swap can pull it. The wrapper is the predicted Safe; prepare/execution move the
         // COT EOA→Safe. Same-chain COT-input swaps rely on this too —

--- a/src/swap/routing/exact-out.ts
+++ b/src/swap/routing/exact-out.ts
@@ -620,7 +620,7 @@ export async function _exactOutRoute(
   const destinationBuffer =
     needsTokenSwap || needsGasSwap
       ? applyBuffer(
-          inputAmount,
+          needsTokenSwap ? inputAmount : gasInputAmount,
           DST_BUFFER_PCT,
           DST_BUFFER_MAX_USD,
           oraclePrices,

--- a/src/swap/routing/exact-out.ts
+++ b/src/swap/routing/exact-out.ts
@@ -16,8 +16,11 @@ import {
   EADDRESS,
   SRC_BUFFER_MAX_USD,
   SRC_BUFFER_PCT,
+  STABLE_SETTLEMENT_CURRENCY_IDS,
+  STABLE_SRC_BUFFER_MAX_USD,
+  STABLE_SRC_BUFFER_PCT,
 } from '../constants';
-import { resolveCOT } from '../cot';
+import { type CurrencyID, resolveCOT, resolveCurrencyId } from '../cot';
 import type { RouteOptions } from '../route';
 import type {
   AssetsUsedEntry,
@@ -670,14 +673,21 @@ export async function _exactOutRoute(
       : new Decimal(0);
   const destinationBufferedInput = inputAmount.plus(destinationBuffer);
   const originalDestinationMaxInput = new Decimal(destinationBufferedInput);
-  const sourceBuffer = applyBuffer(
-    destinationBufferedInput,
-    SRC_BUFFER_PCT,
-    SRC_BUFFER_MAX_USD,
-    oraclePrices,
-    data.toChainId,
-    dstCOT.address
+  const sourceBufferConfig = resolveSourceBufferConfig(
+    roughlyEstimatedSources,
+    selectedCurrencyId,
+    chainList
   );
+  const sourceBuffer = sourceBufferConfig
+    ? applyBuffer(
+        destinationBufferedInput,
+        sourceBufferConfig.pct,
+        sourceBufferConfig.maxUsd,
+        oraclePrices,
+        data.toChainId,
+        dstCOT.address
+      )
+    : new Decimal(0);
   const sourceBufferedRequired = destinationBufferedInput.plus(sourceBuffer);
   // Estimate the bridge fee up front and add it to the *selection* target (not the net delivery
   // target `sourceBufferedRequired`) so a single `autoSelectSources` pass produces enough COT to
@@ -953,6 +963,27 @@ function applyBuffer(
   const tokenPrice = entry ? entry.priceUsd.toNumber() : 1;
   const maxBufferInToken = new Decimal(maxUsd).div(tokenPrice);
   return Decimal.min(pctBuffer, maxBufferInToken);
+}
+
+function resolveSourceBufferConfig(
+  sources: SourceHolding[],
+  settlementCurrencyId: number,
+  chainList: ChainListType
+): { pct: number; maxUsd: number } | null {
+  let needsSourceSwap = false;
+  for (const source of sources) {
+    const settlementToken = resolveCOT(source.chainID, chainList, settlementCurrencyId);
+    if (equalFold(source.tokenAddress, settlementToken.address)) continue;
+    needsSourceSwap = true;
+    if (
+      !STABLE_SETTLEMENT_CURRENCY_IDS.has(
+        resolveCurrencyId(chainList, source.chainID, source.tokenAddress) as CurrencyID
+      )
+    ) {
+      return { pct: SRC_BUFFER_PCT, maxUsd: SRC_BUFFER_MAX_USD };
+    }
+  }
+  return needsSourceSwap ? { pct: STABLE_SRC_BUFFER_PCT, maxUsd: STABLE_SRC_BUFFER_MAX_USD } : null;
 }
 
 function computeGasInCotBudgetRaw(input: {

--- a/src/swap/routing/exact-out.ts
+++ b/src/swap/routing/exact-out.ts
@@ -17,7 +17,7 @@ import {
   SRC_BUFFER_MAX_USD,
   SRC_BUFFER_PCT,
 } from '../constants';
-import { resolveCOT, resolveCurrencyId } from '../cot';
+import { resolveCOT } from '../cot';
 import type { RouteOptions } from '../route';
 import type {
   AssetsUsedEntry,
@@ -50,6 +50,7 @@ import {
 } from './fast-paths';
 import { filterExactOutBalances, selectRoughEligibleSources } from './holdings';
 import { createTokenPriceResolver, type ResolvedTokenPrice } from './prices';
+import { selectStableSettlement } from './settlement';
 
 type ExactOutData = {
   toChainId: number;
@@ -292,18 +293,6 @@ const tryExactOutFastPaths = async (
     );
     if (sameToken) return sameToken;
   }
-  if (fastPathClass?.kind === 'dynamic-cot') {
-    const dynamicCot = await tryFastPath('dynamic-cot', () =>
-      buildDynamicCotExactOutRoute(
-        data,
-        holdings,
-        roughlyEstimatedSources,
-        options,
-        fastPathClass.familyId
-      )
-    );
-    if (dynamicCot) return dynamicCot;
-  }
   return null;
 };
 
@@ -475,27 +464,23 @@ export async function _exactOutRoute(
     ]);
   }
 
-  const dstCOT = await withTimingSpan(
-    options.timing,
-    'flow.swap.route.resolve_settlement',
-    async () => resolveCOT(data.toChainId, chainList, cotCurrencyId),
-    { tags: { mode: SwapMode.EXACT_OUT } }
-  );
   const priceResolver = createTokenPriceResolver(options);
-  const destinationPricePromise = priceResolver.resolve(data.toChainId, data.toTokenAddress);
-  const cotPricePromise = priceResolver.resolve(data.toChainId, dstCOT.address as Hex);
   const requestedNativeAmountRaw =
     data.toNativeAmountRaw != null && data.toNativeAmountRaw > 0n ? data.toNativeAmountRaw : 0n;
+  const destinationPricePromise =
+    data.toAmountRaw > 0n
+      ? priceResolver.resolve(data.toChainId, data.toTokenAddress)
+      : Promise.resolve<ResolvedTokenPrice | null>(null);
+  const nativePricePromise =
+    requestedNativeAmountRaw > 0n
+      ? priceResolver.resolve(data.toChainId, EADDRESS)
+      : Promise.resolve<ResolvedTokenPrice | null>(null);
   const dstHoldings = holdings.filter((holding) => holding.chainID === data.toChainId);
   const canTryDirectDestination =
     !options.skipFastPaths &&
     data.toAmountRaw > 0n &&
     (data.toNativeAmountRaw ?? 0n) >= 0n &&
     dstHoldings.length > 0;
-  const nativePricePromise =
-    canTryDirectDestination && requestedNativeAmountRaw > 0n
-      ? priceResolver.resolve(data.toChainId, EADDRESS)
-      : Promise.resolve<ResolvedTokenPrice | null>(null);
   const dstHoldingPricePromises = canTryDirectDestination
     ? dstHoldings.map((holding) => priceResolver.resolve(holding.chainID, holding.tokenAddress))
     : [];
@@ -504,8 +489,12 @@ export async function _exactOutRoute(
     destinationPricePromise,
     nativePricePromise,
   ]);
-  const tokenAmount = divDecimals(data.toAmountRaw, dstTokenInfo.decimals);
-  const tokenRequiredUsd = destinationPrice ? tokenAmount.mul(destinationPrice.priceUsd) : null;
+  const tokenRequiredUsd =
+    data.toAmountRaw <= 0n
+      ? new Decimal(0)
+      : destinationPrice
+        ? divDecimals(data.toAmountRaw, dstTokenInfo.decimals).mul(destinationPrice.priceUsd)
+        : null;
   const gasRequiredUsd =
     requestedNativeAmountRaw === 0n
       ? new Decimal(0)
@@ -547,7 +536,57 @@ export async function _exactOutRoute(
     if (direct) return direct;
   }
 
-  const cotPrice = await cotPricePromise;
+  let roughlyEstimatedSources =
+    requiredUsd == null ? null : selectRoughEligibleSources(holdings, requiredUsd);
+  const selectedCurrencyId =
+    roughlyEstimatedSources == null
+      ? cotCurrencyId
+      : selectStableSettlement({
+          chainList,
+          currentCurrencyId: cotCurrencyId,
+          destinationChainId: data.toChainId,
+          destinationTokenAddress: data.toTokenAddress,
+          scoreHoldings: roughlyEstimatedSources,
+          eligibilityHoldings: holdings,
+        });
+  let bridgeQuoteSourceChainIds = [
+    ...new Set(
+      (roughlyEstimatedSources ?? [])
+        .filter((holding) => holding.chainID !== data.toChainId)
+        .map((holding) => holding.chainID)
+    ),
+  ];
+  let bridgeQuoteResponse = options.bridgeQuoteResponse;
+  if (bridgeQuoteSourceChainIds.length > 0 && selectedCurrencyId !== cotCurrencyId) {
+    bridgeQuoteResponse = await fetchBridgeQuoteForCurrency(
+      data.toChainId,
+      selectedCurrencyId,
+      bridgeQuoteSourceChainIds,
+      options
+    );
+  } else if (bridgeQuoteSourceChainIds.length > 0 && !bridgeQuoteResponse) {
+    bridgeQuoteResponse = await fetchBridgeQuoteForCurrency(
+      data.toChainId,
+      selectedCurrencyId,
+      bridgeQuoteSourceChainIds,
+      options
+    );
+  }
+  if (bridgeQuoteSourceChainIds.length > 0 && !bridgeQuoteResponse) {
+    throw Errors.internal('Bridge fee quote unavailable -- cannot route cross-chain swap');
+  }
+  const routeOptions = {
+    ...options,
+    cotCurrencyId: selectedCurrencyId,
+    bridgeQuoteResponse,
+  };
+  const dstCOT = await withTimingSpan(
+    options.timing,
+    'flow.swap.route.resolve_settlement',
+    async () => resolveCOT(data.toChainId, chainList, selectedCurrencyId),
+    { tags: { mode: SwapMode.EXACT_OUT } }
+  );
+  const cotPrice = await priceResolver.resolve(data.toChainId, dstCOT.address as Hex);
   const estimatedInputAmountRaw =
     tokenRequiredUsd && cotPrice
       ? tokenRequiredUsd
@@ -571,13 +610,13 @@ export async function _exactOutRoute(
     tokenSwapQuote,
   } = await resolveExactOutDestinationRequirement(
     data,
-    options,
+    routeOptions,
     destinationChain,
     dstCOT,
     estimatedInputAmountRaw
   );
 
-  const roughlyEstimatedSources = selectRoughEligibleSources(holdings, inputAmount);
+  roughlyEstimatedSources ??= selectRoughEligibleSources(holdings, inputAmount);
   logger.debug('swap.route.exact_out.rough_sources.resolved', {
     sourceChainIds: [...new Set(roughlyEstimatedSources.map((holding) => holding.chainID))],
     sourceCount: roughlyEstimatedSources.length,
@@ -586,33 +625,34 @@ export async function _exactOutRoute(
 
   const fastPathRoute = await tryExactOutFastPaths(
     data,
-    options,
+    routeOptions,
     holdings,
     roughlyEstimatedSources
   );
   if (fastPathRoute) return fastPathRoute;
 
-  const bridgeQuoteSourceChainIds = [
-    ...new Set(
-      roughlyEstimatedSources
-        .filter((holding) => holding.chainID !== data.toChainId)
-        .map((holding) => holding.chainID)
-    ),
-  ];
-  const bridgeQuoteResponse =
-    options.bridgeQuoteResponse ??
-    (bridgeQuoteSourceChainIds.length > 0
-      ? await fetchBridgeQuoteForCurrency(
-          data.toChainId,
-          options.cotCurrencyId,
-          bridgeQuoteSourceChainIds,
-          options
-        )
-      : null);
+  if (requiredUsd == null) {
+    bridgeQuoteSourceChainIds = [
+      ...new Set(
+        roughlyEstimatedSources
+          .filter((holding) => holding.chainID !== data.toChainId)
+          .map((holding) => holding.chainID)
+      ),
+    ];
+    if (bridgeQuoteSourceChainIds.length > 0 && !bridgeQuoteResponse) {
+      bridgeQuoteResponse = await fetchBridgeQuoteForCurrency(
+        data.toChainId,
+        selectedCurrencyId,
+        bridgeQuoteSourceChainIds,
+        routeOptions
+      );
+      routeOptions.bridgeQuoteResponse = bridgeQuoteResponse;
+    }
+  }
 
   const { bridgeProvider, minOutputUsdPerSource } = await resolveExactOutProvider(
     data,
-    options,
+    routeOptions,
     dstCOT,
     roughlyEstimatedSources
   );
@@ -649,10 +689,10 @@ export async function _exactOutRoute(
       dstUsd: inputAmount,
       dstChainId: data.toChainId,
       dstCOT,
-      cotCurrencyId,
+      cotCurrencyId: selectedCurrencyId,
       bridgeQuoteResponse,
     },
-    options
+    routeOptions
   );
   const selectionTarget = sourceBufferedRequired.plus(bridgeFeeEstimate);
 
@@ -671,17 +711,17 @@ export async function _exactOutRoute(
       outputRequired,
       aggregators,
       chainList,
-      cotCurrencyId,
+      cotCurrencyId: selectedCurrencyId,
       userAddressByChain: buildExecutorAddressByChain(
         initialWalletDecision.sourceExecutionPaths,
-        options
+        routeOptions
       ),
       recipientAddressByChain: buildSourceRecipientAddressByChain({
         chainIds: availableSourceChainIds,
         sourceExecutionPaths: initialWalletDecision.sourceExecutionPaths,
         destinationChainId: data.toChainId,
         destinationHasSwap: needsTokenSwap || needsGasSwap,
-        options,
+        options: routeOptions,
       }),
       minOutputUsdPerSource,
     });
@@ -767,7 +807,7 @@ export async function _exactOutRoute(
     }
     bridge = await buildExactOutBridge({
       data,
-      options,
+      options: routeOptions,
       dstCOT,
       quoteResponses,
       usedCOTs,
@@ -793,7 +833,7 @@ export async function _exactOutRoute(
     });
   }
   for (const c of usedCOTs) {
-    const cot = resolveCOT(c.holding.chainID, chainList, cotCurrencyId);
+    const cot = resolveCOT(c.holding.chainID, chainList, selectedCurrencyId);
     const cotToken = chainList.getTokenByAddress(c.holding.chainID, cot.address as Hex);
     assetsUsed.push({
       chainID: c.holding.chainID,
@@ -809,12 +849,12 @@ export async function _exactOutRoute(
     'flow.swap.route.assemble',
     async (): Promise<SwapRoute> => ({
       type: SwapMode.EXACT_OUT,
-      settlementCurrencyId: cotCurrencyId,
+      settlementCurrencyId: selectedCurrencyId,
       sameTokenBridge: false,
       source: {
         swaps: quoteResponses,
         creationTime: Date.now(),
-        cotByChain: buildSourceCotByChain(quoteResponses, chainList, cotCurrencyId),
+        cotByChain: buildSourceCotByChain(quoteResponses, chainList, selectedCurrencyId),
         srcBuffer: sourceBuffer,
         // Bridge the actual source balance so each chain's extra (buffer + realized slippage)
         // consolidates at the destination, returned there in a single transfer.
@@ -841,7 +881,7 @@ export async function _exactOutRoute(
             inputAmount: nextInputAmount,
           } = await quoteExactOutDestination({
             data,
-            options,
+            options: routeOptions,
             dstCOT,
             destinationQuoteAddress,
             gasInCotBudgetRaw,
@@ -892,39 +932,6 @@ export async function _exactOutRoute(
         has_gas_swap: needsGasSwap,
       },
     }
-  );
-}
-
-async function buildDynamicCotExactOutRoute(
-  data: ExactOutData,
-  holdings: SourceHolding[],
-  roughlyEstimatedSources: SourceHolding[],
-  options: RouteOptions,
-  familyId: number
-): Promise<SwapRoute | null> {
-  const sourceChainIds = [
-    ...new Set(
-      roughlyEstimatedSources
-        .filter((holding) => holding.chainID !== data.toChainId)
-        .map((holding) => holding.chainID)
-    ),
-  ];
-  const fQuote = await fetchBridgeQuoteForCurrency(
-    data.toChainId,
-    familyId,
-    sourceChainIds,
-    options
-  );
-  if (!fQuote) return null;
-  // Restrict the re-entry to the family-F holdings (the allowlist `filterExactOutBalances` honors) →
-  // every source is a COT ⇒ zero source swaps. Insufficient F inside throws `insufficientBalance` ⇒
-  // tryFastPath falls back.
-  const sources: Source[] = holdings
-    .filter((h) => resolveCurrencyId(options.chainList, h.chainID, h.tokenAddress) === familyId)
-    .map((h) => ({ chainId: h.chainID, tokenAddress: h.tokenAddress }));
-  return _exactOutRoute(
-    { ...data, sources },
-    { ...options, cotCurrencyId: familyId, bridgeQuoteResponse: fQuote, skipFastPaths: true }
   );
 }
 

--- a/src/swap/routing/fast-paths.ts
+++ b/src/swap/routing/fast-paths.ts
@@ -19,8 +19,7 @@ import {
 } from '../algorithms/direct-destination-size';
 import { liquidateInputHoldings } from '../algorithms/liquidate';
 import { resolveExactInAmountBasis, selectExactInQuoteOutput } from '../amount-basis';
-import { B2_STABLE_CURRENCY_IDS } from '../constants';
-import { type CurrencyID, resolveCOT, resolveCurrencyId } from '../cot';
+import { resolveCOT, resolveCurrencyId } from '../cot';
 import type { RouteOptions } from '../route';
 import type {
   AssetsUsedEntry,
@@ -41,6 +40,7 @@ import {
   fetchBridgeQuoteForCurrency,
   resolveBridgeProviderDecision,
 } from './bridge';
+import { summarizeIdentityHoldings } from './holdings';
 
 // ---------------------------------------------------------------------------
 // Fast-path classification & fallback envelope
@@ -49,7 +49,6 @@ import {
 export type FastPathClass =
   | { kind: 'direct' } // A — direct destination-chain swap (both modes)
   | { kind: 'same-token-out'; familyId: number } // B1 — same-family direct bridge, EXACT_OUT mirror
-  | { kind: 'dynamic-cot'; familyId: number } // B2 — dynamic COT selection (both modes)
   | null;
 
 // The single bridgeable mesh family shared by ALL members, or undefined when any member is non-mesh
@@ -68,19 +67,6 @@ const uniformMemberFamily = (
     : undefined;
 };
 
-const cotResolvesOnChain = (
-  chainList: ChainListType,
-  chainId: number,
-  currencyId: number
-): boolean => {
-  try {
-    resolveCOT(chainId, chainList, currencyId);
-    return true;
-  } catch {
-    return false;
-  }
-};
-
 // Whether the destination token IS the COT (⇒ no destination token swap). Defensive: a chain with no
 // COT can't have toToken == COT, so treat it as needing a swap.
 export const toTokenIsCot = (
@@ -96,9 +82,8 @@ export const toTokenIsCot = (
   }
 };
 
-// Pure routing-time classifier for the three fast paths. `members` are the sources to judge:
-// resolved holdings for EXACT_IN, the full resolved holdings or RES prefix for EXACT_OUT. Check order
-// encodes the product decision A → B1 → B2; the first match wins and the caller gates on it.
+// Pure routing-time classifier for the direct and same-token fast paths. Stable settlement selection
+// is handled independently after these terminal paths have had precedence.
 export const classifyFastPath = (input: {
   chainList: ChainListType;
   members: { chainID: number; tokenAddress: Hex }[];
@@ -110,7 +95,7 @@ export const classifyFastPath = (input: {
   toAmountRaw: bigint;
   mode: SwapMode;
 }): FastPathClass => {
-  const { chainList, members, dstChainId, dstTokenAddress, cotCurrencyId } = input;
+  const { chainList, members, dstChainId, dstTokenAddress } = input;
   if (members.length === 0) return null;
 
   // A — direct destination swap: every member is already on the destination chain and the caller
@@ -137,23 +122,6 @@ export const classifyFastPath = (input: {
     input.toAmountRaw > 0n
   ) {
     return { kind: 'same-token-out', familyId };
-  }
-
-  // B2 — dynamic COT: all members share a STABLE family F distinct from both the destination family
-  // and the current COT, and F resolves as a COT on the destination chain (the resolveCOT throw,
-  // caught here, is the guard). ETH is excluded by B2_STABLE_CURRENCY_IDS. Requires at least one
-  // off-dst-chain member: B2's whole benefit is skipping the F→USDC→bridge→USDC round-trip, so with
-  // everything already on the dst chain there is no bridge to optimize (a same-chain F→toToken swap is
-  // one hop either way) — firing would only add a wasted F-quote + re-entry. (toToken ≠ cot on dst is
-  // Path A's job; toToken == cot is the plain same-chain liquidation.)
-  if (
-    familyId !== dstFamily &&
-    familyId !== cotCurrencyId &&
-    B2_STABLE_CURRENCY_IDS.has(familyId as CurrencyID) &&
-    !members.every((member) => member.chainID === dstChainId) &&
-    cotResolvesOnChain(chainList, dstChainId, familyId)
-  ) {
-    return { kind: 'dynamic-cot', familyId };
   }
 
   return null;
@@ -215,12 +183,12 @@ export async function buildDirectDestinationExactInRoute(
   const swapHoldings = holdings.filter((h) => !isSameSwapToken(h.tokenAddress, toTokenAddress));
 
   const walletDecision = resolveWalletDecisions({
-    sourceChainIds: new Set(holdings.map((h) => h.chainID)),
+    sourceChainIds: new Set(swapHoldings.map((h) => h.chainID)),
     walletPathHints,
   });
   // No destination swap on this chain (the swap output IS the final token) → recipient = EOA.
   const recipientAddressByChain = buildSourceRecipientAddressByChain({
-    chainIds: holdings.map((h) => h.chainID),
+    chainIds: swapHoldings.map((h) => h.chainID),
     sourceExecutionPaths: walletDecision.sourceExecutionPaths,
     destinationChainId: dstChainId,
     destinationHasSwap: false,
@@ -271,11 +239,11 @@ export async function buildDirectDestinationExactInRoute(
       ),
     new Decimal(0)
   );
-  const identityDelivered = identityHoldings.reduce(
-    (sum, holding) => sum.plus(divDecimals(holding.amountRaw, holding.decimals)),
-    new Decimal(0)
+  const identityOutput = summarizeIdentityHoldings(
+    identityHoldings,
+    options.balances,
+    oraclePrices
   );
-  const totalDelivered = swappedDelivered.plus(identityDelivered);
 
   const assetsUsed: AssetsUsedEntry[] = holdings.map((holding) => ({
     chainID: holding.chainID,
@@ -307,7 +275,8 @@ export async function buildDirectDestinationExactInRoute(
       destination: {
         chainId: dstChainId,
         eoaToEphemeral: null,
-        inputAmount: { min: totalDelivered, max: totalDelivered },
+        identityOutput,
+        inputAmount: { min: swappedDelivered, max: swappedDelivered },
         swap: { tokenSwap: null, gasSwap: null },
         getDstSwap: async () => null,
       },
@@ -563,11 +532,9 @@ export async function buildSameTokenBridgeRoute(
   // dst-chain holdings already sit at the EOA as the right token; only other-chain holdings are
   // bridged. Bridge funding is EOA-held (no swap happened) → eoaBalance.
   const assets: BridgeAsset[] = [];
-  let dstChainBalance = new Decimal(0);
   for (const holding of holdings) {
     const amount = divDecimals(holding.amountRaw, holding.decimals);
     if (holding.chainID === dstChainId) {
-      dstChainBalance = dstChainBalance.plus(amount);
       continue;
     }
     assets.push({
@@ -645,9 +612,13 @@ export async function buildSameTokenBridgeRoute(
     }
   }
 
-  const finalDelivered = deliveredFromBridge.plus(dstChainBalance);
+  const identityOutput = summarizeIdentityHoldings(
+    holdings.filter((holding) => holding.chainID === dstChainId),
+    options.balances,
+    oraclePrices
+  );
   const walletDecision = resolveWalletDecisions({
-    sourceChainIds: new Set(holdings.map((holding) => holding.chainID)),
+    sourceChainIds: new Set(assets.map((asset) => asset.chainID)),
     walletPathHints,
   });
   const assetsUsed: AssetsUsedEntry[] = holdings.map((holding) => ({
@@ -676,7 +647,8 @@ export async function buildSameTokenBridgeRoute(
       destination: {
         chainId: dstChainId,
         eoaToEphemeral: null,
-        inputAmount: { min: finalDelivered, max: finalDelivered },
+        identityOutput,
+        inputAmount: { min: deliveredFromBridge, max: deliveredFromBridge },
         swap: { tokenSwap: null, gasSwap: null },
         getDstSwap: async () => null,
       },

--- a/src/swap/routing/holdings.ts
+++ b/src/swap/routing/holdings.ts
@@ -98,6 +98,25 @@ export const sumHoldingsUsd = (
     new Decimal(0)
   );
 
+export const summarizeIdentityHoldings = (
+  holdings: SelectedHolding[],
+  balances: FlatBalance[],
+  oraclePrices: OraclePriceResponse
+): { amountRaw: bigint; amount: Decimal; value: Decimal } | undefined => {
+  if (holdings.length === 0) return undefined;
+  return {
+    amountRaw: holdings.reduce((sum, holding) => sum + holding.amountRaw, 0n),
+    amount: holdings.reduce(
+      (sum, holding) => sum.plus(divDecimals(holding.amountRaw, holding.decimals)),
+      new Decimal(0)
+    ),
+    value: holdings.reduce(
+      (sum, holding) => sum.plus(holdingUsd(holding, balances, oraclePrices)),
+      new Decimal(0)
+    ),
+  };
+};
+
 // Greedy leading prefix of `holdings` (already priority-ordered) whose cumulative USD value first
 // reaches `targetUsd`. Includes the holding that tips the running total over the target; reads only
 // `value`, so it preserves H.

--- a/src/swap/routing/settlement.ts
+++ b/src/swap/routing/settlement.ts
@@ -1,0 +1,70 @@
+import type { Hex } from 'viem';
+import type { ChainListType } from '../../domain';
+import { logger } from '../../domain/utils/logger';
+import { equalFold } from '../../services/strings';
+import { STABLE_SETTLEMENT_CURRENCY_IDS } from '../constants';
+import { resolveCOT } from '../cot';
+
+type SettlementHolding = { chainID: number; tokenAddress: Hex };
+
+export const selectStableSettlement = (input: {
+  chainList: ChainListType;
+  currentCurrencyId: number;
+  destinationChainId: number;
+  destinationTokenAddress: Hex;
+  scoreHoldings: SettlementHolding[];
+  eligibilityHoldings?: SettlementHolding[];
+}): number => {
+  const eligibilityHoldings = input.eligibilityHoldings ?? input.scoreHoldings;
+  const requiredChainIds = new Set([
+    input.destinationChainId,
+    ...eligibilityHoldings.map((holding) => holding.chainID),
+  ]);
+  const candidates = [...STABLE_SETTLEMENT_CURRENCY_IDS].map((currencyId) => {
+    try {
+      const tokensByChain = new Map(
+        [...requiredChainIds].map((chainId) => [
+          chainId,
+          resolveCOT(chainId, input.chainList, currencyId).address,
+        ])
+      );
+      const sourceLegs = input.scoreHoldings.filter(
+        (holding) =>
+          !(
+            holding.chainID === input.destinationChainId &&
+            equalFold(holding.tokenAddress, input.destinationTokenAddress)
+          ) && !equalFold(holding.tokenAddress, tokensByChain.get(holding.chainID) as Hex)
+      ).length;
+      const destinationLeg = equalFold(
+        tokensByChain.get(input.destinationChainId) as Hex,
+        input.destinationTokenAddress
+      )
+        ? 0
+        : 1;
+      return { currencyId, feasible: true as const, score: sourceLegs + destinationLeg };
+    } catch {
+      return { currencyId, feasible: false as const, score: null };
+    }
+  });
+  const feasible = candidates.filter(
+    (candidate): candidate is { currencyId: number; feasible: true; score: number } =>
+      candidate.feasible
+  );
+  const bestScore = feasible.reduce(
+    (best, candidate) => Math.min(best, candidate.score),
+    Number.POSITIVE_INFINITY
+  );
+  const best = feasible.filter((candidate) => candidate.score === bestScore);
+  const selected =
+    best.find((candidate) => candidate.currencyId === input.currentCurrencyId)?.currencyId ??
+    best[0]?.currencyId ??
+    input.currentCurrencyId;
+
+  logger.debug('swap.route.stable_settlement.selected', {
+    candidates,
+    currentCurrencyId: input.currentCurrencyId,
+    selectedCurrencyId: selected,
+    retainedCurrentOnTie: best.length > 1 && selected === input.currentCurrencyId,
+  });
+  return selected;
+};

--- a/src/swap/swap.md
+++ b/src/swap/swap.md
@@ -117,8 +117,10 @@ Destination swaps always execute from the Safe and deliver requested token/nativ
 
 Exact In maximizes destination output from the selected raw input. Exact Out selects enough source
 value to satisfy a fixed destination amount and optional native-gas amount, including configured
-buffers and bridge fees. Provider selection happens only for route-relevant remote value; direct
-destination routes do not request a bridge provider.
+buffers and bridge fees. Its destination buffer is the smaller of 5% or $1. When the requested
+token is already the destination COT and only native gas needs a swap, that buffer applies only to
+the gas-swap input; the requested COT amount remains exact. Provider selection happens only for
+route-relevant remote value; direct destination routes do not request a bridge provider.
 
 ## Preparation
 
@@ -222,6 +224,8 @@ Retries are deliberately narrow:
 - transient permit-preparation RPC errors may retry up to three total attempts;
 - user rejection and direct approval failures are terminal;
 - ambiguous middleware submission failures are not replayed;
+- a safely retryable source swap is re-quoted across the route's aggregators, excluding the failed
+  router only from its original aggregator, and uses the quote with the highest output;
 - destination requotes remain bounded by their original route constraints.
 
 ## Key invariants

--- a/src/swap/swap.md
+++ b/src/swap/swap.md
@@ -119,8 +119,11 @@ Exact In maximizes destination output from the selected raw input. Exact Out sel
 value to satisfy a fixed destination amount and optional native-gas amount, including configured
 buffers and bridge fees. Its destination buffer is the smaller of 5% or $1. When the requested
 token is already the destination COT and only native gas needs a swap, that buffer applies only to
-the gas-swap input; the requested COT amount remains exact. Provider selection happens only for
-route-relevant remote value; direct destination routes do not request a bridge provider.
+the gas-swap input; the requested COT amount remains exact. Its source buffer depends on the rough
+selected source prefix: zero when every source already matches the selected settlement token, the
+smaller of 0.5% or $0.25 for stable-only conversions, and the smaller of 2% or $1 when any
+non-stable conversion is required. Provider selection happens only for route-relevant remote value;
+direct destination routes do not request a bridge provider.
 
 For general COT routes, the SDK deterministically chooses between USDC and USDT before requesting
 aggregator quotes. Each source that is not already the candidate costs one leg, and a

--- a/src/swap/swap.md
+++ b/src/swap/swap.md
@@ -122,6 +122,18 @@ token is already the destination COT and only native gas needs a swap, that buff
 the gas-swap input; the requested COT amount remains exact. Provider selection happens only for
 route-relevant remote value; direct destination routes do not request a bridge provider.
 
+For general COT routes, the SDK deterministically chooses between USDC and USDT before requesting
+aggregator quotes. Each source that is not already the candidate costs one leg, and a
+candidate different from the requested output costs one destination leg. Destination-chain holdings
+already equal to the Exact-In output are excluded. Exact In scores all selected holdings; priced
+Exact Out (including `swapAndExecute`) scores its rough eligible prefix but requires the candidate on
+every usable source chain. ETH remains available to the same-token bridge path but is not a general
+settlement candidate. Equal scores keep the current COT; an unavailable bridge quote fails routing.
+
+Mixed Exact-In routes leave destination-chain holdings already denominated in the requested token
+untouched. That identity output is included in `onIntent`, `assetsUsed`, and `calculateMaxForSwap`,
+but creates no plan step or transaction. Max-amount haircuts apply only to the routed portion.
+
 ## Preparation
 
 `prepareSwapExecution` uses the Safe derived at flow start as the owner/spender for every swap quote.

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -240,9 +240,10 @@ export type SwapRoute = {
     creationTime: number;
     cotByChain?: Map<number, SourceChainCOT>;
     // Headroom in COT units that source swaps may lose on a re-quote when legs revert.
-    // EXACT_OUT carries `min(SRC_BUFFER_PCT, SRC_BUFFER_MAX_USD)` of the destination-
-    // buffered input. EXACT_IN carries `null` — it re-quotes a failed leg and proceeds
-    // with no drift guard (Seam 2 re-sizes the dst swap to whatever COT actually lands).
+    // EXACT_OUT carries zero for direct settlement sources, a reduced buffer for stable-only
+    // conversions, or the standard source buffer when any non-stable conversion is required.
+    // EXACT_IN carries `null` — it re-quotes a failed leg and proceeds with no drift guard
+    // (Seam 2 re-sizes the dst swap to whatever COT actually lands).
     srcBuffer: Decimal | null;
     // EXACT_IN reclaim (set only when a bridge runs): execution bridges the COT that actually
     // landed at the source wrapper (`balanceOf`) rather than the conservative quote floor, so

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -279,6 +279,13 @@ export type SwapRoute = {
       amount: bigint; // raw integer units
       contractAddress: Hex;
     } | null;
+    // EXACT_IN holdings already matching the requested token on the destination chain. They stay
+    // in the user's EOA and contribute to display/max output without entering settlement execution.
+    identityOutput?: {
+      amountRaw: bigint;
+      amount: Decimal;
+      value: Decimal;
+    };
     inputAmount: {
       min: Decimal; // human-readable decimal amount
       max: Decimal; // human-readable decimal amount

--- a/tests/helpers/swap-characterization.ts
+++ b/tests/helpers/swap-characterization.ts
@@ -170,9 +170,9 @@ const RATES: Record<Agg, Record<string, Decimal>> = {
     'WETH>USDC': new Decimal('2500'),
     'USDC>ETH': new Decimal('0.0004'),
     'ETH>USDC': new Decimal('2500'),
-    'USDC>USDT': new Decimal('1'), // 1:1 stable (dst-swap sizing for B1/B2 EXACT_OUT)
+    'USDC>USDT': new Decimal('1'), // 1:1 stable (destination-swap sizing)
     'USDT>USDC': new Decimal('1'),
-    'USDT>WETH': new Decimal('0.0004'), // USDT priced like USDC (B2 settles the dst swap in USDT)
+    'USDT>WETH': new Decimal('0.0004'), // USDT priced like USDC
     'USDT>ETH': new Decimal('0.0004'),
   },
   lifi: {
@@ -785,6 +785,13 @@ export const makeCharMiddleware = (opts: {
       symbol: 'USDT',
       decimals: 6,
       priceUsd: new Decimal(1),
+    }),
+    makeOraclePrice({
+      chainId,
+      tokenAddress: WETH,
+      symbol: 'WETH',
+      decimals: 18,
+      priceUsd: new Decimal(2500),
     }),
   ]);
 

--- a/tests/swap/characterization/max-pipeline.test.ts
+++ b/tests/swap/characterization/max-pipeline.test.ts
@@ -534,6 +534,72 @@ describe('calculateMaxForSwap characterization', () => {
     expect(result.maxAmountRaw).toBe(parseUnits(result.maxAmount, result.decimals));
   });
 
+  it('does not apply the max haircut to destination-token identity output', async () => {
+    const options = makeOptions([
+      {
+        amount: '100',
+        chainID: OP_CHAIN,
+        decimals: 6,
+        symbol: 'USDC',
+        tokenAddress: USDC_OP,
+        value: 100,
+        logo: '',
+        name: 'USDC',
+      },
+      {
+        amount: '20',
+        chainID: BASE_CHAIN,
+        decimals: 6,
+        symbol: 'USDC',
+        tokenAddress: USDC_BASE,
+        value: 20,
+        logo: '',
+        name: 'USDC',
+      },
+    ]);
+
+    const result = await calculateMaxForSwap(
+      { toChainId: BASE_CHAIN, toTokenAddress: USDC_BASE },
+      options
+    );
+
+    expect(result.maxAmount).toBe('117.000000');
+    expect(result.maxAmountRaw).toBe(117_000_000n);
+  });
+
+  it('preserves identity output when the routed token-swap portion is below the haircut floor', async () => {
+    const options = makeOptions([
+      {
+        amount: '1',
+        chainID: OP_CHAIN,
+        decimals: 6,
+        symbol: 'USDC',
+        tokenAddress: USDC_OP,
+        value: 1,
+        logo: '',
+        name: 'USDC',
+      },
+      {
+        amount: '1',
+        chainID: BASE_CHAIN,
+        decimals: 18,
+        symbol: 'WETH',
+        tokenAddress: WETH,
+        value: 1500,
+        logo: '',
+        name: 'WETH',
+      },
+    ]);
+
+    const result = await calculateMaxForSwap(
+      { toChainId: BASE_CHAIN, toTokenAddress: WETH },
+      options
+    );
+
+    expect(result.maxAmount).toBe('1.000000000000000000');
+    expect(result.maxAmountRaw).toBe(1_000_000_000_000_000_000n);
+  });
+
   it.each([
     {
       name: 'uses the 3 USDC floor below the percentage crossover',

--- a/tests/swap/characterization/max-pipeline.test.ts
+++ b/tests/swap/characterization/max-pipeline.test.ts
@@ -474,7 +474,7 @@ describe('calculateMaxForSwap characterization', () => {
     expect(result.symbol).toBe('WETH');
     expect(result.decimals).toBe(18);
     expect(result.maxAmountRaw).toBe(mulDecimals(expectedOutput, 18));
-    expect(result.maxAmount).toBe(expectedOutput.toFixed(18));
+    expect(result.maxAmount).toBe(formatUnits(result.maxAmountRaw, 18));
 
     // Ground truth — NOT recomputed from the route's own quote object. The destination swap is
     // USDC→WETH and Bebop wins (asserted above), so the true per-COT rate is the known Bebop rate.
@@ -563,8 +563,8 @@ describe('calculateMaxForSwap characterization', () => {
       options
     );
 
-    expect(result.maxAmount).toBe('117.000000');
-    expect(result.maxAmountRaw).toBe(117_000_000n);
+    expect(result.maxAmount).toBe('113.000000');
+    expect(result.maxAmountRaw).toBe(113_000_000n);
   });
 
   it('preserves identity output when the routed token-swap portion is below the haircut floor', async () => {
@@ -602,22 +602,22 @@ describe('calculateMaxForSwap characterization', () => {
 
   it.each([
     {
-      name: 'uses the 3 USDC floor below the percentage crossover',
-      amount: '50',
+      name: 'uses the combined USD floor below the percentage crossover',
+      amount: '20',
       oraclePrices: undefined,
-      expected: '47',
+      expected: '18',
     },
     {
-      name: 'uses the 3% cap above the floor crossover',
+      name: 'uses the combined percentage above the floor crossover',
       amount: '10000',
       oraclePrices: undefined,
-      expected: '9700',
+      expected: '9300',
     },
     {
       name: 'falls back to the percentage haircut when no price is available',
       amount: '50',
       oraclePrices: [],
-      expected: '48.5',
+      expected: '46.5',
     },
     {
       name: 'clamps at zero when the converted floor exceeds delivery',
@@ -700,8 +700,8 @@ describe('calculateMaxForSwap characterization', () => {
     );
 
     expect(result.symbol).toBe('ETH');
-    expect(result.maxAmount).toBe(new Decimal('0.0188').toFixed(18));
-    expect(result.maxAmountRaw).toBe(parseUnits('0.0188', 18));
+    expect(result.maxAmount).toBe(new Decimal('0.0186').toFixed(18));
+    expect(result.maxAmountRaw).toBe(parseUnits('0.0186', 18));
   });
 
   it('uses the percentage haircut when source quotes carry no USD value', async () => {

--- a/tests/swap/characterization/swap.test.ts
+++ b/tests/swap/characterization/swap.test.ts
@@ -401,9 +401,9 @@ describe('swap execution characterization', () => {
     expect(sentTxs).toHaveLength(0);
   });
 
-  it('EXACT_IN · Nexus · B2 dynamic-COT (USDT sources → WETH): settles in USDT, no source swaps, dst swap pulls USDT', async () => {
-    // Every source is USDT (a stable family ≠ USDC, the default COT) → B2 re-enters with cotCurrencyId
-    // = USDT: the sources ARE the COT, so there are NO source swaps — each chain just funds (EOA→EPH)
+  it('EXACT_IN · Nexus · least-swap settlement (USDT sources → WETH): no source swaps, dst swap pulls USDT', async () => {
+    // USDT requires fewer legs than USDC, so the sources are already the selected settlement token:
+    // there are no source swaps — each chain just funds (EOA→EPH)
     // and deposits USDT. The bridge carries USDT, and the single destination swap is USDT→WETH.
     const balances: FlatBalance[] = [
       { amount: '2000', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_ARB, value: 2000, name: 'Tether USD', logo: '' },
@@ -462,15 +462,14 @@ describe('swap execution characterization', () => {
     const dst = executionBatchesForChain(middlewareClient, BASE_CHAIN);
     expect(dst.length).toBe(1);
     const swp = dst[0].find((c) => c.fn === 'swap')!;
-    eq(USDT_BASE)(swp.args[0]); // input = the dynamic COT (USDT)
+    eq(USDT_BASE)(swp.args[0]); // input = the selected settlement token
     eq(WETH)(swp.args[1]); // output = WETH
     eq(EOA)(swp.args[5]); // receiver = EOA
     expect(sentTxs).toHaveLength(0);
   });
 
-  it('EXACT_OUT · Nexus · B2 dynamic-COT (USDT sources → WETH + gas): USDT funding + deposits, dst batch pulls USDT for token AND gas', async () => {
-    // B2 EXACT_OUT: USDT-multichain sources, a WETH target AND a native gas amount. Re-enters with
-    // cotCurrencyId = USDT → no source swaps (USDT is the COT), the bridge carries USDT, and the dst
+  it('EXACT_OUT · Nexus · least-swap settlement (USDT sources → WETH + gas): dst batch pulls USDT for token and gas', async () => {
+    // The priced rough prefix selects USDT, so there are no source swaps, the bridge carries USDT, and the dst
     // batch runs BOTH the token swap (USDT→WETH) and the gas swap (USDT→native) off the bridged USDT.
     const balances: FlatBalance[] = [
       { amount: '3000', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_ARB, value: 3000, name: 'Tether USD', logo: '' },
@@ -505,12 +504,12 @@ describe('swap execution characterization', () => {
       { onIntent: (d: { allow: () => void }) => d.allow() }
     );
 
-    // Source chains only deposit USDT (no source swap — USDT is the dynamic COT). At least one source
+    // Source chains only deposit USDT (no source swap). At least one source
     // funds+deposits; every source batch is deposit-shaped, never a swap.
     const sourceBatches = [ARB_CHAIN, OP_CHAIN].flatMap((c) => executionBatchesForChain(middlewareClient, c));
     expect(sourceBatches.length).toBeGreaterThan(0);
     for (const b of sourceBatches) {
-      expect(b.some((c) => c.fn === 'swap'), 'no source swap on a B2 source chain').toBe(false);
+      expect(b.some((c) => c.fn === 'swap'), 'no source swap on a settled source chain').toBe(false);
       expect(b.some((c) => c.fn === 'deposit'), 'source chain deposits USDT').toBe(true);
     }
     // RFF carries USDT.
@@ -525,7 +524,7 @@ describe('swap execution characterization', () => {
     const gasSwap = swaps.find((c) => (c.args[1] as Hex).toLowerCase() === (EADDRESS as Hex).toLowerCase());
     expect(tokenSwap, 'USDT→WETH token swap').toBeDefined();
     expect(gasSwap, 'USDT→native gas swap').toBeDefined();
-    eq(USDT_BASE)(tokenSwap!.args[0]); // both pull the dynamic COT (USDT)
+    eq(USDT_BASE)(tokenSwap!.args[0]); // both pull the selected settlement token
     eq(USDT_BASE)(gasSwap!.args[0]);
     eq(EOA)(tokenSwap!.args[5]);
     eq(EOA)(gasSwap!.args[5]);

--- a/tests/swap/constants.test.ts
+++ b/tests/swap/constants.test.ts
@@ -34,9 +34,11 @@ describe('swap economic constants', () => {
     expect(SRC_BUFFER_MAX_USD).toBe(1);
   });
 
-  it('max-amount haircut = max(3%, $3)', () => {
-    expect(MAX_SWAP_HAIRCUT_PCT).toBe(0.03);
-    expect(MAX_SWAP_HAIRCUT_MIN_USDC).toBe(3);
+  it('max-amount haircut combines the source and destination buffers', () => {
+    expect(MAX_SWAP_HAIRCUT_PCT).toBe(DST_BUFFER_PCT + SRC_BUFFER_PCT);
+    expect(MAX_SWAP_HAIRCUT_PCT).toBe(0.07);
+    expect(MAX_SWAP_HAIRCUT_MIN_USDC).toBe(DST_BUFFER_MAX_USD + SRC_BUFFER_MAX_USD);
+    expect(MAX_SWAP_HAIRCUT_MIN_USDC).toBe(2);
   });
 
   it('convergence: ×1.005 safety, +0.5 COT input cap, ≤10 iterations', () => {

--- a/tests/swap/constants.test.ts
+++ b/tests/swap/constants.test.ts
@@ -1,7 +1,7 @@
 import Decimal from 'decimal.js';
 import { describe, expect, it } from 'vitest';
 import {
-  B2_STABLE_CURRENCY_IDS,
+  STABLE_SETTLEMENT_CURRENCY_IDS,
   DST_BUFFER_MAX_USD,
   DST_BUFFER_PCT,
   MAX_SWAP_HAIRCUT_MIN_USDC,
@@ -49,8 +49,10 @@ describe('swap economic constants', () => {
     expect(SLIPPAGE_DEFAULT).toBe(0.005);
   });
 
-  it('B2 dynamic COT is stables-only (USDC + USDT) — ETH excluded', () => {
-    expect([...B2_STABLE_CURRENCY_IDS].sort()).toEqual([CurrencyID.USDC, CurrencyID.USDT].sort());
-    expect(B2_STABLE_CURRENCY_IDS.has(CurrencyID.ETH)).toBe(false);
+  it('least-swap settlement is stables-only (USDC + USDT) — ETH excluded', () => {
+    expect([...STABLE_SETTLEMENT_CURRENCY_IDS].sort()).toEqual(
+      [CurrencyID.USDC, CurrencyID.USDT].sort()
+    );
+    expect(STABLE_SETTLEMENT_CURRENCY_IDS.has(CurrencyID.ETH)).toBe(false);
   });
 });

--- a/tests/swap/constants.test.ts
+++ b/tests/swap/constants.test.ts
@@ -24,9 +24,9 @@ import {
 // budget to be a deliberate, reviewed product decision rather than something that slips through
 // behind an ambiguous numeric example. Keep this in lockstep with src/swap/swap.md §12.
 describe('swap economic constants', () => {
-  it('destination buffer = min(10%, $2)', () => {
-    expect(DST_BUFFER_PCT).toBe(0.1);
-    expect(DST_BUFFER_MAX_USD).toBe(2);
+  it('destination buffer = min(5%, $1)', () => {
+    expect(DST_BUFFER_PCT).toBe(0.05);
+    expect(DST_BUFFER_MAX_USD).toBe(1);
   });
 
   it('EXACT_OUT source buffer = min(2%, $1)', () => {

--- a/tests/swap/constants.test.ts
+++ b/tests/swap/constants.test.ts
@@ -9,6 +9,8 @@ import {
   SLIPPAGE_DEFAULT,
   SRC_BUFFER_MAX_USD,
   SRC_BUFFER_PCT,
+  STABLE_SRC_BUFFER_MAX_USD,
+  STABLE_SRC_BUFFER_PCT,
 } from '../../src/swap/constants';
 import { CurrencyID } from '../../src/swap/cot';
 import {
@@ -32,6 +34,11 @@ describe('swap economic constants', () => {
   it('EXACT_OUT source buffer = min(2%, $1)', () => {
     expect(SRC_BUFFER_PCT).toBe(0.02);
     expect(SRC_BUFFER_MAX_USD).toBe(1);
+  });
+
+  it('EXACT_OUT stable source buffer = min(0.5%, $0.25)', () => {
+    expect(STABLE_SRC_BUFFER_PCT).toBe(0.005);
+    expect(STABLE_SRC_BUFFER_MAX_USD).toBe(0.25);
   });
 
   it('max-amount haircut combines the source and destination buffers', () => {

--- a/tests/swap/execution/failure-cleanup.test.ts
+++ b/tests/swap/execution/failure-cleanup.test.ts
@@ -209,8 +209,8 @@ describe('resolveFailureSweepCurrencyId', () => {
     ).toBe(CurrencyID.USDC);
   });
 
-  it('sweeps the dynamic COT (F) for a B2 route settling in a non-USDC family', () => {
-    // B2 re-enters the COT flow with cotCurrencyId = F (USDT), so a failed route strands F, not USDC.
+  it('sweeps the selected settlement token for a route settling in a non-USDC family', () => {
+    // A USDT-settled route strands USDT on failure, not the default USDC.
     expect(
       resolveFailureSweepCurrencyId(
         makeRoute({ sameTokenBridge: false, provider: 'nexus', settlementCurrencyId: CurrencyID.USDT })

--- a/tests/swap/execution/orchestrator-contracts.test.ts
+++ b/tests/swap/execution/orchestrator-contracts.test.ts
@@ -36,6 +36,7 @@ const makeRoute = () => ({
     sameTokenBridge: false,
     settlementCurrencyId: CurrencyID.USDC,
     source: { swaps: [], creationTime: Date.now(), srcBuffer: null },
+    extras: { aggregators: [] },
     bridge: null,
     destination: {
       chainId: 8453,

--- a/tests/swap/execution/source-contracts.test.ts
+++ b/tests/swap/execution/source-contracts.test.ts
@@ -224,7 +224,8 @@ describe('executeSourceSwaps contracts', () => {
         srcBuffer: new Decimal(0),
       },
       context,
-      metadata()
+      metadata(),
+      [quote.aggregator]
     );
 
     const calls = vi.mocked(createSafeExecuteTxFromCalls).mock.calls[0]![0].calls;
@@ -251,7 +252,8 @@ describe('executeSourceSwaps contracts', () => {
           srcBuffer: new Decimal(0),
         },
         context,
-        metadata()
+        metadata(),
+        [quote.aggregator]
       )
     ).rejects.toMatchObject({ code: 'user_action/allowance_approval_denied' });
 
@@ -278,7 +280,8 @@ describe('executeSourceSwaps contracts', () => {
           srcBuffer: new Decimal(0),
         },
         context,
-        metadata()
+        metadata(),
+        [quote.aggregator]
       )
     ).rejects.toMatchObject({ code: 'user_action/tx_send_denied' });
 
@@ -298,7 +301,8 @@ describe('executeSourceSwaps contracts', () => {
         reclaimFromActualBalance: true,
       },
       context,
-      metadata()
+      metadata(),
+      [quote.aggregator]
     );
 
     expect(readContract).toHaveBeenCalledWith(

--- a/tests/swap/execution/source-swap-requote.test.ts
+++ b/tests/swap/execution/source-swap-requote.test.ts
@@ -134,7 +134,8 @@ describe('native EOA source swap dispatches the fresh re-quote on retry', () => 
     await executeSourceSwaps(
       { swaps: [original], creationTime: Date.now(), srcBuffer: REAL_SRC_BUFFER },
       ctx,
-      metadata()
+      metadata(),
+      [aggregator]
     ).catch(() => undefined); // both attempts revert; we only assert what was dispatched
 
     const sends = sendTransaction.mock.calls.map((c) => innerData(c[0].data as Hex));
@@ -153,10 +154,42 @@ describe('native EOA source swap dispatches the fresh re-quote on retry', () => 
     await executeSourceSwaps(
       { swaps: [original], creationTime: Date.now(), srcBuffer: REAL_SRC_BUFFER },
       ctx,
-      metadata()
+      metadata(),
+      [aggregator]
     );
 
     const sends = sendTransaction.mock.calls.map((c) => innerData(c[0].data as Hex));
     expect(sends).toEqual(['0xaaaaaaaa', '0xbbbbbbbb']);
+  });
+
+  it('selects the best source re-quote across the route aggregators', async () => {
+    const sameAggregatorQuote = makeNativeQuote('0xbbbbbbbb', 45_000_000n);
+    const competingQuote = makeNativeQuote('0xcccccccc', 46_000_000n);
+    const originalAggregator = {
+      supportsChain: () => true,
+      getQuotes: vi.fn().mockResolvedValue([sameAggregatorQuote.quote]),
+    } as unknown as Aggregator;
+    const competingAggregator = {
+      supportsChain: () => true,
+      getQuotes: vi.fn().mockResolvedValue([competingQuote.quote]),
+    } as unknown as Aggregator;
+    const original = makeNativeQuote('0xaaaaaaaa', 45_000_000n, originalAggregator);
+    original.quote.routerId = 'uniswap-v3';
+    const { ctx, sendTransaction } = makeCtx({ receiptStatuses: ['reverted', 'success'] });
+
+    await executeSourceSwaps(
+      { swaps: [original], creationTime: Date.now(), srcBuffer: REAL_SRC_BUFFER },
+      ctx,
+      metadata(),
+      [originalAggregator, competingAggregator]
+    );
+
+    expect(originalAggregator.getQuotes).toHaveBeenCalledWith(
+      expect.any(Array),
+      ['uniswap-v3']
+    );
+    expect(competingAggregator.getQuotes).toHaveBeenCalledWith(expect.any(Array));
+    const sends = sendTransaction.mock.calls.map((call) => innerData(call[0].data as Hex));
+    expect(sends).toEqual(['0xaaaaaaaa', '0xcccccccc']);
   });
 });

--- a/tests/swap/intent.test.ts
+++ b/tests/swap/intent.test.ts
@@ -470,6 +470,41 @@ describe('createSwapIntent', () => {
     expect(intent.destination.amount).toBe('3000');
   });
 
+  it('EXACT_IN adds identity output to the routed destination amount and value', () => {
+    const route = makeRoute({
+      type: SwapMode.EXACT_IN,
+      destination: {
+        chainId: ARB_CHAIN,
+        eoaToEphemeral: null,
+        identityOutput: {
+          amountRaw: 2_000_000n,
+          amount: new Decimal(2),
+          value: new Decimal(2),
+        },
+        inputAmount: { min: new Decimal(3), max: new Decimal(3) },
+        swap: {
+          tokenSwap: makeQuoteResponse({
+            quote: {
+              input: { contractAddress: USDC_ARB, amount: '3', amountRaw: 3_000_000n, decimals: 6, value: 3, symbol: 'USDC' },
+              output: { contractAddress: WETH, amount: '3', amountRaw: 3_000_000n, decimals: 6, value: 3, symbol: 'WETH' },
+            } as never,
+          }),
+          gasSwap: null,
+        },
+        getDstSwap: async () => null,
+      },
+    });
+    const input: SwapData = {
+      mode: SwapMode.EXACT_IN,
+      data: { sources: [], toChainId: ARB_CHAIN, toTokenAddress: WETH },
+    };
+
+    const intent = createSwapIntent(route, input, makeChainList() as unknown as ChainListType);
+
+    expect(intent.destination.amount).toBe('5');
+    expect(intent.destination.value).toBe('5');
+  });
+
   it('uses route destination gas-swap output for destination gas display', () => {
     const route = makeRoute({
       destination: {

--- a/tests/swap/route-fast-paths.test.ts
+++ b/tests/swap/route-fast-paths.test.ts
@@ -7,7 +7,6 @@ import {
   selectRoughEligibleSources,
 } from '../../src/swap/route';
 import { CurrencyID } from '../../src/swap/cot';
-import { EADDRESS } from '../../src/swap/constants';
 import { SwapMode } from '../../src/swap/types';
 import type { ChainListType } from '../../src/domain';
 import {
@@ -139,7 +138,7 @@ describe('classifyFastPath', () => {
     ).toBeNull();
   });
 
-  it('B2 (dynamic-cot): uniform stable family distinct from dst family + COT, resolving on the dst chain', () => {
+  it('leaves stable-family optimization to the settlement selector', () => {
     expect(
       classify({
         chainList: makeChainListWithUsdtCot(),
@@ -148,64 +147,6 @@ describe('classifyFastPath', () => {
           { chainID: OP_CHAIN, tokenAddress: USDT_OP },
         ],
         dstTokenAddress: WETH, // non-mesh destination
-        allowDirectDestination: true,
-        mode: SwapMode.EXACT_IN,
-      })
-    ).toEqual({ kind: 'dynamic-cot', familyId: CurrencyID.USDT });
-  });
-
-  it('B2 does not fire when all members are already on the dst chain (no bridge to optimize)', () => {
-    // USDT@Base → USDC@Base: same-chain, toToken IS the COT so A/B1 skip. B2 would settle in USDT but
-    // saves nothing (a USDT→USDC swap is one hop either way) — the "some member off-chain" guard drops it.
-    expect(
-      classify({
-        chainList: makeChainListWithUsdtCot(),
-        members: [{ chainID: BASE_CHAIN, tokenAddress: USDT_BASE }],
-        dstTokenAddress: USDC_BASE, // == COT → ordinary routing disallows Path A
-        allowDirectDestination: false,
-        mode: SwapMode.EXACT_IN,
-      })
-    ).toBeNull();
-  });
-
-  it('B2 does not fire when the family COT cannot be resolved on the destination chain', () => {
-    // Default chainList: USDT has no getTokenByCurrencyId entry → resolveCOT throws → null.
-    expect(
-      classify({
-        members: [
-          { chainID: ARB_CHAIN, tokenAddress: USDT_ARB },
-          { chainID: OP_CHAIN, tokenAddress: USDT_OP },
-        ],
-        dstTokenAddress: WETH,
-        allowDirectDestination: true,
-        mode: SwapMode.EXACT_IN,
-      })
-    ).toBeNull();
-  });
-
-  it('B2 excludes ETH — a native (ETH family) source to a non-mesh destination is null', () => {
-    expect(
-      classify({
-        chainList: makeChainListWithUsdtCot(),
-        members: [
-          { chainID: ARB_CHAIN, tokenAddress: EADDRESS as Hex },
-          { chainID: OP_CHAIN, tokenAddress: EADDRESS as Hex },
-        ],
-        dstTokenAddress: WETH,
-        allowDirectDestination: true,
-        mode: SwapMode.EXACT_IN,
-      })
-    ).toBeNull();
-  });
-
-  it('B2 is a no-op when the family IS the COT (USDC everywhere → today’s default flow)', () => {
-    expect(
-      classify({
-        members: [
-          { chainID: ARB_CHAIN, tokenAddress: USDC_ARB },
-          { chainID: OP_CHAIN, tokenAddress: USDC_OP },
-        ],
-        dstTokenAddress: WETH,
         allowDirectDestination: true,
         mode: SwapMode.EXACT_IN,
       })

--- a/tests/swap/route.test.ts
+++ b/tests/swap/route.test.ts
@@ -890,8 +890,10 @@ describe('determineSwapRoute', () => {
     // Only the off-chain (ARB) source is bridged; the BASE source already sits at the EOA.
     expect(route.bridge!.assets).toHaveLength(1);
     expect(route.bridge!.assets[0].chainID).toBe(ARB_CHAIN);
-    // Delivered = bridged ARB (1, fees 0) + dst-chain BASE (2) = 3.
-    expect(route.destination.inputAmount.min.toFixed()).toBe('3');
+    // Only routed delivery enters settlement accounting; the local 2 USDT stays untouched.
+    expect(route.destination.inputAmount.min.toFixed()).toBe('1');
+    expect(route.destination.identityOutput?.amount.toFixed()).toBe('2');
+    expect(route.sourceExecutionPaths.has(BASE_CHAIN)).toBe(false);
   });
   it('B1 EXACT_OUT same-family full holdings bridge directly with no swaps (USDT→USDT)', async () => {
     const input: SwapData = {
@@ -1184,7 +1186,7 @@ describe('determineSwapRoute', () => {
     expect(determineDestinationSwaps).not.toHaveBeenCalled();
     expect(autoSelectSources).not.toHaveBeenCalled();
   });
-  it('B2 EXACT_OUT dynamic-COT: USDT sources → WETH re-enters (allowlisted) settling in USDT, zero source swaps', async () => {
+  it('EXACT_OUT least-swap settlement: USDT sources → WETH settles in USDT with zero source swaps', async () => {
     const input: SwapData = {
       mode: SwapMode.EXACT_OUT,
       data: {
@@ -1197,7 +1199,7 @@ describe('determineSwapRoute', () => {
         toAmountRaw: 1_000_000_000_000_000_000n, // 1 WETH
       },
     };
-    // Sizing quote (outer USDC→WETH, then the re-entered USDT→WETH) + autoSelect over the USDT COT.
+    // The priced rough prefix selects USDT before destination quoting and source selection.
     vi.mocked(determineDestinationSwaps).mockResolvedValue(makeDestinationQuoteResponse({ chainID: BASE_CHAIN }));
     vi.mocked(autoSelectSources).mockResolvedValue({
       quoteResponses: [],
@@ -1211,6 +1213,9 @@ describe('determineSwapRoute', () => {
         { amount: '3255', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_ARB, value: 3255, logo: '', name: 'Tether USD' },
         { amount: '100', chainID: OP_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_OP, value: 100, logo: '', name: 'Tether USD' },
       ],
+      oraclePrices: [
+        { universe: 'EVM', chainId: BASE_CHAIN, priceUsd: new Decimal(3000), tokenAddress: WETH, tokenSymbol: 'WETH', tokenDecimals: 18, timestamp: 0 },
+      ],
       dstTokenInfo: makeDstTokenInfo({ contractAddress: WETH, decimals: 18, symbol: 'WETH', name: 'Wrapped Ether' }),
     }));
     // Settles in USDT; the allowlisted sources ARE the COT → autoSelect returns usedCOTs, no swaps.
@@ -1219,7 +1224,150 @@ describe('determineSwapRoute', () => {
     expect(route.destination.swap.tokenSwap).not.toBeNull();
     expect(getQuote).toHaveBeenCalled();
   });
-  it('B2 EXACT_IN dynamic-COT: USDT sources → WETH re-enters settling in USDT (zero source swaps)', async () => {
+  it('EXACT_OUT scores the rough source prefix before destination quoting', async () => {
+    const input: SwapData = {
+      mode: SwapMode.EXACT_OUT,
+      data: {
+        toChainId: BASE_CHAIN,
+        toTokenAddress: WETH,
+        toAmountRaw: 1_000_000_000_000_000_000n,
+      },
+    };
+    vi.mocked(determineDestinationSwaps).mockResolvedValue(
+      makeDestinationQuoteResponse({ chainID: BASE_CHAIN })
+    );
+    vi.mocked(autoSelectSources).mockResolvedValue({
+      quoteResponses: [],
+      usedCOTs: [
+        {
+          holding: {
+            chainID: ARB_CHAIN,
+            tokenAddress: USDT_ARB,
+            amountRaw: 4_000_000_000n,
+            decimals: 6,
+            symbol: 'USDT',
+          },
+          amountUsed: new Decimal('3102'),
+          idx: 0,
+        },
+      ],
+    });
+    const getQuote = vi.fn().mockResolvedValue(makeBridgeQuoteResponse());
+
+    const route = await determineSwapRoute(
+      input,
+      makeRouteOptions({
+        chainList: makeSwapChainListWithUsdtCot(),
+        middlewareClient: { ...mockMiddleware, getQuote } as never,
+        oraclePrices: [
+          { universe: 'EVM', chainId: BASE_CHAIN, priceUsd: new Decimal('3100'), tokenAddress: WETH, tokenSymbol: 'WETH', tokenDecimals: 18, timestamp: 0 },
+          { universe: 'EVM', chainId: BASE_CHAIN, priceUsd: new Decimal('1'), tokenAddress: USDC_BASE, tokenSymbol: 'USDC', tokenDecimals: 6, timestamp: 0 },
+          { universe: 'EVM', chainId: BASE_CHAIN, priceUsd: new Decimal('1'), tokenAddress: USDT_BASE, tokenSymbol: 'USDT', tokenDecimals: 6, timestamp: 0 },
+        ],
+        balances: [
+          { amount: '1500', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_ARB, value: 1500, logo: '', name: 'USDT' },
+          { amount: '1000', chainID: OP_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_OP, value: 1000, logo: '', name: 'USDT' },
+          { amount: '1000', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDC', tokenAddress: USDC_ARB, value: 1000, logo: '', name: 'USDC' },
+        ],
+        dstTokenInfo: makeDstTokenInfo({ contractAddress: WETH, decimals: 18, symbol: 'WETH', name: 'Wrapped Ether' }),
+      })
+    );
+
+    expect(route.settlementCurrencyId).toBe(CurrencyID.USDT);
+    expect(determineDestinationSwaps).toHaveBeenCalledTimes(1);
+    expect(determineDestinationSwaps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({ cotCurrencyID: CurrencyID.USDT }),
+      })
+    );
+    expect(autoSelectSources).toHaveBeenCalledWith(
+      expect.objectContaining({ cotCurrencyId: CurrencyID.USDT })
+    );
+  });
+  it('EXACT_OUT fails before aggregator quoting when the selected-family bridge quote is unavailable', async () => {
+    const input: SwapData = {
+      mode: SwapMode.EXACT_OUT,
+      data: {
+        sources: [
+          { chainId: ARB_CHAIN, tokenAddress: USDT_ARB },
+          { chainId: OP_CHAIN, tokenAddress: USDT_OP },
+        ],
+        toChainId: BASE_CHAIN,
+        toTokenAddress: WETH,
+        toAmountRaw: 1_000_000_000_000_000_000n,
+      },
+    };
+    const getQuote = vi.fn().mockResolvedValue(null);
+
+    await expect(
+      determineSwapRoute(
+        input,
+        makeRouteOptions({
+          chainList: makeSwapChainListWithUsdtCot(),
+          middlewareClient: { ...mockMiddleware, getQuote } as never,
+          oraclePrices: [
+            { universe: 'EVM', chainId: BASE_CHAIN, priceUsd: new Decimal('3100'), tokenAddress: WETH, tokenSymbol: 'WETH', tokenDecimals: 18, timestamp: 0 },
+          ],
+          balances: [
+            { amount: '3255', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_ARB, value: 3255, logo: '', name: 'Tether USD' },
+            { amount: '100', chainID: OP_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_OP, value: 100, logo: '', name: 'Tether USD' },
+          ],
+          dstTokenInfo: makeDstTokenInfo({ contractAddress: WETH, decimals: 18, symbol: 'WETH', name: 'Wrapped Ether' }),
+        })
+      )
+    ).rejects.toThrow(/bridge fee quote unavailable/i);
+    expect(determineDestinationSwaps).not.toHaveBeenCalled();
+    expect(autoSelectSources).not.toHaveBeenCalled();
+  });
+  it('EXACT_OUT retains the current settlement when the requirement is unpriced', async () => {
+    const input: SwapData = {
+      mode: SwapMode.EXACT_OUT,
+      data: {
+        sources: [
+          { chainId: ARB_CHAIN, tokenAddress: USDT_ARB },
+          { chainId: OP_CHAIN, tokenAddress: USDT_OP },
+        ],
+        toChainId: BASE_CHAIN,
+        toTokenAddress: WETH,
+        toAmountRaw: 1_000_000_000_000_000_000n,
+      },
+    };
+    vi.mocked(determineDestinationSwaps).mockResolvedValue(
+      makeDestinationQuoteResponse({ chainID: BASE_CHAIN })
+    );
+    vi.mocked(autoSelectSources).mockResolvedValue({
+      quoteResponses: [
+        makeQuoteResponse({
+          chainID: ARB_CHAIN,
+          quote: {
+            input: { contractAddress: USDT_ARB, amount: '4000', amountRaw: 4_000_000_000n, decimals: 6, value: 4000, symbol: 'USDT' },
+            output: { contractAddress: USDC_ARB, amount: '4000', amountRaw: 4_000_000_000n, decimals: 6, value: 4000, symbol: 'USDC' },
+          } as never,
+          holding: { chainID: ARB_CHAIN, tokenAddress: USDT_ARB, amountRaw: 4_000_000_000n, decimals: 6, symbol: 'USDT' },
+        }),
+      ],
+      usedCOTs: [],
+    });
+
+    const route = await determineSwapRoute(
+      input,
+      makeRouteOptions({
+        chainList: makeSwapChainListWithUsdtCot(),
+        oraclePrices: [],
+        balances: [
+          { amount: '4000', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_ARB, value: 4000, logo: '', name: 'Tether USD' },
+          { amount: '100', chainID: OP_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_OP, value: 100, logo: '', name: 'Tether USD' },
+        ],
+        dstTokenInfo: makeDstTokenInfo({ contractAddress: WETH, decimals: 18, symbol: 'WETH', name: 'Wrapped Ether' }),
+      })
+    );
+
+    expect(route.settlementCurrencyId).toBe(CurrencyID.USDC);
+    expect(autoSelectSources).toHaveBeenCalledWith(
+      expect.objectContaining({ cotCurrencyId: CurrencyID.USDC })
+    );
+  });
+  it('EXACT_IN least-swap settlement: USDT sources → WETH settles in USDT with zero source swaps', async () => {
     const input: SwapData = {
       mode: SwapMode.EXACT_IN,
       data: {
@@ -1231,8 +1379,7 @@ describe('determineSwapRoute', () => {
         toTokenAddress: WETH,
       },
     };
-    // The re-entered flow (cotCurrencyId=USDT) is EXACT_IN → quotes the dst swap USDT→WETH via
-    // destinationSwapWithExactIn.
+    // The selected USDT settlement quotes the destination swap USDT→WETH.
     vi.mocked(destinationSwapWithExactIn).mockResolvedValue(makeDestinationQuoteResponse({ chainID: BASE_CHAIN }));
     const getQuote = vi.fn().mockResolvedValue(makeBridgeQuoteResponse());
     const route = await determineSwapRoute(input, makeRouteOptions({
@@ -1244,7 +1391,7 @@ describe('determineSwapRoute', () => {
       ],
       dstTokenInfo: makeDstTokenInfo({ contractAddress: WETH, decimals: 18, symbol: 'WETH', name: 'Wrapped Ether' }),
     }));
-    // Settles in USDT (the dynamic COT); the sources ARE the COT → no source-swap liquidation.
+    // The sources are already the selected settlement token, so no source liquidation is needed.
     expect(route.settlementCurrencyId).toBe(CurrencyID.USDT);
     expect(liquidateInputHoldings).not.toHaveBeenCalled();
     expect(route.source.swaps).toHaveLength(0);
@@ -1252,7 +1399,194 @@ describe('determineSwapRoute', () => {
     expect(route.destination.swap.tokenSwap).not.toBeNull();
     expect(getQuote).toHaveBeenCalled();
   });
-  it('B2 EXACT_IN falls back to the USDC COT flow when the F-quote is unavailable', async () => {
+  it('EXACT_IN chooses the stable family with the fewest swap legs', async () => {
+    const input: SwapData = {
+      mode: SwapMode.EXACT_IN,
+      data: {
+        sources: [
+          { chainId: ARB_CHAIN, tokenAddress: USDT_ARB, amountRaw: 1_000_000n },
+          { chainId: OP_CHAIN, tokenAddress: USDT_OP, amountRaw: 1_000_000n },
+          { chainId: BASE_CHAIN, tokenAddress: USDT_BASE, amountRaw: 1_000_000n },
+          { chainId: ARB_CHAIN, tokenAddress: USDC_ARB, amountRaw: 1_000_000n },
+        ],
+        toChainId: BASE_CHAIN,
+        toTokenAddress: USDC_BASE,
+      },
+    };
+    vi.mocked(liquidateInputHoldings).mockResolvedValue([
+      makeQuoteResponse({
+        chainID: ARB_CHAIN,
+        quote: {
+          output: {
+            contractAddress: USDT_ARB,
+            amount: '1',
+            amountRaw: 1_000_000n,
+            decimals: 6,
+            value: 1,
+            symbol: 'USDT',
+          },
+        } as never,
+      }),
+    ]);
+    vi.mocked(destinationSwapWithExactIn).mockResolvedValue(
+      makeDestinationQuoteResponse({ chainID: BASE_CHAIN })
+    );
+    const getQuote = vi.fn().mockResolvedValue(makeBridgeQuoteResponse());
+
+    const route = await determineSwapRoute(
+      input,
+      makeRouteOptions({
+        chainList: makeSwapChainListWithUsdtCot(),
+        middlewareClient: { ...mockMiddleware, getQuote } as never,
+        balances: [
+          { amount: '1', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_ARB, value: 1, logo: '', name: 'USDT' },
+          { amount: '1', chainID: OP_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_OP, value: 1, logo: '', name: 'USDT' },
+          { amount: '1', chainID: BASE_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_BASE, value: 1, logo: '', name: 'USDT' },
+          { amount: '1', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDC', tokenAddress: USDC_ARB, value: 1, logo: '', name: 'USDC' },
+        ],
+        dstTokenInfo: makeDstTokenInfo({ contractAddress: USDC_BASE, decimals: 6, symbol: 'USDC', name: 'USD Coin' }),
+      })
+    );
+
+    expect(route.settlementCurrencyId).toBe(CurrencyID.USDT);
+    expect(liquidateInputHoldings).toHaveBeenCalledWith(
+      expect.objectContaining({ cotCurrencyId: CurrencyID.USDT })
+    );
+    expect(route.destination.swap.tokenSwap).not.toBeNull();
+  });
+  it('EXACT_IN ETH → USDT selects USDT and avoids a destination swap', async () => {
+    const input: SwapData = {
+      mode: SwapMode.EXACT_IN,
+      data: {
+        sources: [
+          { chainId: ARB_CHAIN, tokenAddress: EADDRESS, amountRaw: 1_000_000_000_000_000n },
+        ],
+        toChainId: BASE_CHAIN,
+        toTokenAddress: USDT_BASE,
+      },
+    };
+    vi.mocked(liquidateInputHoldings).mockResolvedValue([
+      makeQuoteResponse({
+        chainID: ARB_CHAIN,
+        quote: {
+          input: { contractAddress: EADDRESS, amount: '0.001', amountRaw: 1_000_000_000_000_000n, decimals: 18, value: 2, symbol: 'ETH' },
+          output: { contractAddress: USDT_ARB, amount: '2', amountRaw: 2_000_000n, decimals: 6, value: 2, symbol: 'USDT' },
+        } as never,
+        holding: { chainID: ARB_CHAIN, tokenAddress: EADDRESS, amountRaw: 1_000_000_000_000_000n, decimals: 18, symbol: 'ETH' },
+      }),
+    ]);
+    const getQuote = vi.fn().mockResolvedValue(makeBridgeQuoteResponse());
+
+    const route = await determineSwapRoute(
+      input,
+      makeRouteOptions({
+        chainList: makeSwapChainListWithUsdtCot(),
+        middlewareClient: { ...mockMiddleware, getQuote } as never,
+        balances: [
+          { amount: '0.001', chainID: ARB_CHAIN, decimals: 18, symbol: 'ETH', tokenAddress: EADDRESS, value: 2, logo: '', name: 'Ether' },
+        ],
+        dstTokenInfo: makeDstTokenInfo({ contractAddress: USDT_BASE, decimals: 6, symbol: 'USDT', name: 'Tether USD' }),
+      })
+    );
+
+    expect(route.settlementCurrencyId).toBe(CurrencyID.USDT);
+    expect(liquidateInputHoldings).toHaveBeenCalledWith(
+      expect.objectContaining({ cotCurrencyId: CurrencyID.USDT })
+    );
+    expect(route.destination.swap.tokenSwap).toBeNull();
+  });
+
+  it('EXACT_IN converts other remote sources directly into the remote output family', async () => {
+    const input: SwapData = {
+      mode: SwapMode.EXACT_IN,
+      data: {
+        sources: [
+          { chainId: ARB_CHAIN, tokenAddress: USDT_ARB, amountRaw: 5_000_000n },
+          { chainId: OP_CHAIN, tokenAddress: USDC_OP, amountRaw: 1_000_000n },
+        ],
+        toChainId: BASE_CHAIN,
+        toTokenAddress: USDT_BASE,
+      },
+    };
+    vi.mocked(liquidateInputHoldings).mockResolvedValue([
+      makeQuoteResponse({
+        chainID: OP_CHAIN,
+        quote: {
+          input: { contractAddress: USDC_OP, amount: '1', amountRaw: 1_000_000n, decimals: 6, value: 1, symbol: 'USDC' },
+          output: { contractAddress: USDT_OP, amount: '1', amountRaw: 1_000_000n, decimals: 6, value: 1, symbol: 'USDT' },
+        } as never,
+        holding: { chainID: OP_CHAIN, tokenAddress: USDC_OP, amountRaw: 1_000_000n, decimals: 6, symbol: 'USDC' },
+      }),
+    ]);
+    const getQuote = vi.fn().mockResolvedValue(makeBridgeQuoteResponse());
+
+    const route = await determineSwapRoute(
+      input,
+      makeRouteOptions({
+        chainList: makeSwapChainListWithUsdtCot(),
+        middlewareClient: { ...mockMiddleware, getQuote } as never,
+        balances: [
+          { amount: '5', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_ARB, value: 5, logo: '', name: 'Tether USD' },
+          { amount: '1', chainID: OP_CHAIN, decimals: 6, symbol: 'USDC', tokenAddress: USDC_OP, value: 1, logo: '', name: 'USD Coin' },
+        ],
+        dstTokenInfo: makeDstTokenInfo({ contractAddress: USDT_BASE, decimals: 6, symbol: 'USDT', name: 'Tether USD' }),
+      })
+    );
+
+    expect(route.settlementCurrencyId).toBe(CurrencyID.USDT);
+    expect(
+      vi.mocked(liquidateInputHoldings).mock.calls[0][0].holdings.map(
+        (holding: { tokenAddress: Hex }) => holding.tokenAddress
+      )
+    ).toEqual([USDC_OP]);
+    expect(route.destination.swap.tokenSwap).toBeNull();
+    expect(route.destination.inputAmount.max.toFixed()).toBe('6');
+  });
+  it('EXACT_IN keeps destination-token holdings as identity output', async () => {
+    const input: SwapData = {
+      mode: SwapMode.EXACT_IN,
+      data: {
+        sources: [
+          { chainId: ARB_CHAIN, tokenAddress: USDC_ARB, amountRaw: 3_000_000n },
+          { chainId: BASE_CHAIN, tokenAddress: USDT_BASE, amountRaw: 2_000_000n },
+        ],
+        toChainId: BASE_CHAIN,
+        toTokenAddress: USDT_BASE,
+      },
+    };
+    vi.mocked(destinationSwapWithExactIn).mockResolvedValue(
+      makeDestinationQuoteResponse({
+        chainID: BASE_CHAIN,
+        quote: {
+          input: { contractAddress: USDC_BASE, amount: '3', amountRaw: 3_000_000n, decimals: 6, value: 3, symbol: 'USDC' },
+          output: { contractAddress: USDT_BASE, amount: '3', amountRaw: 3_000_000n, decimals: 6, value: 3, symbol: 'USDT' },
+        } as never,
+      })
+    );
+    const options = makeRouteOptions({
+      chainList: makeSwapChainListWithUsdtCot(),
+      balances: [
+        { amount: '3', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDC', tokenAddress: USDC_ARB, value: 3, logo: '', name: 'USD Coin' },
+        { amount: '2', chainID: BASE_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_BASE, value: 2, logo: '', name: 'Tether USD' },
+      ],
+      dstTokenInfo: makeDstTokenInfo({ contractAddress: USDT_BASE, decimals: 6, symbol: 'USDT', name: 'Tether USD' }),
+    });
+
+    const route = await determineSwapRoute(input, options);
+    const intent = createSwapIntent(route, input, options.chainList);
+
+    expect(route.destination.identityOutput).toEqual({
+      amountRaw: 2_000_000n,
+      amount: new Decimal(2),
+      value: new Decimal(2),
+    });
+    expect(route.destination.inputAmount.max.toFixed()).toBe('3');
+    expect(route.extras.assetsUsed).toHaveLength(2);
+    expect(route.source.swaps).toHaveLength(0);
+    expect(intent.destination.amount).toBe('5');
+    expect(intent.destination.value).toBe('5');
+  });
+  it('EXACT_IN fails when the selected-family bridge quote is unavailable', async () => {
     const input: SwapData = {
       mode: SwapMode.EXACT_IN,
       data: {
@@ -1264,25 +1598,23 @@ describe('determineSwapRoute', () => {
         toTokenAddress: WETH,
       },
     };
-    // Default (USDC) COT-flow mocks so the fell-through route completes: liquidate USDT→USDC, dst swap.
     vi.mocked(liquidateInputHoldings).mockResolvedValue([makeQuoteResponse({ chainID: ARB_CHAIN })]);
     vi.mocked(destinationSwapWithExactIn).mockResolvedValue(makeDestinationQuoteResponse({ chainID: BASE_CHAIN }));
-    const getQuote = vi.fn().mockResolvedValue(null); // F-quote fails → B2 returns null → fallback
-    const route = await determineSwapRoute(input, makeRouteOptions({
-      chainList: makeSwapChainListWithUsdtCot(),
-      middlewareClient: { ...mockMiddleware, getQuote } as never,
-      balances: [
-        { amount: '1', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_ARB, value: 1, logo: '', name: 'Tether USD' },
-        { amount: '1', chainID: OP_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_OP, value: 1, logo: '', name: 'Tether USD' },
-      ],
-      dstTokenInfo: makeDstTokenInfo({ contractAddress: WETH, decimals: 18, symbol: 'WETH', name: 'Wrapped Ether' }),
-    }));
-    // Default flow settles in USDC and liquidates the USDT sources.
-    expect(route.settlementCurrencyId).toBe(CurrencyID.USDC);
-    expect(liquidateInputHoldings).toHaveBeenCalled();
+    const getQuote = vi.fn().mockResolvedValue(null);
+    await expect(
+      determineSwapRoute(input, makeRouteOptions({
+        chainList: makeSwapChainListWithUsdtCot(),
+        middlewareClient: { ...mockMiddleware, getQuote } as never,
+        balances: [
+          { amount: '1', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_ARB, value: 1, logo: '', name: 'Tether USD' },
+          { amount: '1', chainID: OP_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_OP, value: 1, logo: '', name: 'Tether USD' },
+        ],
+        dstTokenInfo: makeDstTokenInfo({ contractAddress: WETH, decimals: 18, symbol: 'WETH', name: 'Wrapped Ether' }),
+      }))
+    ).rejects.toThrow(/bridge fee quote unavailable/i);
+    expect(liquidateInputHoldings).not.toHaveBeenCalled();
   });
-  it('B2 skipFastPaths stops the re-entry recursion — dynamic-cot-eligible sources run the default COT flow', async () => {
-    // The B2 re-entry sets skipFastPaths; the re-entered call must NOT re-classify (else it would loop).
+  it('least-swap settlement still runs when terminal fast paths are disabled', async () => {
     const input: SwapData = {
       mode: SwapMode.EXACT_IN,
       data: {
@@ -1307,9 +1639,8 @@ describe('determineSwapRoute', () => {
       ],
       dstTokenInfo: makeDstTokenInfo({ contractAddress: WETH, decimals: 18, symbol: 'WETH', name: 'Wrapped Ether' }),
     }));
-    // No re-classification → default USDC flow, no F-quote fetched.
-    expect(route.settlementCurrencyId).toBe(CurrencyID.USDC);
-    expect(getQuote).not.toHaveBeenCalled();
+    expect(route.settlementCurrencyId).toBe(CurrencyID.USDT);
+    expect(getQuote).toHaveBeenCalled();
   });
   it('EXACT_IN mixed: dst-chain SOURCE SWAP output is counted in destination amount', async () => {
     // Mirrors the reported intent: ETH on the dst chain (Base) swaps to USDC locally, while
@@ -1618,7 +1949,7 @@ describe('determineSwapRoute', () => {
       data: {
         sources: [{ chainId: ARB_CHAIN, tokenAddress: WETH, amountRaw: 1000000000000000000n }],
         toChainId: ARB_CHAIN,
-        toTokenAddress: WETH,
+        toTokenAddress: DAI,
       },
     };
     vi.mocked(liquidateInputHoldings).mockResolvedValue([makeQuoteResponse()]);
@@ -1626,9 +1957,11 @@ describe('determineSwapRoute', () => {
     const route = await determineSwapRoute(
       input,
       makeRouteOptions({
+        skipFastPaths: true,
         balances: [
           { amount: '1', chainID: ARB_CHAIN, decimals: 18, symbol: 'WETH', tokenAddress: WETH, value: 3000, logo: '', name: 'WETH' },
         ],
+        dstTokenInfo: makeDstTokenInfo({ contractAddress: DAI, decimals: 18, symbol: 'DAI', name: 'Dai' }),
       })
     );
     // cotAvailableForDestination = 3000 (all same chain, no bridge fees). No source buffer →
@@ -2876,10 +3209,34 @@ describe('determineSwapRoute', () => {
 
       expect(route.directDestination).toBe(true);
       expect(route.source.swaps).toHaveLength(1); // only WETH→PEPE, identity not swapped
-      // delivered = 1000 (swapped) + 500 (identity) = 1500 PEPE
-      expect(route.destination.inputAmount.max.toString()).toBe('1500');
+      expect(route.destination.inputAmount.max.toString()).toBe('1000');
+      expect(route.destination.identityOutput?.amount.toString()).toBe('500');
       const liqArg = vi.mocked(liquidateInputHoldings).mock.calls[0][0];
       expect(liqArg.holdings.map((h: { tokenAddress: Hex }) => h.tokenAddress)).toEqual([WETH]);
+    });
+
+    it('identity-only holdings require no execution chain', async () => {
+      const input: SwapData = {
+        mode: SwapMode.EXACT_IN,
+        data: {
+          sources: [
+            { chainId: ARB_CHAIN, tokenAddress: PEPE, amountRaw: 500000000000000000000n },
+          ],
+          toChainId: ARB_CHAIN,
+          toTokenAddress: PEPE,
+        },
+      };
+      vi.mocked(liquidateInputHoldings).mockResolvedValue([]);
+
+      const route = await determineSwapRoute(
+        input,
+        makeRouteOptions({ dstTokenInfo: pepeInfo, balances: [pepeArbBalance] })
+      );
+
+      expect(route.source.swaps).toHaveLength(0);
+      expect(route.sourceExecutionPaths.size).toBe(0);
+      expect(route.destination.inputAmount.max.toString()).toBe('0');
+      expect(route.destination.identityOutput?.amount.toString()).toBe('500');
     });
 
     it('does NOT fire when the destination token is the COT (needsTokenSwap false) — default COT-dst flow', async () => {
@@ -2921,7 +3278,7 @@ describe('determineSwapRoute', () => {
       expect(destinationSwapWithExactIn).toHaveBeenCalled();
     });
 
-    it('is skipped when skipFastPaths is set (B2 re-entry guard)', async () => {
+    it('is skipped when skipFastPaths is set', async () => {
       const input: SwapData = {
         mode: SwapMode.EXACT_IN,
         data: { sources: [{ chainId: ARB_CHAIN, tokenAddress: WETH, amountRaw: 1000000000000000000n }], toChainId: ARB_CHAIN, toTokenAddress: PEPE },
@@ -3458,7 +3815,7 @@ describe('determineSwapRoute', () => {
           { chainId: BASE_CHAIN, tokenAddress: USDC_BASE, amountRaw: 10000000n },
         ],
         toChainId: BASE_CHAIN,
-        toTokenAddress: WETH,
+        toTokenAddress: DAI,
       },
     };
     vi.mocked(liquidateInputHoldings).mockResolvedValue([]);
@@ -3741,7 +4098,7 @@ describe('determineSwapRoute', () => {
       data: {
         sources: [{ chainId: ARB_CHAIN, tokenAddress: WETH, amountRaw: 1000000000000000000n }],
         toChainId: ARB_CHAIN,
-        toTokenAddress: WETH,
+        toTokenAddress: DAI,
       },
     };
     vi.mocked(liquidateInputHoldings).mockResolvedValue([makeQuoteResponse()]);
@@ -3752,6 +4109,8 @@ describe('determineSwapRoute', () => {
       ...makeRouteOptions({
         eoaAddress,
         safeAddress,
+        skipFastPaths: true,
+        dstTokenInfo: makeDstTokenInfo({ contractAddress: DAI, decimals: 18, symbol: 'DAI', name: 'Dai' }),
         balances: [{ amount: '1', chainID: ARB_CHAIN, decimals: 18, symbol: 'WETH', tokenAddress: WETH, value: 3000, logo: '', name: 'WETH' }],
       }),
       quoteAddressHints: new Map([[ARB_CHAIN, EPHEMERAL_EXECUTOR]]),
@@ -4316,7 +4675,7 @@ describe('determineSwapRoute', () => {
     expect(callArgs.userAddressByChain.get(ARB_CHAIN)).toBe(safeAddress);
   });
 
-  it('throws before any planning when forceMayan and destination USDC is mayanDisabled', async () => {
+  it('throws before source selection when forceMayan and the selected settlement is mayanDisabled', async () => {
     const baseChainList = makeSwapChainList() as unknown as ChainListType;
     const chainList = {
       ...baseChainList,
@@ -4331,11 +4690,28 @@ describe('determineSwapRoute', () => {
 
     const input: SwapData = {
       mode: SwapMode.EXACT_OUT,
-      data: { toChainId: BASE_CHAIN, toTokenAddress: WETH, toAmountRaw: 1000000000000000000n },
+      data: {
+        sources: [{ chainId: ARB_CHAIN, tokenAddress: USDC_ARB }],
+        toChainId: BASE_CHAIN,
+        toTokenAddress: WETH,
+        toAmountRaw: 1000000000000000000n,
+      },
     };
+    vi.mocked(determineDestinationSwaps).mockResolvedValue(
+      makeDestinationQuoteResponse({ chainID: BASE_CHAIN })
+    );
 
     await expect(
-      determineSwapRoute(input, makeRouteOptions({ chainList, forceMayan: true }))
+      determineSwapRoute(
+        input,
+        makeRouteOptions({
+          chainList,
+          forceMayan: true,
+          balances: [
+            { amount: '4000', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDC', tokenAddress: USDC_ARB, value: 4000, logo: '', name: 'USD Coin' },
+          ],
+        })
+      )
     ).rejects.toThrow(/disabled for mayan/i);
 
     // Confirm we bailed before planning ran.
@@ -4380,8 +4756,8 @@ describe('determineSwapRoute', () => {
           { chainId: ARB_CHAIN, tokenAddress: USDC_ARB },
           { chainId: BASE_CHAIN, tokenAddress: USDC_BASE },
         ],
-        toChainId: ARB_CHAIN,
-        toTokenAddress: USDC_ARB,
+        toChainId: OP_CHAIN,
+        toTokenAddress: USDC_OP,
       },
     };
 
@@ -4393,7 +4769,7 @@ describe('determineSwapRoute', () => {
       makeRouteOptions({
         forceMayan: true,
         dstTokenInfo: makeDstTokenInfo({
-          contractAddress: USDC_ARB,
+          contractAddress: USDC_OP,
           decimals: 6,
           symbol: 'USDC',
           name: 'USD Coin',
@@ -4873,8 +5249,9 @@ describe('determineSwapRoute — bridge provider parity', () => {
 
     expect(route.bridge!.provider).toBe('mayan');
     expect(route.bridge!.amounts.tokenAmount.toFixed()).toBe('2.5');
-    expect(route.destination.inputAmount.min.toFixed()).toBe('5.5');
-    expect(route.destination.inputAmount.max.toFixed()).toBe('5.5');
+    expect(route.destination.inputAmount.min.toFixed()).toBe('2.5');
+    expect(route.destination.inputAmount.max.toFixed()).toBe('2.5');
+    expect(route.destination.identityOutput?.amount.toFixed()).toBe('3');
   });
 
   it('fast path native dst participates in provider selection (calls the provider endpoint with the normalized zero-address)', async () => {

--- a/tests/swap/route.test.ts
+++ b/tests/swap/route.test.ts
@@ -510,6 +510,7 @@ describe('determineSwapRoute', () => {
     expect(route.type).toBe(SwapMode.EXACT_OUT);
     expect(route.bridge).not.toBeNull();
     expect(route.bridge!.assets.length).toBeGreaterThan(0);
+    expect(route.source.srcBuffer?.toString()).toBe('1');
     // EXACT_OUT reclaim: bridge source actuals so every chain's extra (buffer + realized slippage)
     // consolidates at the destination (returned there by a single direct transfer at execution time).
     expect(route.source.reclaimFromActualBalance).toBe(true);
@@ -706,10 +707,10 @@ describe('determineSwapRoute', () => {
       })
     );
 
-    expect(vi.mocked(autoSelectSources).mock.calls[0][0].outputRequired.toFixed()).toBe('511.5');
+    expect(vi.mocked(autoSelectSources).mock.calls[0][0].outputRequired.toFixed()).toBe('510.5');
     expect(route.destination.inputAmount.min.toFixed()).toBe('510');
     expect(route.destination.inputAmount.max.toFixed()).toBe('510.5');
-    expect(route.buffer.amount).toBe('1.5');
+    expect(route.buffer.amount).toBe('0.5');
   });
   it('fails closed when cross-chain routing needs a bridge quote and none is available', async () => {
     const input: SwapData = {
@@ -2187,7 +2188,7 @@ describe('determineSwapRoute', () => {
     expect(route.buffer.amount).toBeDefined();
     expect(route.type).toBe(SwapMode.EXACT_OUT);
   });
-  it('EXACT_OUT applies a source buffer on top of the destination-buffered input requirement', async () => {
+  it('EXACT_OUT skips the source buffer when sources already match settlement', async () => {
     const input: SwapData = {
       mode: SwapMode.EXACT_OUT,
       data: { toChainId: ARB_CHAIN, toTokenAddress: WETH, toAmountRaw: 1000000000000000000n },
@@ -2237,7 +2238,7 @@ describe('determineSwapRoute', () => {
       input,
       makeRouteOptions({
         // This same-chain COT→WETH input would take Path A (direct swap); skip fast paths to isolate
-        // the DEFAULT-flow two-buffer math (dst buffer + source buffer in COT units) under test here.
+        // the default COT route and its destination-only buffer.
         skipFastPaths: true,
         balances: [
           {
@@ -2255,10 +2256,108 @@ describe('determineSwapRoute', () => {
     );
     expect(
       vi.mocked(autoSelectSources).mock.calls[0][0].outputRequired.toString()
-    ).toBe('3102');
+    ).toBe('3101');
     expect(route.destination.inputAmount.min.toString()).toBe('3100');
     expect(route.destination.inputAmount.max.toString()).toBe('3101');
-    expect(route.buffer.amount).toBe('2');
+    expect(route.source.srcBuffer?.toString()).toBe('0');
+    expect(route.buffer.amount).toBe('1');
+  });
+
+  it('EXACT_OUT uses a reduced source buffer for stable-only conversions', async () => {
+    const input: SwapData = {
+      mode: SwapMode.EXACT_OUT,
+      data: { toChainId: ARB_CHAIN, toTokenAddress: WETH, toAmountRaw: 1000000000000000000n },
+    };
+    vi.mocked(autoSelectSources).mockResolvedValue({
+      quoteResponses: [
+        makeQuoteResponse({
+          quote: {
+            input: {
+              contractAddress: USDT_ARB,
+              amount: '2101.25',
+              amountRaw: 2101250000n,
+              decimals: 6,
+              value: 2101.25,
+              symbol: 'USDT',
+            },
+            output: {
+              contractAddress: USDC_ARB,
+              amount: '2101.25',
+              amountRaw: 2101250000n,
+              decimals: 6,
+              value: 2101.25,
+              symbol: 'USDC',
+            },
+            txData: {
+              approvalAddress: '0x1111111111111111111111111111111111111111' as Hex,
+              tx: {
+                to: '0x2222222222222222222222222222222222222222' as Hex,
+                data: '0xabcdef' as Hex,
+                value: '0x0' as Hex,
+              },
+            },
+          },
+          holding: {
+            chainID: ARB_CHAIN,
+            tokenAddress: USDT_ARB,
+            amountRaw: 2101250000n,
+            decimals: 6,
+            symbol: 'USDT',
+          },
+        }),
+      ],
+      usedCOTs: [
+        {
+          holding: {
+            chainID: ARB_CHAIN,
+            tokenAddress: USDC_ARB,
+            amountRaw: 1000000000n,
+            decimals: 6,
+            symbol: 'USDC',
+          },
+          amountUsed: new Decimal('1000'),
+          idx: 0,
+        },
+      ],
+    });
+    vi.mocked(determineDestinationSwaps).mockResolvedValue(
+      makeDestinationQuoteResponse({ chainID: ARB_CHAIN })
+    );
+
+    const route = await determineSwapRoute(
+      input,
+      makeRouteOptions({
+        skipFastPaths: true,
+        balances: [
+          {
+            amount: '1000',
+            chainID: ARB_CHAIN,
+            decimals: 6,
+            symbol: 'USDC',
+            tokenAddress: USDC_ARB,
+            value: 1000,
+            logo: '',
+            name: 'USDC',
+          },
+          {
+            amount: '5000',
+            chainID: ARB_CHAIN,
+            decimals: 6,
+            symbol: 'USDT',
+            tokenAddress: USDT_ARB,
+            value: 5000,
+            logo: '',
+            name: 'USDT',
+          },
+        ],
+      })
+    );
+
+    expect(vi.mocked(autoSelectSources).mock.calls[0][0].outputRequired.toString()).toBe(
+      '3101.25'
+    );
+    expect(route.source.srcBuffer?.toString()).toBe('0.25');
+    expect(route.buffer.amount).toBe('1.25');
   });
   it('EXACT_OUT applies sources as an allowlist before source selection', async () => {
     const input: SwapData = {
@@ -5030,7 +5129,7 @@ describe('determineSwapRoute — bridge provider parity', () => {
     expect(req.destination.chain_id).toBe(toHex(BASE_CHAIN));
   });
 
-  it('EXACT_OUT sends the bridged (non-dst) rough prefix as the amount and still buffers autoSelect', async () => {
+  it('EXACT_OUT sends the bridged rough prefix as the amount without buffering direct COT sources', async () => {
     const input: SwapData = {
       mode: SwapMode.EXACT_OUT,
       data: { toChainId: ARB_CHAIN, toTokenAddress: WETH, toAmountRaw: 1000000000000000000n },
@@ -5063,16 +5162,16 @@ describe('determineSwapRoute — bridge provider parity', () => {
     // Bridged prefix excludes the $1000 dst-chain holding → $5000 raw (not $6000).
     expect(req.destination.amount).toBe('5000000000');
     expect(equalFold(req.destination.contract_address, USDC_ARB)).toBe(true);
-    // autoSelect still gets the full buffered requirement (3100 + buffers).
-    expect(vi.mocked(autoSelectSources).mock.calls[0][0].outputRequired.toString()).toBe('3102');
+    // autoSelect gets the destination-buffered requirement; direct COT sources need no source buffer.
+    expect(vi.mocked(autoSelectSources).mock.calls[0][0].outputRequired.toString()).toBe('3101');
   });
 
   it('EXACT_OUT Mayan: folds the pre-estimated bridge fee (input − minReceived) into the source selection', async () => {
     // Before the real source quoting, the route rough-selects ~110% of the 1000 USDC requirement,
     // quotes Mayan, and folds the haircut (a flat $22 on the 1100 rough leg) into the target that
     // autoSelectSources must cover — so the real selection produces enough COT to survive the bridge
-    // fee. With no destination swap, net dst-need + source buffer is 1001; with the fee,
-    // autoSelect is asked for 1023.
+    // fee. With no destination or source swap, the net destination need is 1000; with the fee,
+    // autoSelect is asked for 1022.
     const mayanMw = {
       getBridgeProvider: vi.fn().mockResolvedValue({ provider: 'mayan' }),
       getMayanQuotes: vi.fn().mockImplementation(
@@ -5116,7 +5215,7 @@ describe('determineSwapRoute — bridge provider parity', () => {
     );
     expect(autoSelectSources).toHaveBeenCalled();
     const { outputRequired } = vi.mocked(autoSelectSources).mock.calls[0][0];
-    expect(outputRequired.toFixed()).toBe('1023');
+    expect(outputRequired.toFixed()).toBe('1022');
   });
 
   it('EXACT_OUT Mayan: estimatedFees records the haircut (gross − Σ minReceived), not Nexus fees', async () => {

--- a/tests/swap/route.test.ts
+++ b/tests/swap/route.test.ts
@@ -626,6 +626,91 @@ describe('determineSwapRoute', () => {
       )
     ).toBe(true);
   });
+  it('EXACT_OUT buffers only the gas-swap input for a COT destination with gas', async () => {
+    const input: SwapData = {
+      mode: SwapMode.EXACT_OUT,
+      data: {
+        toChainId: BASE_CHAIN,
+        toTokenAddress: USDC_BASE,
+        toAmountRaw: 500_000_000n,
+        toNativeAmountRaw: 1_000_000_000_000_000n,
+      },
+    };
+    vi.mocked(destinationGasSwapExactIn).mockResolvedValue(
+      makeGasQuoteResponse({
+        chainID: BASE_CHAIN,
+        inputAmountRaw: 10_000_000n,
+        inputAmount: '10',
+        inputContract: USDC_BASE,
+      })
+    );
+    vi.mocked(autoSelectSources).mockResolvedValue({
+      quoteResponses: [],
+      usedCOTs: [
+        {
+          holding: {
+            chainID: ARB_CHAIN,
+            tokenAddress: USDC_ARB,
+            amountRaw: 600_000_000n,
+            decimals: 6,
+            symbol: 'USDC',
+          },
+          amountUsed: new Decimal('513'),
+          idx: 0,
+        },
+      ],
+    });
+
+    const route = await determineSwapRoute(
+      input,
+      makeRouteOptions({
+        skipFastPaths: true,
+        dstTokenInfo: makeDstTokenInfo({
+          contractAddress: USDC_BASE,
+          decimals: 6,
+          symbol: 'USDC',
+          name: 'USD Coin',
+        }),
+        oraclePrices: [
+          {
+            universe: 'EVM',
+            chainId: BASE_CHAIN,
+            priceUsd: new Decimal('2500'),
+            tokenAddress: ZERO_ADDRESS,
+            tokenSymbol: 'ETH',
+            tokenDecimals: 18,
+            timestamp: 0,
+          },
+          {
+            universe: 'EVM',
+            chainId: BASE_CHAIN,
+            priceUsd: new Decimal('1'),
+            tokenAddress: USDC_BASE,
+            tokenSymbol: 'USDC',
+            tokenDecimals: 6,
+            timestamp: 0,
+          },
+        ],
+        balances: [
+          {
+            amount: '600',
+            chainID: ARB_CHAIN,
+            decimals: 6,
+            symbol: 'USDC',
+            tokenAddress: USDC_ARB,
+            value: 600,
+            logo: '',
+            name: 'USDC',
+          },
+        ],
+      })
+    );
+
+    expect(vi.mocked(autoSelectSources).mock.calls[0][0].outputRequired.toFixed()).toBe('511.5');
+    expect(route.destination.inputAmount.min.toFixed()).toBe('510');
+    expect(route.destination.inputAmount.max.toFixed()).toBe('510.5');
+    expect(route.buffer.amount).toBe('1.5');
+  });
   it('fails closed when cross-chain routing needs a bridge quote and none is available', async () => {
     const input: SwapData = {
       mode: SwapMode.EXACT_OUT,
@@ -1837,10 +1922,10 @@ describe('determineSwapRoute', () => {
     );
     expect(
       vi.mocked(autoSelectSources).mock.calls[0][0].outputRequired.toString()
-    ).toBe('3103');
+    ).toBe('3102');
     expect(route.destination.inputAmount.min.toString()).toBe('3100');
-    expect(route.destination.inputAmount.max.toString()).toBe('3102');
-    expect(route.buffer.amount).toBe('3');
+    expect(route.destination.inputAmount.max.toString()).toBe('3101');
+    expect(route.buffer.amount).toBe('2');
   });
   it('EXACT_OUT applies sources as an allowlist before source selection', async () => {
     const input: SwapData = {
@@ -3774,7 +3859,7 @@ describe('determineSwapRoute', () => {
     expect(accepted?.tokenSwap).not.toBeNull();
   });
   it('EXACT_OUT getDstSwap keeps the original buffered max on an accepted requote (buffer applied once)', async () => {
-    // The dst buffer (min 10% / $2) is applied exactly once when the route is built.
+    // The dst buffer (min 5% / $1) is applied exactly once when the route is built.
     // A requote that moves `min` but stays within the frozen original max must NOT re-add
     // the buffer to `max` — otherwise the ceiling would creep up on every requote.
     const input: SwapData = {
@@ -3792,7 +3877,7 @@ describe('determineSwapRoute', () => {
       ],
     });
     vi.mocked(determineDestinationSwaps)
-      // Initial build: input 3100 → dst buffer 2 → originalDestinationMaxInput = 3102.
+      // Initial build: input 3100 → dst buffer 1 → originalDestinationMaxInput = 3101.
       .mockResolvedValueOnce(
         makeDestinationQuoteResponse({
           chainID: ARB_CHAIN,
@@ -3806,7 +3891,7 @@ describe('determineSwapRoute', () => {
           },
         })
       )
-      // Requote: input 3101 — changed, but still ≤ 3102, so it is accepted.
+      // Requote: input 3101 — changed, but still ≤ 3101, so it is accepted.
       .mockResolvedValueOnce(
         makeDestinationQuoteResponse({
           chainID: ARB_CHAIN,
@@ -3827,7 +3912,7 @@ describe('determineSwapRoute', () => {
         balances: [{ amount: '4000', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDC', tokenAddress: USDC_ARB, value: 4000, logo: '', name: 'USDC' }],
       })
     );
-    expect(route.destination.inputAmount.max.toString()).toBe('3102');
+    expect(route.destination.inputAmount.max.toString()).toBe('3101');
     const routerExclusions = new Map<Aggregator, string[]>([
       [{} as Aggregator, ['uniswap-v3']],
     ]);
@@ -3839,11 +3924,11 @@ describe('determineSwapRoute', () => {
     );
     // min tracks the fresh requote; max stays pinned at the original buffered ceiling.
     expect(route.destination.inputAmount.min.toString()).toBe('3101');
-    expect(route.destination.inputAmount.max.toString()).toBe('3102');
+    expect(route.destination.inputAmount.max.toString()).toBe('3101');
   });
   it('EXACT_OUT getDstSwap requotes the gas swap and rejects when its input drifts past the buffered max budget', async () => {
-    // Initial: token swap input 3100 + gas swap input 22 = 3122 → dst buffer 2 → max 3124.
-    // Requote: token 3100 + gas 30 = 3130 → exceeds 3124, must throw.
+    // Initial: token swap input 3100 + gas swap input 22 = 3122 → dst buffer 1 → max 3123.
+    // Requote: token 3100 + gas 30 = 3130 → exceeds 3123, must throw.
     const input: SwapData = {
       mode: SwapMode.EXACT_OUT,
       data: {
@@ -3904,14 +3989,14 @@ describe('determineSwapRoute', () => {
         balances: [{ amount: '4000', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDC', tokenAddress: USDC_ARB, value: 4000, logo: '', name: 'USDC' }],
       })
     );
-    // Initial: token 3100 + gas 22 = 3122; dst buffer = min(10%, $2) → $2 → max = 3124.
+    // Initial: token 3100 + gas 22 = 3122; dst buffer = min(5%, $1) → $1 → max = 3123.
     expect(route.destination.swap.gasSwap?.quote.input.amountRaw).toBe(22_000_000n);
     expect(route.destination.inputAmount.min.toString()).toBe('3122');
-    expect(route.destination.inputAmount.max.toString()).toBe('3124');
+    expect(route.destination.inputAmount.max.toString()).toBe('3123');
     await expect(route.destination.getDstSwap(0n)).rejects.toThrow(/max budget/i);
   });
   it('EXACT_OUT getDstSwap accepts a gas-swap requote when total input stays under the buffered max', async () => {
-    // Initial: 3100 + 22 = 3122; max 3124. Requote: 3100 + 24 = 3124 — at the cap, accepted.
+    // Initial: 3100 + 22 = 3122; max 3123. Requote: 3100 + 23 = 3123 — at the cap, accepted.
     const input: SwapData = {
       mode: SwapMode.EXACT_OUT,
       data: {
@@ -3957,8 +4042,8 @@ describe('determineSwapRoute', () => {
         makeGasQuoteResponse({
           chainID: ARB_CHAIN,
           inputContract: USDC_ARB,
-          inputAmountRaw: 24_000_000n,
-          inputAmount: '24',
+          inputAmountRaw: 23_000_000n,
+          inputAmount: '23',
         })
       );
     const route = await determineSwapRoute(
@@ -3972,11 +4057,11 @@ describe('determineSwapRoute', () => {
         balances: [{ amount: '4000', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDC', tokenAddress: USDC_ARB, value: 4000, logo: '', name: 'USDC' }],
       })
     );
-    expect(route.destination.inputAmount.max.toString()).toBe('3124');
+    expect(route.destination.inputAmount.max.toString()).toBe('3123');
     const requoted = await route.destination.getDstSwap(0n);
-    expect(requoted?.gasSwap?.quote.input.amountRaw).toBe(24_000_000n);
-    expect(route.destination.inputAmount.min.toString()).toBe('3124');
-    expect(route.destination.inputAmount.max.toString()).toBe('3124');
+    expect(requoted?.gasSwap?.quote.input.amountRaw).toBe(23_000_000n);
+    expect(route.destination.inputAmount.min.toString()).toBe('3123');
+    expect(route.destination.inputAmount.max.toString()).toBe('3123');
   });
   it('EXACT_IN getDstSwap accepts a worsened requote (no rate tolerance guard)', async () => {
     const input: SwapData = {
@@ -4603,7 +4688,7 @@ describe('determineSwapRoute — bridge provider parity', () => {
     expect(req.destination.amount).toBe('5000000000');
     expect(equalFold(req.destination.contract_address, USDC_ARB)).toBe(true);
     // autoSelect still gets the full buffered requirement (3100 + buffers).
-    expect(vi.mocked(autoSelectSources).mock.calls[0][0].outputRequired.toString()).toBe('3103');
+    expect(vi.mocked(autoSelectSources).mock.calls[0][0].outputRequired.toString()).toBe('3102');
   });
 
   it('EXACT_OUT Mayan: folds the pre-estimated bridge fee (input − minReceived) into the source selection', async () => {

--- a/tests/swap/routing/settlement.test.ts
+++ b/tests/swap/routing/settlement.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ChainListType } from '../../../src/domain';
+import { CurrencyID } from '../../../src/swap/cot';
+import { selectStableSettlement } from '../../../src/swap/routing/settlement';
+import {
+  ARB_CHAIN,
+  BASE_CHAIN,
+  OP_CHAIN,
+  USDC_ARB,
+  USDC_BASE,
+  USDT_ARB,
+  USDT_BASE,
+  USDT_OP,
+  WETH,
+  makeSwapChainListWithUsdtCot,
+} from '../../helpers/swap';
+
+describe('selectStableSettlement', () => {
+  it('selects the family with the fewest source and destination swap legs', () => {
+    expect(
+      selectStableSettlement({
+        chainList: makeSwapChainListWithUsdtCot(),
+        currentCurrencyId: CurrencyID.USDC,
+        destinationChainId: BASE_CHAIN,
+        destinationTokenAddress: USDC_BASE,
+        scoreHoldings: [
+          { chainID: ARB_CHAIN, tokenAddress: USDT_ARB },
+          { chainID: OP_CHAIN, tokenAddress: USDT_OP },
+          { chainID: BASE_CHAIN, tokenAddress: USDT_BASE },
+          { chainID: ARB_CHAIN, tokenAddress: USDC_ARB },
+        ],
+      })
+    ).toBe(CurrencyID.USDT);
+  });
+
+  it('retains the current family on equal scores', () => {
+    expect(
+      selectStableSettlement({
+        chainList: makeSwapChainListWithUsdtCot(),
+        currentCurrencyId: CurrencyID.USDC,
+        destinationChainId: BASE_CHAIN,
+        destinationTokenAddress: WETH,
+        scoreHoldings: [
+          { chainID: ARB_CHAIN, tokenAddress: USDC_ARB },
+          { chainID: ARB_CHAIN, tokenAddress: USDT_ARB },
+        ],
+      })
+    ).toBe(CurrencyID.USDC);
+  });
+
+  it('rejects a candidate missing from any eligible source chain outside the scored prefix', () => {
+    const chainList = makeSwapChainListWithUsdtCot();
+    const getTokenByCurrencyId = chainList.getTokenByCurrencyId.bind(chainList);
+    chainList.getTokenByCurrencyId = vi.fn((chainId: number, currencyId: number) => {
+      if (chainId === OP_CHAIN && currencyId === CurrencyID.USDT) {
+        throw new Error('USDT unavailable');
+      }
+      return getTokenByCurrencyId(chainId, currencyId);
+    }) as ChainListType['getTokenByCurrencyId'];
+
+    expect(
+      selectStableSettlement({
+        chainList,
+        currentCurrencyId: CurrencyID.USDC,
+        destinationChainId: BASE_CHAIN,
+        destinationTokenAddress: USDT_BASE,
+        scoreHoldings: [{ chainID: ARB_CHAIN, tokenAddress: USDT_ARB }],
+        eligibilityHoldings: [
+          { chainID: ARB_CHAIN, tokenAddress: USDT_ARB },
+          { chainID: OP_CHAIN, tokenAddress: USDT_OP },
+        ],
+      })
+    ).toBe(CurrencyID.USDC);
+  });
+});


### PR DESCRIPTION
## Summary

Improves swap efficiency across routing and execution. Exact-Out destination buffering is reduced to `min(5%, $1)`, COT-plus-gas routes buffer only the gas-swap input, and source buffering now reflects conversion risk: zero for direct settlement sources, `min(0.5%, $0.25)` for stable-only conversions, and `min(2%, $1)` when a non-stable conversion is required. Failed source swaps also requote across every route aggregator instead of remaining pinned to the original one, while maximum-input haircut limits track the combined worst-case source and destination buffer budgets.

Routing now selects USDC or USDT by minimizing required source and destination swap legs. Destination-chain Exact-In holdings already denominated in the requested output remain untouched and are accounted for separately in intents and maximum-output calculations.

## Changes

- Reduce the Exact-Out destination buffer from `min(10%, $2)` to `min(5%, $1)`.
- For an exact COT destination plus native gas, apply the destination buffer only to the gas-swap input while keeping the requested COT amount exact.
- Size the Exact-Out source buffer by conversion risk: zero when selected sources already match the settlement token, `min(0.5%, $0.25)` for USDC/USDT-only conversions, and `min(2%, $1)` when any non-stable source conversion is required.
- Requote safely retryable source-swap failures across all aggregators available to the route, exclude the failed router from its original aggregator, and select the highest-output replacement quote.
- Derive the maximum-input swap haircut from the combined source and destination buffers, currently `max(7%, $2)`.
- Add a shared deterministic stable-settlement selector for USDC and USDT, retaining the current COT when scores tie.
- Preserve direct-destination and same-token bridge precedence, including ETH same-token bridging, while removing the recursive dynamic-COT route builders and classifier branch.
- Select the settlement family before aggregator quoting and fail routing when its required bridge quote is unavailable.
- Use the priced rough source prefix for Exact-Out scoring, retain the current COT for unpriced requirements, and require candidate availability across every usable source chain.
- Keep destination-chain Exact-In output-token holdings at the EOA with no swap, bridge, plan step, Safe deployment, or transaction.
- Include untouched identity output in `assetsUsed`, approval intents, and `calculateMaxForSwap`, applying haircuts only to the routed portion.
- Validate forced-Mayan support against the route-selected settlement token.
- Update routing documentation and characterization coverage for settlement selection, identity passthrough, execution, cleanup, and max-output accounting.

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

## Risk / Impact

- Exact-Out routes have a smaller destination drift allowance, reducing overfunding while leaving less headroom for execution-time rate movement.
- Exact-Out routes with direct settlement or stable-only sources have less source re-quote headroom; direct sources receive no source buffer and stable-only conversions are capped at `min(0.5%, $0.25)`.
- A retried source swap may switch aggregators when another route aggregator returns a higher output; the failed router remains excluded only from its owning aggregator.
- Maximum-input calculations now reserve the combined `7%` / `$2` route buffer budget instead of the previous fixed `3%` / `$3` haircut.
- Routes may now bridge USDT instead of the current USDC COT when doing so requires fewer swap legs; ties remain on the current COT.
- Exact-Out family selection depends on destination USD pricing. Unpriced requirements retain the current COT.
- A missing bridge quote for the selected family now fails routing instead of retrying another family.
- Mixed Exact-In routes no longer move destination-chain holdings already matching the requested output; displayed and maximum output still include them.
- No public API signatures or exports change.