### PR TITLE
swap: route bridges without source swaps through the user EOA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1709,7 +1709,7 @@ Swap plans contain the following step types:
 | Step Type | Description |
 |-----------|-------------|
 | `source_swap` | Execute a swap through the Safe on a source chain |
-| `eoa_to_ephemeral_transfer` | Move EOA-held bridge funds to the ephemeral bridge holder |
+| `eoa_to_ephemeral_transfer` | Move EOA-held bridge funds to the ephemeral holder for a non-direct bridge |
 | `bridge_deposit` | Deposit into vault for cross-chain bridge |
 | `bridge_intent_submission` | Submit the bridge intent to the network |
 | `bridge_fill` | Wait for bridge fill on destination chain |
@@ -2290,6 +2290,12 @@ Token-only Safe transactions are sponsor-broadcast through middleware. Native-va
 transactions are submitted by the EOA because the outer transaction must fund the Safe call. The
 ephemeral account remains an owner/signing identity and may hold remote bridge settlement funds; it
 is never the swap executor.
+
+When a swap route is a direct bridge with no source or destination swap, it follows the normal bridge
+custody path instead: the connected EOA owns and signs the RFF and authorizes the vault directly.
+This applies to Nexus and Mayan, including direct routes nested inside `swapAndExecute`. The route
+does not transfer funds to the ephemeral holder or require a Safe on its source chains. Swap intent
+fields and plan step types are unchanged; the `eoa_to_ephemeral_transfer` step is simply absent.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1709,7 +1709,7 @@ Swap plans contain the following step types:
 | Step Type | Description |
 |-----------|-------------|
 | `source_swap` | Execute a swap through the Safe on a source chain |
-| `eoa_to_ephemeral_transfer` | Move EOA-held bridge funds to the ephemeral holder for a non-direct bridge |
+| `eoa_to_ephemeral_transfer` | Move EOA-held bridge funds to the ephemeral holder when source swaps are required |
 | `bridge_deposit` | Deposit into vault for cross-chain bridge |
 | `bridge_intent_submission` | Submit the bridge intent to the network |
 | `bridge_fill` | Wait for bridge fill on destination chain |
@@ -2291,11 +2291,14 @@ transactions are submitted by the EOA because the outer transaction must fund th
 ephemeral account remains an owner/signing identity and may hold remote bridge settlement funds; it
 is never the swap executor.
 
-When a swap route is a direct bridge with no source or destination swap, it follows the normal bridge
-custody path instead: the connected EOA owns and signs the RFF and authorizes the vault directly.
-This applies to Nexus and Mayan, including direct routes nested inside `swapAndExecute`. The route
-does not transfer funds to the ephemeral holder or require a Safe on its source chains. Swap intent
-fields and plan step types are unchanged; the `eoa_to_ephemeral_transfer` step is simply absent.
+When a swap route bridges without source swaps, it follows the normal bridge custody path: the
+connected EOA owns and signs the RFF and authorizes the vault directly. This applies to Nexus and
+Mayan, including routes nested inside `swapAndExecute`. The route does not transfer source funds to
+the ephemeral holder or require a Safe on its source chains. If a destination swap is required, the
+bridge still fills the destination Safe; otherwise it fills the EOA. Exact-out same-token routes can
+also request destination gas through the bridge intent and fill both outputs directly to the EOA.
+Swap intent fields and plan step types are unchanged; the `eoa_to_ephemeral_transfer` step is simply
+absent.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,12 +160,13 @@ swap(params)
 `swapAndExecute` composes swap planning with an execution request on the destination chain.
 `calculateMaxForSwap` reuses swap preflight and route logic to estimate the maximum usable input.
 
-A direct bridge route is identified by its execution shape: it has a bridge but no source or
-destination swap. This includes the same-token fast paths and a COT-to-COT bridge. These routes use
-the normal bridge custody model: the connected EOA is the source holder, RFF party, and signer;
-ERC-20 allowance targets the vault; native deposits are sent directly by the EOA. They do not
-prepare EOA-to-ephemeral transfers or deploy a Safe. The public swap intent and step types remain
-unchanged, and `swapAndExecute` inherits the behavior through its nested swap route.
+A bridge route with no source swaps uses the normal bridge custody model: the connected EOA is the
+source holder, RFF party, and signer; ERC-20 allowance targets the vault; native deposits are sent
+directly by the EOA. It does not prepare EOA-to-ephemeral transfers or deploy a Safe on its source
+chains. The bridge fills the destination Safe when a destination swap is required and the EOA
+otherwise. Terminal same-token Exact Out routes can request destination gas through the bridge
+intent and deliver both token and native outputs directly to the EOA. The public swap intent and
+step types remain unchanged, and `swapAndExecute` inherits the behavior through its nested route.
 
 Swap preflight does not request bridge-fee quotes. After terminal direct/same-token paths, routing
 chooses between USDC and USDT by counting required source and destination swap legs; ties retain the
@@ -192,8 +193,8 @@ the chain promise before requesting any permit, direct approval, or EOA transact
 resolve the spender to deployed contract code without repeated Safe bytecode reads. Safe owners are
 the connected EOA and the SDK ephemeral account at threshold 1. Token-only batches are
 sponsor-broadcast; batches carrying native value are wrapped in `Safe.execTransaction` and submitted
-by the EOA. Direct bridge source chains bypass this Safe path and reuse the bridge allowance and
-execution modules with the EOA wallet.
+by the EOA. Bridge source chains without source swaps bypass this Safe path and reuse the bridge
+allowance and execution modules with the EOA wallet.
 
 Bridge funding preparation retries only transient permit-path RPC work, with three total attempts.
 Direct approvals and wallet rejections are terminal. Ambiguous Safe middleware failures are not

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,6 +160,13 @@ swap(params)
 `swapAndExecute` composes swap planning with an execution request on the destination chain.
 `calculateMaxForSwap` reuses swap preflight and route logic to estimate the maximum usable input.
 
+A direct bridge route is identified by its execution shape: it has a bridge but no source or
+destination swap. This includes the same-token fast paths and a COT-to-COT bridge. These routes use
+the normal bridge custody model: the connected EOA is the source holder, RFF party, and signer;
+ERC-20 allowance targets the vault; native deposits are sent directly by the EOA. They do not
+prepare EOA-to-ephemeral transfers or deploy a Safe. The public swap intent and step types remain
+unchanged, and `swapAndExecute` inherits the behavior through its nested swap route.
+
 Swap preflight does not request bridge-fee quotes. After terminal direct/same-token paths, routing
 chooses between USDC and USDT by counting required source and destination swap legs; ties retain the
 current settlement family. Exact In scores selected holdings. Exact Out scores its priced
@@ -177,15 +184,16 @@ prompts, permit signatures, direct approvals, and EOA transaction dispatch. Swap
 parallelize non-EOA work such as route requests, public-client reads, per-chain Safe deployment,
 sponsored Safe execution, and receipt waits.
 
-Safe V2 is the only swap execution account. The flow derives its address once, then checks bytecode
-on every execution chain as part of the read-only cache warmup while the intent is displayed. After
+Safe V2 is the only aggregator-swap execution account. The flow derives its address once, then
+checks bytecode on every Safe execution chain as part of the read-only cache warmup while the intent is displayed. After
 intent approval, already deployed Safes skip middleware and absent Safes are ensured concurrently.
 A successful ensure marks the shared cache deployed for that chain. Preparation and execution await
 the chain promise before requesting any permit, direct approval, or EOA transaction, so wallet UIs
 resolve the spender to deployed contract code without repeated Safe bytecode reads. Safe owners are
 the connected EOA and the SDK ephemeral account at threshold 1. Token-only batches are
 sponsor-broadcast; batches carrying native value are wrapped in `Safe.execTransaction` and submitted
-by the EOA.
+by the EOA. Direct bridge source chains bypass this Safe path and reuse the bridge allowance and
+execution modules with the EOA wallet.
 
 Bridge funding preparation retries only transient permit-path RPC work, with three total attempts.
 Direct approvals and wallet rejections are terminal. Ambiguous Safe middleware failures are not

--- a/src/swap/bridge-intent.ts
+++ b/src/swap/bridge-intent.ts
@@ -58,10 +58,10 @@ const toBridgeIntentChain = (
  * (executeBridgeFromIntent, runBridgeHooks, etc.).
  *
  * Differences from regular bridge intent:
- * - Sources = post-swap ephemeral balances (bridge.assets)
+ * - Sources = swap route bridge assets
  * - Recipient = dynamic (EOA or ephemeral)
  * - Ethereum chain sorted last (most expensive)
- * - Fee stubs all zero (TODO: fees)
+ * - Holder = ephemeral for composed routes, EOA for direct bridge routes
  */
 export const createSwapBridgeIntent = (params: {
   bridge: NonNullable<SwapRoute['bridge']>;
@@ -69,6 +69,7 @@ export const createSwapBridgeIntent = (params: {
   chainList: ChainListType;
   recipient: Hex;
   ephemeralAddress: Hex;
+  holderAddress?: Hex;
 }): BridgeIntentDraft => {
   const { bridge, assets, chainList, recipient, ephemeralAddress } = params;
   const totalBridgedAmount = assets.reduce(
@@ -80,6 +81,7 @@ export const createSwapBridgeIntent = (params: {
       ? computeNexusBridgeFees({
           nexusFeeModel: bridge.nexusFeeModel,
           grossBridged: totalBridgedAmount,
+          collectionFee: bridge.estimatedFees.collection,
         }).estimatedFees
       : bridge.estimatedFees;
   // Gas-swap COT (`bridge.amounts.gasInCot`) is still bridged — it funds the dst gas swap.
@@ -114,11 +116,9 @@ export const createSwapBridgeIntent = (params: {
     return bTotal.comparedTo(aTotal);
   });
 
-  // Bridge funding always flows through the ephemeral identity — RFF `parties` come from the
-  // ephemeral bridge holder, and the Safe deposit batch moves funds from there. Deposit fees
-  // are always zero in this model because the bridge intent is sponsor-relayed; no on-chain
-  // ERC-20 transfer from the EOA happens during bridging.
-  const holderAddress = ephemeralAddress;
+  // Composed routes bridge from the ephemeral holder. Direct bridge routes pass the EOA holder and
+  // retain the normal bridge collection fee on each source.
+  const holderAddress = params.holderAddress ?? ephemeralAddress;
   const lookupMayanQuote = (asset: BridgeAsset) => {
     if (bridge.provider !== 'mayan') return undefined;
     const key = `${asset.chainID}:${asset.contractAddress.toLowerCase()}`;
@@ -133,7 +133,10 @@ export const createSwapBridgeIntent = (params: {
     if (totalBalance.lte(0)) {
       return [];
     }
-    const depositFee = { amount: new Decimal(0), raw: 0n };
+    const depositFee = {
+      amount: asset.depositFee ?? new Decimal(0),
+      raw: asset.depositFeeRaw ?? 0n,
+    };
     if (depositFee.amount.gte(totalBalance)) {
       throw Errors.internal(
         `Route produced infeasible bridge asset for chain ${asset.chainID}: deposit fee ${depositFee.amount.toString()} >= balance ${totalBalance.toString()}`
@@ -142,7 +145,7 @@ export const createSwapBridgeIntent = (params: {
     const mayanQuote = lookupMayanQuote(asset);
     return [
       {
-        amountRaw: mulDecimals(totalBalance.minus(depositFee.amount), asset.decimals),
+        amountRaw: mulDecimals(totalBalance, asset.decimals) - depositFee.raw,
         chain: toBridgeIntentChain(chainList, asset.chainID),
         token: toBridgeIntentToken(chainList, asset.chainID, asset.contractAddress),
         amount: totalBalance.minus(depositFee.amount),

--- a/src/swap/bridge-intent.ts
+++ b/src/swap/bridge-intent.ts
@@ -61,7 +61,7 @@ const toBridgeIntentChain = (
  * - Sources = swap route bridge assets
  * - Recipient = dynamic (EOA or ephemeral)
  * - Ethereum chain sorted last (most expensive)
- * - Holder = ephemeral for composed routes, EOA for direct bridge routes
+ * - Holder = ephemeral for source-swap routes, EOA when the bridge has no source swaps
  */
 export const createSwapBridgeIntent = (params: {
   bridge: NonNullable<SwapRoute['bridge']>;
@@ -84,8 +84,13 @@ export const createSwapBridgeIntent = (params: {
           collectionFee: bridge.estimatedFees.collection,
         }).estimatedFees
       : bridge.estimatedFees;
-  // Gas-swap COT (`bridge.amounts.gasInCot`) is still bridged — it funds the dst gas swap.
-  // Bridge solver no longer delivers separate native gas; intent.destination.nativeAmount=0.
+  const destinationGas = bridge.destinationGas ?? {
+    amount: new Decimal(0),
+    amountRaw: 0n,
+    amountInToken: new Decimal(0),
+  };
+  // `gasInCot` funds a destination gas swap. `destinationGas.amountInToken` instead funds native
+  // gas delivered directly by the bridge.
   const executionTokenAmount = totalBridgedAmount
     .minus(effectiveFees.collection)
     .minus(effectiveFees.fulfilment)
@@ -93,7 +98,9 @@ export const createSwapBridgeIntent = (params: {
   if (executionTokenAmount.isNegative()) {
     throw new Error('Bridge token amount cannot be negative after fee deduction');
   }
-  const expectedExecutionCot = bridge.amounts.tokenAmount.plus(bridge.amounts.gasInCot);
+  const expectedExecutionCot = bridge.amounts.tokenAmount
+    .plus(bridge.amounts.gasInCot)
+    .plus(destinationGas.amountInToken);
   if (
     !totalBridgedAmount.eq(bridge.amounts.totalAmount) ||
     !executionTokenAmount.eq(expectedExecutionCot)
@@ -116,7 +123,7 @@ export const createSwapBridgeIntent = (params: {
     return bTotal.comparedTo(aTotal);
   });
 
-  // Composed routes bridge from the ephemeral holder. Direct bridge routes pass the EOA holder and
+  // Source-swap routes bridge from the ephemeral holder. EOA-funded routes pass the EOA holder and
   // retain the normal bridge collection fee on each source.
   const holderAddress = params.holderAddress ?? ephemeralAddress;
   const lookupMayanQuote = (asset: BridgeAsset) => {
@@ -164,18 +171,18 @@ export const createSwapBridgeIntent = (params: {
     availableSources: sources,
     selectedSources: sources,
     destination: {
-      amountRaw: mulDecimals(executionTokenAmount, bridge.decimals),
+      amountRaw: mulDecimals(
+        bridge.destinationGas ? bridge.amounts.tokenAmount : executionTokenAmount,
+        bridge.decimals
+      ),
       chain: toBridgeIntentChain(chainList, bridge.chainID),
       token: toBridgeIntentToken(chainList, bridge.chainID, bridge.tokenAddress),
-      amount: executionTokenAmount,
+      amount: bridge.destinationGas ? bridge.amounts.tokenAmount : executionTokenAmount,
       value: new Decimal(0),
-      // Swap routes never request bridge-delivered native gas — the destination gas swap
-      // (route.destination.swap.gasSwap) handles native delivery via the dst aggregator,
-      // so the wire-format native fields stay zero.
-      nativeAmount: new Decimal(0),
-      nativeAmountRaw: 0n,
+      nativeAmount: destinationGas.amount,
+      nativeAmountRaw: destinationGas.amountRaw,
       nativeAmountValue: new Decimal(0),
-      nativeAmountInToken: new Decimal(0),
+      nativeAmountInToken: destinationGas.amountInToken,
       nativeToken: toBridgeIntentTokenFromMetadata(chainList.getNativeToken(bridge.chainID)),
       universe: Universe.ETHEREUM,
     },

--- a/src/swap/execution/bridge.ts
+++ b/src/swap/execution/bridge.ts
@@ -761,12 +761,15 @@ export const refreshMayanQuotesForExecution = async (
   middlewareClient: ExecutionContext['middlewareClient']
 ): Promise<NonNullable<SwapRoute['bridge']>> => {
   const quotes = await quoteMayanLegs(middlewareClient, {
-    legs: bridgedAssets.map((asset) => ({
+    legs: bridgedAssets.map((asset, index) => ({
       chainId: asset.chainID,
       tokenAddress: asset.contractAddress,
       amountRaw:
         mulDecimals(asset.eoaBalance.plus(asset.ephemeralBalance), asset.decimals) -
         (asset.depositFeeRaw ?? 0n),
+      ...(index === 0 && bridge.destinationGas
+        ? { gasDrop: bridge.destinationGas.amount.toNumber() }
+        : {}),
     })),
     destination: { chainId: bridge.chainID, tokenAddress: bridge.tokenAddress },
   });

--- a/src/swap/execution/bridge.ts
+++ b/src/swap/execution/bridge.ts
@@ -8,7 +8,14 @@ import Decimal from 'decimal.js';
 import { encodeFunctionData, type Hex, type PublicClient } from 'viem';
 import type { PrivateKeyAccount } from 'viem/accounts';
 import { EVMVaultABI } from '../../abi/vault';
-import { submitRFFToMiddleware, waitForFill } from '../../bridge/executor';
+import { prepareBridgeExecution } from '../../bridge/allowances/prepare';
+import {
+  type BridgeExecutionProgressUpdate,
+  executeBridgeFromIntent,
+  submitRFFToMiddleware,
+  waitForFill,
+} from '../../bridge/executor';
+import { buildHookStateFromIntent } from '../../bridge/hooks/state';
 import { type Chain, DEFAULT_FILL_TIMEOUT_MINUTES, getLogger } from '../../domain';
 import {
   ERROR_CODES,
@@ -36,7 +43,13 @@ import {
 import { minutesFromNow } from '../../services/time';
 import { withTimingSpan } from '../../services/timing';
 import { createSwapBridgeIntent } from '../bridge-intent';
-import type { BridgeAsset, ExecutionContext, SwapMetadata, SwapRoute } from '../types';
+import type {
+  BridgeAsset,
+  ExecutionContext,
+  SwapExecutionProgressUpdate,
+  SwapMetadata,
+  SwapRoute,
+} from '../types';
 import { resolveEphemeralVaultAllowance } from '../wallet/ephemeral-vault-allowance';
 import { resolvePreparedFundingTransferCalls } from './eoa-to-ephemeral';
 import { dispatchSafeSource } from './safe-dispatch';
@@ -751,7 +764,9 @@ export const refreshMayanQuotesForExecution = async (
     legs: bridgedAssets.map((asset) => ({
       chainId: asset.chainID,
       tokenAddress: asset.contractAddress,
-      amountRaw: mulDecimals(asset.eoaBalance.plus(asset.ephemeralBalance), asset.decimals),
+      amountRaw:
+        mulDecimals(asset.eoaBalance.plus(asset.ephemeralBalance), asset.decimals) -
+        (asset.depositFeeRaw ?? 0n),
     })),
     destination: { chainId: bridge.chainID, tokenAddress: bridge.tokenAddress },
   });
@@ -759,11 +774,18 @@ export const refreshMayanQuotesForExecution = async (
     (sum, asset) => sum.plus(asset.eoaBalance).plus(asset.ephemeralBalance),
     new Decimal(0)
   );
+  const collection = bridgedAssets.reduce(
+    (sum, asset) => sum.plus(asset.depositFee ?? 0),
+    new Decimal(0)
+  );
   const protectedDelivered = quotes.reduce(
     (sum, quote) => sum.plus(new Decimal(quote.quote.minReceived.toString())),
     new Decimal(0)
   );
-  const haircut = Decimal.max(grossBridged.minus(protectedDelivered), new Decimal(0));
+  const haircut = Decimal.max(
+    grossBridged.minus(collection).minus(protectedDelivered),
+    new Decimal(0)
+  );
   return {
     ...bridge,
     amount: grossBridged,
@@ -773,9 +795,9 @@ export const refreshMayanQuotesForExecution = async (
       totalAmount: grossBridged,
     },
     estimatedFees: {
-      collection: new Decimal(0),
+      collection,
       fulfilment: new Decimal(0),
-      caGas: new Decimal(0),
+      caGas: collection,
       protocol: haircut,
       solver: new Decimal(0),
     },
@@ -783,6 +805,136 @@ export const refreshMayanQuotesForExecution = async (
       quotes.map((quote) => [`${quote.chainId}:${quote.tokenAddress.toLowerCase()}`, quote.quote])
     ),
   };
+};
+
+const forwardDirectBridgeProgress = (
+  emit: ((update: SwapExecutionProgressUpdate) => void) | undefined,
+  update: BridgeExecutionProgressUpdate
+) => {
+  if (!emit) return;
+
+  switch (update.stepType) {
+    case 'request_signing':
+      if (update.state === 'wallet_prompted') {
+        emit({ stepType: 'bridge_intent_submission', state: 'started' });
+      } else if (update.state === 'failed') {
+        emit({
+          stepType: 'bridge_intent_submission',
+          state: 'failed',
+          error: update.error,
+        });
+      }
+      return;
+    case 'request_submission':
+      if (update.state === 'completed') {
+        emit({
+          stepType: 'bridge_intent_submission',
+          state: 'completed',
+          intentRequestHash: update.intentRequestHash,
+        });
+      } else if (update.state === 'failed') {
+        emit({
+          stepType: 'bridge_intent_submission',
+          state: 'failed',
+          intentRequestHash: update.intentRequestHash,
+          error: update.error,
+        });
+      }
+      return;
+    case 'vault_deposit':
+      if (update.state === 'started' || update.state === 'wallet_prompted') {
+        emit({ stepType: 'bridge_deposit', chainId: update.chainId, state: 'started' });
+      } else if (update.state === 'submitted' || update.state === 'confirmed') {
+        emit({
+          stepType: 'bridge_deposit',
+          chainId: update.chainId,
+          state: update.state,
+          txHash: update.txHash,
+          explorerUrl: update.explorerUrl,
+        });
+      } else if (update.state === 'failed') {
+        emit({
+          stepType: 'bridge_deposit',
+          chainId: update.chainId,
+          state: 'failed',
+          error: update.error,
+          ...(update.txHash ? { txHash: update.txHash } : {}),
+          ...(update.explorerUrl ? { explorerUrl: update.explorerUrl } : {}),
+        });
+      }
+      return;
+    case 'bridge_fill':
+      emit(update);
+  }
+};
+
+const executeEoaBridgePath = async (
+  bridge: NonNullable<SwapRoute['bridge']>,
+  bridgedAssets: BridgeAsset[],
+  ctx: Pick<
+    ExecutionContext,
+    | 'chainList'
+    | 'destinationDirectEoa'
+    | 'eoaAddress'
+    | 'eoaWallet'
+    | 'ephemeralWallet'
+    | 'intentExplorerUrl'
+    | 'middlewareClient'
+    | 'onProgress'
+    | 'safeAddress'
+    | 'timing'
+  >,
+  metadata: SwapMetadata
+) => {
+  const recipient = resolveBridgeRecipient({
+    destinationDirectEoa: ctx.destinationDirectEoa,
+    eoaAddress: ctx.eoaAddress,
+    safeAddress: ctx.safeAddress,
+  });
+  const intentBridge =
+    bridge.provider === 'mayan'
+      ? await withTimingSpan(
+          ctx.timing,
+          'flow.swap.execute.bridge.refresh_mayan_quotes',
+          async () => refreshMayanQuotesForExecution(bridge, bridgedAssets, ctx.middlewareClient),
+          { tags: { provider: 'mayan', source_chain_count: bridgedAssets.length } }
+        )
+      : bridge;
+  const intent = createSwapBridgeIntent({
+    bridge: intentBridge,
+    assets: bridgedAssets,
+    chainList: ctx.chainList,
+    recipient,
+    ephemeralAddress: ctx.ephemeralWallet.address,
+    holderAddress: ctx.eoaAddress,
+  });
+  const { insufficientAllowanceSources } = await buildHookStateFromIntent(intent, {
+    chainList: ctx.chainList,
+  });
+  const dstChain = resolveChain(ctx.chainList, bridge.chainID);
+
+  await prepareBridgeExecution({
+    allowanceSelections: insufficientAllowanceSources.map(() => 'min'),
+    insufficientAllowanceSources,
+    bridge: {
+      chainList: ctx.chainList,
+      middlewareClient: ctx.middlewareClient,
+      evm: { address: ctx.eoaAddress, walletClient: ctx.eoaWallet },
+    },
+    dstChain,
+  });
+
+  const result = await executeBridgeFromIntent(intent, {
+    walletClient: ctx.eoaWallet,
+    address: ctx.eoaAddress,
+    chainList: ctx.chainList,
+    middlewareClient: ctx.middlewareClient,
+    intentExplorerUrl: ctx.intentExplorerUrl,
+    dstChain,
+    onProgress: (update) => forwardDirectBridgeProgress(ctx.onProgress, update),
+  });
+  metadata.intent_request_hash = result.requestHash;
+  metadata.has_xcs = true;
 };
 
 const executeEphemeralBridgePath = async (
@@ -1129,7 +1281,8 @@ export const executeSwapBridge = async (
     | 'safeDeploymentPromises'
     | 'timing'
   >,
-  metadata: SwapMetadata
+  metadata: SwapMetadata,
+  directEoa = false
 ): Promise<void> => {
   const bridgedAssets = assets
     .filter(
@@ -1138,6 +1291,11 @@ export const executeSwapBridge = async (
     )
     .sort((left, right) => left.chainID - right.chainID);
   if (bridgedAssets.length === 0) {
+    return;
+  }
+
+  if (directEoa) {
+    await executeEoaBridgePath(bridge, bridgedAssets, ctx, metadata);
     return;
   }
 

--- a/src/swap/execution/failure-cleanup.ts
+++ b/src/swap/execution/failure-cleanup.ts
@@ -8,28 +8,32 @@ import {
 } from '../../services/init-refund-sweep';
 import { minutesFromNow } from '../../services/time';
 import { type CurrencyID, resolveCOT } from '../cot';
-import type { ExecutionContext, SwapRoute } from '../types';
+import { type ExecutionContext, isDirectBridgeRoute, type SwapRoute } from '../types';
 import { buildEphemeralPermitCall } from '../wallet/ephemeral-permit';
 import { readSettlementBalanceRaw } from './settlement-balance';
 
 const logger = getLogger();
 
 /**
- * The currency the on-failure cleanup should sweep, or `null` to skip it. A Nexus same-token bridge
- * deposits the exact amount directly from the EOA — nothing is staged on the ephemeral — so there's
+ * The currency the on-failure cleanup should sweep, or `null` to skip it. A direct bridge deposits
+ * from the EOA — nothing is staged on the ephemeral — so there's
  * nothing to sweep. The direct-destination fast path (Path A) is one atomic batch on one chain
  * (revertOnFailure), with no later stage, so nothing ever strands there either. Every other route
- * can strand the COT (or, for a Mayan same-token bridge, the bridged family token) on a failed leg,
- * swept under the route's settlement currency.
+ * can strand the COT on a failed leg, swept under the route's settlement currency.
  */
 export const resolveFailureSweepCurrencyId = (
   route: Pick<
     SwapRoute,
-    'sameTokenBridge' | 'bridge' | 'settlementCurrencyId' | 'directDestination'
+    | 'sameTokenBridge'
+    | 'bridge'
+    | 'settlementCurrencyId'
+    | 'directDestination'
+    | 'source'
+    | 'destination'
   >
 ): CurrencyID | null => {
   if (route.directDestination) return null;
-  if (route.sameTokenBridge && route.bridge?.provider === 'nexus') return null;
+  if (isDirectBridgeRoute(route)) return null;
   return route.settlementCurrencyId as CurrencyID;
 };
 

--- a/src/swap/execution/orchestrator.ts
+++ b/src/swap/execution/orchestrator.ts
@@ -2,7 +2,7 @@ import { getLogger } from '../../domain';
 import { NexusError } from '../../domain/errors';
 import { withTimingSpan } from '../../services/timing';
 import type { BridgeAsset, ExecutionContext, SwapMetadata, SwapRoute } from '../types';
-import { SwapMode } from '../types';
+import { isDirectBridgeRoute, SwapMode } from '../types';
 import { executeSwapBridge } from './bridge';
 import { executeDestinationSwap } from './destination-swap';
 import { executeDirectDestinationExactOut } from './direct-destination';
@@ -13,8 +13,8 @@ const logger = getLogger();
 
 type SwapRouteExecutionContext = ExecutionContext & { destinationChainId: number };
 
-// Bridge funding always flows through the ephemeral identity, so executed swap output is the
-// authoritative ephemeralBalance and planned eoaBalance carries direct-COT holdings into the merge.
+// Source-swap output is held by the ephemeral identity; direct bridge routes have no source swaps,
+// so their planned EOA balances pass through this merge unchanged.
 const mergeBridgeAssets = (
   plannedAssets: BridgeAsset[],
   executedAssets: BridgeAsset[]
@@ -94,7 +94,7 @@ export const executeSwapRoute = async (
     if (bridge) {
       const bridgeAssets = mergeBridgeAssets(bridge.assets, executedSourceAssets);
       await withTimingSpan(context.timing, 'flow.swap.execute_bridge', async () =>
-        executeSwapBridge(bridge, bridgeAssets, context, metadata)
+        executeSwapBridge(bridge, bridgeAssets, context, metadata, isDirectBridgeRoute(route))
       );
     }
 

--- a/src/swap/execution/orchestrator.ts
+++ b/src/swap/execution/orchestrator.ts
@@ -2,7 +2,7 @@ import { getLogger } from '../../domain';
 import { NexusError } from '../../domain/errors';
 import { withTimingSpan } from '../../services/timing';
 import type { BridgeAsset, ExecutionContext, SwapMetadata, SwapRoute } from '../types';
-import { isDirectBridgeRoute, SwapMode } from '../types';
+import { isEoaBridgeRoute, SwapMode } from '../types';
 import { executeSwapBridge } from './bridge';
 import { executeDestinationSwap } from './destination-swap';
 import { executeDirectDestinationExactOut } from './direct-destination';
@@ -13,8 +13,8 @@ const logger = getLogger();
 
 type SwapRouteExecutionContext = ExecutionContext & { destinationChainId: number };
 
-// Source-swap output is held by the ephemeral identity; direct bridge routes have no source swaps,
-// so their planned EOA balances pass through this merge unchanged.
+// Source-swap output is held by the ephemeral identity. When no source swaps run, planned EOA
+// balances pass through this merge unchanged.
 const mergeBridgeAssets = (
   plannedAssets: BridgeAsset[],
   executedAssets: BridgeAsset[]
@@ -94,7 +94,7 @@ export const executeSwapRoute = async (
     if (bridge) {
       const bridgeAssets = mergeBridgeAssets(bridge.assets, executedSourceAssets);
       await withTimingSpan(context.timing, 'flow.swap.execute_bridge', async () =>
-        executeSwapBridge(bridge, bridgeAssets, context, metadata, isDirectBridgeRoute(route))
+        executeSwapBridge(bridge, bridgeAssets, context, metadata, isEoaBridgeRoute(route))
       );
     }
 

--- a/src/swap/intent.ts
+++ b/src/swap/intent.ts
@@ -101,6 +101,7 @@ export const createSwapIntent = (
   const nativeCurrency = dstChainData.nativeCurrency ?? { symbol: 'ETH', decimals: 18 };
   const gasOutputRaw =
     route.destination.swap.gasSwap?.quote.output.amountRaw ??
+    route.bridge?.destinationGas?.amountRaw ??
     route.source.swaps
       .filter((swap) => swap.chainID === route.destination.chainId && swap.outputRole === 'gas')
       .reduce((sum, swap) => sum + swap.quote.output.amountRaw, 0n);

--- a/src/swap/prepare.ts
+++ b/src/swap/prepare.ts
@@ -15,6 +15,7 @@ import type {
   PublicClientList,
   SwapRoute,
 } from './types';
+import { isDirectBridgeRoute } from './types';
 import { SwapCache } from './wallet/cache';
 import { buildPreparedTransfer } from './wallet/prepared-transfer';
 
@@ -162,22 +163,23 @@ const getPreparationDetails = (
         },
       ]
     : [];
-  const bridgeTransferSpecs: DeterministicTransferSpec[] =
-    input.route.bridge?.assets.flatMap((asset) => {
-      if (asset.eoaBalance.isZero() || isNativeAddress(asset.contractAddress)) return [];
-      return [
-        {
-          reason: 'bridge',
-          chainId: asset.chainID,
-          tokenAddress: asset.contractAddress,
-          tokenDecimals: asset.decimals,
-          amount: mulDecimals(asset.eoaBalance, asset.decimals),
-          eagerPermit: false,
-          targetAddress: safeAddress,
-          recipientAddress: input.ephemeralWallet.address,
-        },
-      ];
-    }) ?? [];
+  const bridgeTransferSpecs: DeterministicTransferSpec[] = isDirectBridgeRoute(input.route)
+    ? []
+    : (input.route.bridge?.assets.flatMap((asset) => {
+        if (asset.eoaBalance.isZero() || isNativeAddress(asset.contractAddress)) return [];
+        return [
+          {
+            reason: 'bridge',
+            chainId: asset.chainID,
+            tokenAddress: asset.contractAddress,
+            tokenDecimals: asset.decimals,
+            amount: mulDecimals(asset.eoaBalance, asset.decimals),
+            eagerPermit: false,
+            targetAddress: safeAddress,
+            recipientAddress: input.ephemeralWallet.address,
+          },
+        ];
+      }) ?? []);
 
   return {
     directDestinationExtras,
@@ -246,9 +248,12 @@ const queueSwapCacheQueries = (
 };
 
 const getSafeExecutionChainIds = (route: SwapRoute): number[] => {
-  const chainIds = new Set(route.sourceExecutionPaths.keys());
-  for (const asset of route.bridge?.assets ?? []) {
-    chainIds.add(asset.chainID);
+  const directBridge = isDirectBridgeRoute(route);
+  const chainIds = new Set(directBridge ? [] : route.sourceExecutionPaths.keys());
+  if (!directBridge) {
+    for (const asset of route.bridge?.assets ?? []) {
+      chainIds.add(asset.chainID);
+    }
   }
   if (route.destination.swap.tokenSwap || route.destination.swap.gasSwap) {
     chainIds.add(route.destination.chainId);

--- a/src/swap/prepare.ts
+++ b/src/swap/prepare.ts
@@ -15,7 +15,7 @@ import type {
   PublicClientList,
   SwapRoute,
 } from './types';
-import { isDirectBridgeRoute } from './types';
+import { isEoaBridgeRoute } from './types';
 import { SwapCache } from './wallet/cache';
 import { buildPreparedTransfer } from './wallet/prepared-transfer';
 
@@ -163,7 +163,7 @@ const getPreparationDetails = (
         },
       ]
     : [];
-  const bridgeTransferSpecs: DeterministicTransferSpec[] = isDirectBridgeRoute(input.route)
+  const bridgeTransferSpecs: DeterministicTransferSpec[] = isEoaBridgeRoute(input.route)
     ? []
     : (input.route.bridge?.assets.flatMap((asset) => {
         if (asset.eoaBalance.isZero() || isNativeAddress(asset.contractAddress)) return [];
@@ -248,9 +248,9 @@ const queueSwapCacheQueries = (
 };
 
 const getSafeExecutionChainIds = (route: SwapRoute): number[] => {
-  const directBridge = isDirectBridgeRoute(route);
-  const chainIds = new Set(directBridge ? [] : route.sourceExecutionPaths.keys());
-  if (!directBridge) {
+  const eoaBridge = isEoaBridgeRoute(route);
+  const chainIds = new Set(eoaBridge ? [] : route.sourceExecutionPaths.keys());
+  if (!eoaBridge) {
     for (const asset of route.bridge?.assets ?? []) {
       chainIds.add(asset.chainID);
     }

--- a/src/swap/routing/bridge.ts
+++ b/src/swap/routing/bridge.ts
@@ -270,12 +270,15 @@ export const enrichMayanBridge = async (
   // Per-source Mayan legs derived from the bridge assets (what each leg sends and the
   // destination token it must deliver). Swap leaves the leg amounts at the full produced
   // balance — the COT selection upstream already sized them — and only prices them here.
-  const legs = bridge.assets.map((asset) => ({
+  const legs = bridge.assets.map((asset, index) => ({
     chainId: asset.chainID,
     tokenAddress: asset.contractAddress,
     amountRaw:
       mulDecimals(asset.eoaBalance.plus(asset.ephemeralBalance), asset.decimals) -
       (asset.depositFeeRaw ?? 0n),
+    ...(index === 0 && bridge.destinationGas
+      ? { gasDrop: bridge.destinationGas.amount.toNumber() }
+      : {}),
   }));
   logger.debug('swap.route.mayan_quote.requested', {
     legs: legs.map((leg) => ({ ...leg, amountRaw: leg.amountRaw.toString() })),

--- a/src/swap/routing/bridge.ts
+++ b/src/swap/routing/bridge.ts
@@ -16,6 +16,7 @@ import {
   quoteMayanLegs,
   selectMayanQuoteOutput,
 } from '../../services/mayan';
+import { equalFold } from '../../services/strings';
 import type { QuoteResponse } from '../aggregators/types';
 import { resolveExactInAmountBasis, selectExactInQuoteOutput } from '../amount-basis';
 import { resolveCOT } from '../cot';
@@ -272,7 +273,9 @@ export const enrichMayanBridge = async (
   const legs = bridge.assets.map((asset) => ({
     chainId: asset.chainID,
     tokenAddress: asset.contractAddress,
-    amountRaw: mulDecimals(asset.eoaBalance.plus(asset.ephemeralBalance), asset.decimals),
+    amountRaw:
+      mulDecimals(asset.eoaBalance.plus(asset.ephemeralBalance), asset.decimals) -
+      (asset.depositFeeRaw ?? 0n),
   }));
   logger.debug('swap.route.mayan_quote.requested', {
     legs: legs.map((leg) => ({ ...leg, amountRaw: leg.amountRaw.toString() })),
@@ -296,21 +299,25 @@ export const enrichMayanBridge = async (
     (sum, asset) => sum.plus(asset.eoaBalance).plus(asset.ephemeralBalance),
     new Decimal(0)
   );
+  const collection = bridge.assets.reduce(
+    (sum, asset) => sum.plus(asset.depositFee ?? 0),
+    new Decimal(0)
+  );
   const amountBasis = resolveExactInAmountBasis(options.exactInAmountBasis);
   const delivered = [...mayanQuotesBySource.values()].reduce(
     (sum, quote) => sum.plus(selectMayanQuoteOutput(quote, bridge.decimals, amountBasis)),
     new Decimal(0)
   );
-  const haircut = Decimal.max(grossBridged.minus(delivered), new Decimal(0));
+  const haircut = Decimal.max(grossBridged.minus(collection).minus(delivered), new Decimal(0));
 
   return {
     ...bridge,
     provider: 'mayan',
     mayanQuotesBySource,
     estimatedFees: {
-      collection: new Decimal(0),
+      collection,
       fulfilment: new Decimal(0),
-      caGas: new Decimal(0),
+      caGas: collection,
       protocol: haircut,
       solver: new Decimal(0),
     },
@@ -362,6 +369,30 @@ export const accumulateBridgeAsset = (
   });
 };
 
+export const withDirectBridgeDepositFees = (
+  assets: BridgeAsset[],
+  quote: BridgeQuoteResponse,
+  provider: BridgeProvider
+): BridgeAsset[] =>
+  assets.map((asset) => {
+    if (isNativeAddress(asset.contractAddress)) return asset;
+    const source = quote.sources.find(
+      (entry) =>
+        entry.chainId === asset.chainID && equalFold(entry.tokenAddress, asset.contractAddress)
+    );
+    if (!source) {
+      throw Errors.internal(`Bridge collection fee missing for source chain ${asset.chainID}`);
+    }
+    const depositFeeRaw = BigInt(
+      provider === 'mayan' ? (source.depositMayanFeeToken ?? '0') : source.depositFeeToken
+    );
+    return {
+      ...asset,
+      depositFee: divDecimals(depositFeeRaw, asset.decimals),
+      depositFeeRaw,
+    };
+  });
+
 // Nexus bridge fees. The protocol bps applies to `grossBridged` — the COT actually sent into the
 // bridge (Σ assets) — in BOTH routes, so the fee no longer differs by route (EXACT_IN was already
 // gross; EXACT_OUT used to size it off the smaller net delivery). The Mayan branch records its own
@@ -370,6 +401,7 @@ export const computeBridgeFees = (params: {
   quoteResponse: BridgeQuoteResponse;
   grossBridged: Decimal;
   dstCOTDecimals: number;
+  collectionFee?: Decimal;
 }): {
   estimatedFees: NonNullable<SwapRoute['bridge']>['estimatedFees'];
   totalFeeAmount: Decimal;
@@ -387,6 +419,7 @@ export const computeBridgeFees = (params: {
     ...computeNexusBridgeFees({
       nexusFeeModel,
       grossBridged: params.grossBridged,
+      collectionFee: params.collectionFee,
     }),
     nexusFeeModel,
   };
@@ -395,18 +428,18 @@ export const computeBridgeFees = (params: {
 export const computeNexusBridgeFees = (params: {
   nexusFeeModel: NexusFeeModel;
   grossBridged: Decimal;
+  collectionFee?: Decimal;
 }): {
   estimatedFees: NonNullable<SwapRoute['bridge']>['estimatedFees'];
   totalFeeAmount: Decimal;
   deliveredAmount: Decimal;
 } => {
   const fulfilment = params.nexusFeeModel.fulfillmentFee;
-  const protocol = params.grossBridged.mul(params.nexusFeeModel.fulfillmentBps).div(10000);
-  // Collection (per-source deposit) fee only applies when the EOA funds the bridge directly,
-  // which our smart-account-only model no longer supports — bridge funding always flows
-  // through the ephemeral, which the solver covers gas for. Keep the field for the public
-  // SwapRoute surface, but stub it at zero.
-  const collection = new Decimal(0);
+  const collection = params.collectionFee ?? new Decimal(0);
+  const protocol = params.grossBridged
+    .minus(collection)
+    .mul(params.nexusFeeModel.fulfillmentBps)
+    .div(10000);
   const estimatedFees = {
     collection,
     fulfilment,

--- a/src/swap/routing/exact-in.ts
+++ b/src/swap/routing/exact-in.ts
@@ -25,9 +25,11 @@ import {
   bridgedTokenForChain,
   buildBridgeAssetsAndFees,
   buildSourceCotByChain,
+  computeBridgeFees,
   enrichMayanBridge,
   fetchBridgeQuoteForCurrency,
   resolveBridgeProviderDecision,
+  withDirectBridgeDepositFees,
 } from './bridge';
 import {
   buildDirectDestinationExactInRoute,
@@ -179,12 +181,35 @@ const buildExactInBridge = async (input: {
       if (!feeSummary) {
         return { bridge: null, cotAvailableForDestination: input.cotAvailableForDestination };
       }
+      const directBridge =
+        input.sourceSwaps.length === 0 &&
+        equalFold(input.data.toTokenAddress, input.dstCOT.address);
+      const bridgeQuoteResponse = input.options.bridgeQuoteResponse;
+      if (directBridge && !bridgeQuoteResponse) {
+        throw Errors.internal('Bridge fee quote unavailable -- cannot route direct bridge');
+      }
+      const bridgeAssets =
+        directBridge && bridgeQuoteResponse
+          ? withDirectBridgeDepositFees(assets, bridgeQuoteResponse, input.bridgeProvider)
+          : assets;
+      const effectiveFeeSummary =
+        directBridge && bridgeQuoteResponse
+          ? computeBridgeFees({
+              quoteResponse: bridgeQuoteResponse,
+              grossBridged: bridgedCOT,
+              dstCOTDecimals: input.dstCOT.decimals,
+              collectionFee: bridgeAssets.reduce(
+                (sum, asset) => sum.plus(asset.depositFee ?? 0),
+                new Decimal(0)
+              ),
+            })
+          : feeSummary;
       const {
         estimatedFees,
         totalFeeAmount,
         deliveredAmount: effectiveBridgedToDestination,
         nexusFeeModel,
-      } = feeSummary;
+      } = effectiveFeeSummary;
       if (effectiveBridgedToDestination.lte(0)) {
         throw Errors.amountTooLow(
           `Bridge fees (${formatTokenBalance(totalFeeAmount.toFixed())}) exceed bridged amount (${formatTokenBalance(bridgedCOT.toFixed())})`
@@ -201,7 +226,7 @@ const buildExactInBridge = async (input: {
           gasInCot: new Decimal(0),
           totalAmount: bridgedCOT,
         },
-        assets,
+        assets: bridgeAssets,
         chainID: input.data.toChainId,
         decimals: input.dstCOT.decimals,
         tokenAddress: input.dstCOT.address as Hex,

--- a/src/swap/routing/exact-in.ts
+++ b/src/swap/routing/exact-in.ts
@@ -181,19 +181,17 @@ const buildExactInBridge = async (input: {
       if (!feeSummary) {
         return { bridge: null, cotAvailableForDestination: input.cotAvailableForDestination };
       }
-      const directBridge =
-        input.sourceSwaps.length === 0 &&
-        equalFold(input.data.toTokenAddress, input.dstCOT.address);
+      const eoaBridge = input.sourceSwaps.length === 0;
       const bridgeQuoteResponse = input.options.bridgeQuoteResponse;
-      if (directBridge && !bridgeQuoteResponse) {
+      if (eoaBridge && !bridgeQuoteResponse) {
         throw Errors.internal('Bridge fee quote unavailable -- cannot route direct bridge');
       }
       const bridgeAssets =
-        directBridge && bridgeQuoteResponse
+        eoaBridge && bridgeQuoteResponse
           ? withDirectBridgeDepositFees(assets, bridgeQuoteResponse, input.bridgeProvider)
           : assets;
       const effectiveFeeSummary =
-        directBridge && bridgeQuoteResponse
+        eoaBridge && bridgeQuoteResponse
           ? computeBridgeFees({
               quoteResponse: bridgeQuoteResponse,
               grossBridged: bridgedCOT,
@@ -319,7 +317,6 @@ export async function _exactInRoute(data: ExactInData, options: RouteOptions): P
               data.toTokenAddress,
               options.cotCurrencyId
             ),
-            hasGasRequest: false,
             toAmountRaw: 0n,
             mode: SwapMode.EXACT_IN,
           }),

--- a/src/swap/routing/exact-out.ts
+++ b/src/swap/routing/exact-out.ts
@@ -40,10 +40,12 @@ import {
   bridgedTokenForChain,
   buildBridgeAssetsAndFees,
   buildSourceCotByChain,
+  computeBridgeFees,
   enrichMayanBridge,
   estimateBridgeFees,
   fetchBridgeQuoteForCurrency,
   resolveBridgeProviderDecision,
+  withDirectBridgeDepositFees,
 } from './bridge';
 import {
   buildDirectDestinationExactOutRoute,
@@ -268,7 +270,6 @@ const tryExactOutFastPaths = async (
     dstTokenAddress: data.toTokenAddress,
     cotCurrencyId: options.cotCurrencyId,
     allowDirectDestination: false,
-    hasGasRequest: (data.toNativeAmountRaw ?? 0n) > 0n,
     toAmountRaw: data.toAmountRaw,
     mode: SwapMode.EXACT_OUT,
   } as const;
@@ -366,7 +367,7 @@ const buildExactOutBridge = async (input: {
     input.options.timing,
     'flow.swap.route.build_bridge',
     async () => {
-      const { assets, grossBridged, feeSummary } = buildBridgeAssetsAndFees({
+      const { assets, feeSummary } = buildBridgeAssetsAndFees({
         destinationChainId: input.data.toChainId,
         quoteResponses: input.quoteResponses,
         cotSources: input.usedCOTs,
@@ -378,20 +379,60 @@ const buildExactOutBridge = async (input: {
       if (!feeSummary) {
         throw Errors.internal('Bridge assets unavailable -- cannot route cross-chain swap');
       }
-      const { estimatedFees, deliveredAmount, nexusFeeModel } = feeSummary;
+      const eoaBridge = input.quoteResponses.length === 0;
+      const feeAssets = eoaBridge
+        ? withDirectBridgeDepositFees(assets, input.bridgeQuoteResponse, input.bridgeProvider)
+        : assets;
+      const bridgeAssets = eoaBridge
+        ? feeAssets.map((asset) => ({
+            ...asset,
+            eoaBalance: asset.eoaBalance.plus(asset.depositFee ?? 0),
+          }))
+        : assets;
+      const effectiveGrossBridged = bridgeAssets.reduce(
+        (sum, asset) => sum.plus(asset.eoaBalance).plus(asset.ephemeralBalance),
+        new Decimal(0)
+      );
+      if (eoaBridge) {
+        for (const source of input.usedCOTs) {
+          const fee = bridgeAssets.find(
+            (asset) => asset.chainID === source.holding.chainID
+          )?.depositFee;
+          if (!fee) continue;
+          const debit = source.amountUsed.plus(fee);
+          if (mulDecimals(debit, source.holding.decimals) > source.holding.amountRaw) {
+            throw Errors.insufficientBalance(
+              `Bridge collection fee exceeds the available balance on chain ${source.holding.chainID}`
+            );
+          }
+          source.amountUsed = debit;
+        }
+      }
+      const effectiveFeeSummary = eoaBridge
+        ? computeBridgeFees({
+            quoteResponse: input.bridgeQuoteResponse,
+            grossBridged: effectiveGrossBridged,
+            dstCOTDecimals: input.dstCOT.decimals,
+            collectionFee: bridgeAssets.reduce(
+              (sum, asset) => sum.plus(asset.depositFee ?? 0),
+              new Decimal(0)
+            ),
+          })
+        : feeSummary;
+      const { estimatedFees, deliveredAmount, nexusFeeModel } = effectiveFeeSummary;
       const deliveredTokenAmount = Decimal.max(
         deliveredAmount.minus(input.gasInCot),
         new Decimal(0)
       );
 
       let bridge: NonNullable<SwapRoute['bridge']> = {
-        amount: grossBridged,
+        amount: effectiveGrossBridged,
         amounts: {
           tokenAmount: deliveredTokenAmount,
           gasInCot: input.gasInCot,
-          totalAmount: grossBridged,
+          totalAmount: effectiveGrossBridged,
         },
-        assets,
+        assets: bridgeAssets,
         chainID: input.data.toChainId,
         decimals: input.dstCOT.decimals,
         tokenAddress: input.dstCOT.address as Hex,
@@ -435,7 +476,6 @@ export async function _exactOutRoute(
         dstTokenAddress: data.toTokenAddress,
         cotCurrencyId,
         allowDirectDestination: data.toAmountRaw >= 0n && (data.toNativeAmountRaw ?? 0n) >= 0n,
-        hasGasRequest: (data.toNativeAmountRaw ?? 0n) > 0n,
         toAmountRaw: data.toAmountRaw,
         mode: SwapMode.EXACT_OUT,
       });

--- a/src/swap/routing/fast-paths.ts
+++ b/src/swap/routing/fast-paths.ts
@@ -1,3 +1,4 @@
+import type { BridgeProvider } from '@avail-project/nexus-types';
 import Decimal from 'decimal.js';
 import { formatUnits, type Hex } from 'viem';
 import type { ChainListType } from '../../domain';
@@ -39,6 +40,7 @@ import {
   enrichMayanBridge,
   fetchBridgeQuoteForCurrency,
   resolveBridgeProviderDecision,
+  withDirectBridgeDepositFees,
 } from './bridge';
 import { summarizeIdentityHoldings } from './holdings';
 
@@ -444,20 +446,17 @@ export async function buildDirectDestinationExactOutRoute(
 // from the gross, EXACT_OUT grosses up from the target, then each finalizes here. forceMayan
 // short-circuits inside resolveBridgeProviderDecision; native is priced like any token (the caller
 // already normalized it to ZERO_ADDRESS).
-const finalizeSameTokenBridge = async (
+const resolveSameTokenBridgeProvider = async (
   params: {
     assets: BridgeAsset[];
     grossBridged: Decimal;
-    tokenAmount: Decimal;
-    fees: NonNullable<SwapRoute['bridge']>['estimatedFees'];
-    nexusFeeModel: NexusFeeModel;
     dstChainId: number;
     dstTokenAddress: Hex;
     dstTokenDecimals: number;
   },
   options: RouteOptions
-): Promise<NonNullable<SwapRoute['bridge']>> => {
-  const provider = (
+): Promise<BridgeProvider> =>
+  (
     await withTimingSpan(
       options.timing,
       'flow.swap.route.resolve_provider',
@@ -478,6 +477,22 @@ const finalizeSameTokenBridge = async (
       { tags: { route_path: 'same_token', source_chain_count: params.assets.length } }
     )
   ).provider;
+
+const finalizeSameTokenBridge = async (
+  params: {
+    assets: BridgeAsset[];
+    grossBridged: Decimal;
+    tokenAmount: Decimal;
+    fees: NonNullable<SwapRoute['bridge']>['estimatedFees'];
+    nexusFeeModel?: NexusFeeModel;
+    provider: BridgeProvider;
+    dstChainId: number;
+    dstTokenAddress: Hex;
+    dstTokenDecimals: number;
+  },
+  options: RouteOptions
+): Promise<NonNullable<SwapRoute['bridge']>> => {
+  const { provider } = params;
   return withTimingSpan(
     options.timing,
     'flow.swap.route.build_bridge',
@@ -494,7 +509,9 @@ const finalizeSameTokenBridge = async (
         decimals: params.dstTokenDecimals,
         tokenAddress: params.dstTokenAddress,
         estimatedFees: params.fees,
-        ...(provider === 'nexus' ? { nexusFeeModel: params.nexusFeeModel } : {}),
+        ...(provider === 'nexus' && params.nexusFeeModel
+          ? { nexusFeeModel: params.nexusFeeModel }
+          : {}),
         provider,
       };
       return provider === 'mayan' ? enrichMayanBridge(bridge, options) : bridge;
@@ -560,39 +577,51 @@ export async function buildSameTokenBridgeRoute(
   let bridge: SwapRoute['bridge'] = null;
   let deliveredFromBridge = new Decimal(0);
   if (assets.length > 0) {
-    const bridgedToken = assets.reduce(
+    const totalDebit = assets.reduce(
       (sum, asset) => sum.plus(asset.eoaBalance).plus(asset.ephemeralBalance),
       new Decimal(0)
     );
     if (!bridgeQuoteResponse) {
       throw Errors.internal('Bridge fee quote unavailable -- cannot route cross-chain swap');
     }
-    const {
-      estimatedFees: fees,
-      totalFeeAmount: totalFee,
-      deliveredAmount,
-      nexusFeeModel,
-    } = computeBridgeFees({
-      quoteResponse: bridgeQuoteResponse,
-      grossBridged: bridgedToken,
-      dstCOTDecimals: dstTokenInfo.decimals,
-    });
-    deliveredFromBridge = deliveredAmount;
-    if (deliveredFromBridge.lte(0)) {
-      throw Errors.amountTooLow(
-        `Bridge fees (${formatTokenBalance(totalFee.toFixed())}) exceed bridged amount (${formatTokenBalance(bridgedToken.toFixed())})`
-      );
-    }
     // The fast path participates in provider selection too, querying the server with the actual
     // bridged same-token (not the COT). Native is priced like any other token (already normalized to
     // ZERO_ADDRESS above); forceMayan still short-circuits inside resolveBridgeProviderDecision.
-    bridge = await finalizeSameTokenBridge(
+    const provider = await resolveSameTokenBridgeProvider(
       {
         assets,
-        grossBridged: bridgedToken,
+        grossBridged: totalDebit,
+        dstChainId,
+        dstTokenAddress,
+        dstTokenDecimals: dstTokenInfo.decimals,
+      },
+      options
+    );
+    const directAssets = withDirectBridgeDepositFees(assets, bridgeQuoteResponse, provider);
+    const collectionFee = directAssets.reduce(
+      (sum, asset) => sum.plus(asset.depositFee ?? 0),
+      new Decimal(0)
+    );
+    const feeSummary = computeBridgeFees({
+      quoteResponse: bridgeQuoteResponse,
+      grossBridged: totalDebit,
+      dstCOTDecimals: dstTokenInfo.decimals,
+      collectionFee,
+    });
+    deliveredFromBridge = feeSummary.deliveredAmount;
+    if (deliveredFromBridge.lte(0)) {
+      throw Errors.amountTooLow(
+        `Bridge fees (${formatTokenBalance(feeSummary.totalFeeAmount.toFixed())}) exceed bridged amount (${formatTokenBalance(totalDebit.toFixed())})`
+      );
+    }
+    bridge = await finalizeSameTokenBridge(
+      {
+        assets: directAssets,
+        grossBridged: totalDebit,
         tokenAmount: deliveredFromBridge,
-        fees,
-        nexusFeeModel,
+        fees: feeSummary.estimatedFees,
+        nexusFeeModel: feeSummary.nexusFeeModel,
+        provider,
         dstChainId,
         dstTokenAddress,
         dstTokenDecimals: dstTokenInfo.decimals,
@@ -724,7 +753,7 @@ export async function buildSameTokenBridgeExactOutRoute(
   if (bpsFraction.gte(1)) {
     throw Errors.internal('Same-token EXACT_OUT: fulfillmentBps >= 100%');
   }
-  const grossBridged = toAmountHuman.plus(fulfilment).div(new Decimal(1).minus(bpsFraction));
+  const bridgeInput = toAmountHuman.plus(fulfilment).div(new Decimal(1).minus(bpsFraction));
 
   // Greedy split over priority-ordered remote family-F holdings. Native holdings keep a per-chain gas
   // reserve so the deposit tx can pay for itself (never consume 100% native).
@@ -733,11 +762,8 @@ export async function buildSameTokenBridgeExactOutRoute(
       holding.chainID !== dstChainId &&
       resolveCurrencyId(chainList, holding.chainID, holding.tokenAddress) === settlementCurrencyId
   );
-  const assets: BridgeAsset[] = [];
-  const usedHoldings: { holding: SourceHolding; used: Decimal }[] = [];
-  let remaining = grossBridged;
+  const candidates: Array<{ holding: SourceHolding; available: Decimal }> = [];
   for (const holding of familyHoldings) {
-    if (remaining.lte(0)) break;
     let available = divDecimals(holding.amountRaw, holding.decimals);
     if (isNativeAddress(holding.tokenAddress)) {
       const reserveRaw = await estimateRepresentativeSwapNativeReserveFee({
@@ -749,28 +775,68 @@ export async function buildSameTokenBridgeExactOutRoute(
         new Decimal(0)
       );
     }
-    const use = Decimal.min(available, remaining);
-    if (use.lte(0)) continue;
-    assets.push({
-      chainID: holding.chainID,
-      contractAddress: isNativeAddress(holding.tokenAddress) ? ZERO_ADDRESS : holding.tokenAddress,
-      decimals: holding.decimals,
-      eoaBalance: use,
-      ephemeralBalance: new Decimal(0),
-    });
-    usedHoldings.push({ holding, used: use });
-    remaining = remaining.minus(use);
-  }
-  if (remaining.gt(0)) {
-    throw Errors.insufficientBalance(
-      `Same-token EXACT_OUT: family holdings cannot cover the grossed-up target (${remaining.toString()} short)`
-    );
+    candidates.push({ holding, available });
   }
 
+  const selectAssets = (provider?: BridgeProvider) => {
+    const assets: BridgeAsset[] = [];
+    const usedHoldings: { holding: SourceHolding; used: Decimal }[] = [];
+    let remaining = bridgeInput;
+    for (const { holding, available } of candidates) {
+      if (remaining.lte(0)) break;
+      const baseAsset: BridgeAsset = {
+        chainID: holding.chainID,
+        contractAddress: isNativeAddress(holding.tokenAddress)
+          ? ZERO_ADDRESS
+          : holding.tokenAddress,
+        decimals: holding.decimals,
+        eoaBalance: available,
+        ephemeralBalance: new Decimal(0),
+      };
+      const asset = provider
+        ? withDirectBridgeDepositFees([baseAsset], fQuote, provider)[0]
+        : baseAsset;
+      const depositFee = asset.depositFee ?? new Decimal(0);
+      const bridgeAmount = Decimal.min(Decimal.max(available.minus(depositFee), 0), remaining);
+      if (bridgeAmount.lte(0)) continue;
+      const debit = bridgeAmount.plus(depositFee);
+      assets.push({ ...asset, eoaBalance: debit });
+      usedHoldings.push({ holding, used: debit });
+      remaining = remaining.minus(bridgeAmount);
+    }
+    if (remaining.gt(0)) {
+      throw Errors.insufficientBalance(
+        `Same-token EXACT_OUT: family holdings cannot cover the grossed-up target (${remaining.toFixed()} short)`
+      );
+    }
+    return { assets, usedHoldings };
+  };
+
+  const preliminary = selectAssets();
+  const provider = await resolveSameTokenBridgeProvider(
+    {
+      assets: preliminary.assets,
+      grossBridged: bridgeInput,
+      dstChainId,
+      dstTokenAddress,
+      dstTokenDecimals: dstTokenInfo.decimals,
+    },
+    options
+  );
+  const { assets, usedHoldings } = selectAssets(provider);
+  const grossBridged = assets.reduce(
+    (sum, asset) => sum.plus(asset.eoaBalance).plus(asset.ephemeralBalance),
+    new Decimal(0)
+  );
+  const collectionFee = assets.reduce(
+    (sum, asset) => sum.plus(asset.depositFee ?? 0),
+    new Decimal(0)
+  );
   const { estimatedFees: fees, nexusFeeModel } = computeBridgeFees({
     quoteResponse: fQuote,
     grossBridged,
     dstCOTDecimals: dstTokenInfo.decimals,
+    collectionFee,
   });
   const bridge = await finalizeSameTokenBridge(
     {
@@ -779,6 +845,7 @@ export async function buildSameTokenBridgeExactOutRoute(
       tokenAmount: toAmountHuman,
       fees,
       nexusFeeModel,
+      provider,
       dstChainId,
       dstTokenAddress,
       dstTokenDecimals: dstTokenInfo.decimals,

--- a/src/swap/routing/fast-paths.ts
+++ b/src/swap/routing/fast-paths.ts
@@ -7,6 +7,7 @@ import { Errors } from '../../domain/errors';
 import { formatTokenBalance } from '../../domain/utils/format';
 import { logger } from '../../domain/utils/logger';
 import { isNativeAddress } from '../../services/addresses';
+import { convertGasToToken } from '../../services/intent';
 import { divDecimals, mulDecimals } from '../../services/math';
 import { selectMayanQuoteOutput } from '../../services/mayan';
 import { equalFold } from '../../services/strings';
@@ -93,7 +94,6 @@ export const classifyFastPath = (input: {
   dstTokenAddress: Hex;
   cotCurrencyId: number;
   allowDirectDestination: boolean;
-  hasGasRequest: boolean;
   toAmountRaw: bigint;
   mode: SwapMode;
 }): FastPathClass => {
@@ -114,13 +114,12 @@ export const classifyFastPath = (input: {
 
   // B1 — same-family direct bridge (EXACT_OUT mirror of buildSameTokenBridgeRoute). All members and
   // the destination token are one family, including the current COT; at least one source needs a
-  // bridge; no gas leg (disqualified in v1); positive output. A current-COT match belongs here too:
-  // it has no swap drift to buffer.
+  // bridge; positive output. Destination gas can ride the bridge intent, so it does not require a
+  // destination gas swap. A current-COT match belongs here too: it has no swap drift to buffer.
   if (
     input.mode === SwapMode.EXACT_OUT &&
     familyId === dstFamily &&
     members.some((member) => member.chainID !== dstChainId) &&
-    !input.hasGasRequest &&
     input.toAmountRaw > 0n
   ) {
     return { kind: 'same-token-out', familyId };
@@ -485,6 +484,7 @@ const finalizeSameTokenBridge = async (
     tokenAmount: Decimal;
     fees: NonNullable<SwapRoute['bridge']>['estimatedFees'];
     nexusFeeModel?: NexusFeeModel;
+    destinationGas?: NonNullable<SwapRoute['bridge']>['destinationGas'];
     provider: BridgeProvider;
     dstChainId: number;
     dstTokenAddress: Hex;
@@ -512,6 +512,7 @@ const finalizeSameTokenBridge = async (
         ...(provider === 'nexus' && params.nexusFeeModel
           ? { nexusFeeModel: params.nexusFeeModel }
           : {}),
+        ...(params.destinationGas ? { destinationGas: params.destinationGas } : {}),
         provider,
       };
       return provider === 'mayan' ? enrichMayanBridge(bridge, options) : bridge;
@@ -713,7 +714,12 @@ export async function buildSameTokenBridgeRoute(
  * caller propagates that error, while the RES fast-path envelope falls back to the COT flow.
  */
 export async function buildSameTokenBridgeExactOutRoute(
-  data: { toChainId: number; toTokenAddress: Hex; toAmountRaw: bigint },
+  data: {
+    toChainId: number;
+    toTokenAddress: Hex;
+    toAmountRaw: bigint;
+    toNativeAmountRaw?: bigint;
+  },
   holdings: SourceHolding[],
   options: RouteOptions,
   settlementCurrencyId: number,
@@ -722,9 +728,34 @@ export async function buildSameTokenBridgeExactOutRoute(
   const { chainList, oraclePrices, dstTokenInfo, walletPathHints, aggregators, publicClientList } =
     options;
   const dstChainId = data.toChainId;
+  const destinationChain = chainList.getChainByID(dstChainId);
   const dstTokenAddress: Hex = isNativeAddress(dstTokenInfo.contractAddress)
     ? ZERO_ADDRESS
     : (dstTokenInfo.contractAddress as Hex);
+  const requestedNativeAmountRaw =
+    data.toNativeAmountRaw != null && data.toNativeAmountRaw > 0n ? data.toNativeAmountRaw : 0n;
+  const nativeAmount =
+    requestedNativeAmountRaw > 0n
+      ? divDecimals(requestedNativeAmountRaw, destinationChain.nativeCurrency.decimals)
+      : new Decimal(0);
+  const nativeAmountInToken =
+    requestedNativeAmountRaw > 0n
+      ? convertGasToToken(
+          { contractAddress: dstTokenAddress, decimals: dstTokenInfo.decimals },
+          oraclePrices,
+          dstChainId,
+          destinationChain.universe,
+          nativeAmount
+        )
+      : new Decimal(0);
+  const destinationGas =
+    requestedNativeAmountRaw > 0n
+      ? {
+          amount: nativeAmount,
+          amountRaw: requestedNativeAmountRaw,
+          amountInToken: nativeAmountInToken,
+        }
+      : undefined;
 
   // F-denominated bridge-fee quote scoped to the path's remote source candidates. Fees follow the
   // bridged token, so reusing a COT-denominated quote would be a decimal trap. Null ⇒ fall back.
@@ -753,7 +784,10 @@ export async function buildSameTokenBridgeExactOutRoute(
   if (bpsFraction.gte(1)) {
     throw Errors.internal('Same-token EXACT_OUT: fulfillmentBps >= 100%');
   }
-  const bridgeInput = toAmountHuman.plus(fulfilment).div(new Decimal(1).minus(bpsFraction));
+  const bridgeInput = toAmountHuman
+    .plus(nativeAmountInToken)
+    .plus(fulfilment)
+    .div(new Decimal(1).minus(bpsFraction));
 
   // Greedy split over priority-ordered remote family-F holdings. Native holdings keep a per-chain gas
   // reserve so the deposit tx can pay for itself (never consume 100% native).
@@ -845,6 +879,7 @@ export async function buildSameTokenBridgeExactOutRoute(
       tokenAmount: toAmountHuman,
       fees,
       nexusFeeModel,
+      destinationGas,
       provider,
       dstChainId,
       dstTokenAddress,

--- a/src/swap/swap-steps-builder.ts
+++ b/src/swap/swap-steps-builder.ts
@@ -23,7 +23,7 @@ import {
   createSourceSwapStepId,
 } from '../services/step-ids';
 import type { QuoteResponse } from './aggregators/types';
-import type { SwapRoute } from './types';
+import { isDirectBridgeRoute, type SwapRoute } from './types';
 
 const toPlanTokenAmount = (
   metadata: PlanTokenMetadata,
@@ -202,9 +202,9 @@ export const createSwapPlan = (route: SwapRoute, chainList: ChainListType): Swap
     );
     steps.push(createBridgeIntentSubmissionStep());
     for (const asset of sortedAssets) {
-      // EOA → ephemeral transfer step only emits for direct-COT bridge holdings (eoaBalance>0);
-      // the smart-account-driven bridge model funds the rest from per-chain wrappers.
-      if (asset.eoaBalance.gt(0)) {
+      // Non-direct routes stage EOA bridge holdings on the ephemeral wallet. Direct routes deposit
+      // from the EOA and therefore omit the custody-transfer step.
+      if (!isDirectBridgeRoute(route) && asset.eoaBalance.gt(0)) {
         steps.push(createBridgeTransferStep(chainList, asset));
       }
       steps.push(createBridgeDepositStep(chainList, asset));

--- a/src/swap/swap-steps-builder.ts
+++ b/src/swap/swap-steps-builder.ts
@@ -140,6 +140,7 @@ const createBridgeFillStep = (
   route: NonNullable<SwapRoute['bridge']>
 ): BridgeFillStep => {
   const { chain, token } = chainList.getChainAndTokenByAddress(route.chainID, route.tokenAddress);
+  const amount = route.destinationGas ? route.amounts.tokenAmount : route.amount;
 
   return {
     type: 'bridge_fill',
@@ -147,8 +148,8 @@ const createBridgeFillStep = (
     chain: toChainDisplay(chain),
     asset: toPlanTokenAmount(
       token,
-      mulDecimals(route.amount, route.decimals),
-      route.amount.toFixed(route.decimals)
+      mulDecimals(amount, route.decimals),
+      amount.toFixed(route.decimals)
     ),
   };
 };

--- a/src/swap/swap-steps-builder.ts
+++ b/src/swap/swap-steps-builder.ts
@@ -23,7 +23,7 @@ import {
   createSourceSwapStepId,
 } from '../services/step-ids';
 import type { QuoteResponse } from './aggregators/types';
-import { isDirectBridgeRoute, type SwapRoute } from './types';
+import { isEoaBridgeRoute, type SwapRoute } from './types';
 
 const toPlanTokenAmount = (
   metadata: PlanTokenMetadata,
@@ -204,7 +204,7 @@ export const createSwapPlan = (route: SwapRoute, chainList: ChainListType): Swap
     for (const asset of sortedAssets) {
       // Non-direct routes stage EOA bridge holdings on the ephemeral wallet. Direct routes deposit
       // from the EOA and therefore omit the custody-transfer step.
-      if (!isDirectBridgeRoute(route) && asset.eoaBalance.gt(0)) {
+      if (!isEoaBridgeRoute(route) && asset.eoaBalance.gt(0)) {
         steps.push(createBridgeTransferStep(chainList, asset));
       }
       steps.push(createBridgeDepositStep(chainList, asset));

--- a/src/swap/swap.md
+++ b/src/swap/swap.md
@@ -5,10 +5,10 @@ authority when this document and code disagree.
 
 ## Core account model
 
-Safe V2 is the only account that executes aggregator swaps. A direct bridge route (a bridge with no
-source or destination swap) instead uses the connected EOA as the bridge holder and signer, matching
-the normal bridge flow. A chain's `swapSupported` deployment flag controls whether the chain can
-participate in routing; it does not select an execution mode.
+Safe V2 is the only account that executes aggregator swaps. A bridge route with no source swaps uses
+the connected EOA as its source holder and signer, matching the normal bridge flow. A chain's
+`swapSupported` deployment flag controls whether the chain can participate in routing; it does not
+select an execution mode.
 
 For a connected EOA and the SDK ephemeral account, the SDK predicts one deterministic Safe address:
 
@@ -22,7 +22,7 @@ a Safe transaction, but normal sponsored execution is signed by the ephemeral ow
 EOA still provides user-facing permits, direct approvals when a token cannot be permitted, and native
 value for payable Safe transactions.
 
-The ephemeral address is not an execution wallet. Outside the direct bridge route, it remains
+The ephemeral address is not an execution wallet. On routes that require source swaps, it remains
 relevant as:
 
 - a Safe owner and SafeTx signer;
@@ -61,7 +61,7 @@ buildSwapPreflight
 
 Cache warming starts immediately before the intent is exposed to `onIntent`, so its read-only RPC
 work overlaps the user's review time. It includes one bytecode lookup for the derived Safe on each
-Safe execution chain. Direct bridge source chains do not require this lookup. A refreshed intent
+Safe execution chain. Bridge source chains without source swaps do not require this lookup. A refreshed intent
 reuses the existing warmup when its query data is unchanged; a changed query set starts a new
 warmup. Wallet signatures, approvals, and transactions remain gated behind intent acceptance.
 
@@ -71,7 +71,7 @@ Immediately after intent approval, `startSafeDeploymentsForChains` starts one id
 `ensureSafeForEphemeral` promise for every chain that may execute through the Safe:
 
 - every source execution chain;
-- every non-direct bridge deposit chain;
+- every bridge deposit chain that also requires a source swap;
 - the destination chain when a destination token or gas swap exists.
 
 After the shared cache warmup resolves, every chain reads its cached deployment state. Already
@@ -107,10 +107,12 @@ Bridge fill receivers are:
 
 Destination swaps always execute from the Safe and deliver requested token/native output to the EOA.
 
-For a direct bridge route, each source remains in the EOA. The EOA signs the RFF, its address is the
-RFF party, and ERC-20 allowance targets the chain's vault. No EOA-to-ephemeral transfer or Safe
-deployment is prepared. Nexus and Mayan use the normal bridge allowance/executor path; Mayan ERC-20
-collection remains middleware-sponsored, while native deposits are sent by the EOA.
+For a bridge route without source swaps, each source remains in the EOA. The EOA signs the RFF, its
+address is the RFF party, and ERC-20 allowance targets the chain's vault. No EOA-to-ephemeral transfer
+or source-chain Safe deployment is prepared. Nexus and Mayan use the normal bridge
+allowance/executor path; Mayan ERC-20 collection remains middleware-sponsored, while native deposits
+are sent by the EOA. The bridge fills the destination Safe if a destination swap follows and the EOA
+otherwise.
 
 ## Route families
 
@@ -133,7 +135,11 @@ smaller of 0.5% or $0.25 for stable-only conversions, and the smaller of 2% or $
 non-stable conversion is required. Provider selection happens only for route-relevant remote value;
 direct destination routes do not request a bridge provider.
 
-Direct bridge routing includes provider-specific vault collection fees. Exact In deducts those fees
+An Exact Out same-token bridge can include a positive native-gas requirement in the bridge intent.
+Routing accounts for that gas in the selected source amount, omits a destination gas swap, and sets
+the bridge receiver to the EOA.
+
+EOA-funded bridge routing includes provider-specific vault collection fees. Exact In deducts those fees
 from delivery; Exact Out adds them to the selected EOA debit while keeping the requested output
 exact. The public swap intent shape is unchanged.
 
@@ -164,9 +170,9 @@ For ERC-20 value held by the EOA, preparation builds a deterministic transfer au
 - direct ERC-20 approval otherwise.
 
 The Safe consumes the authorization with `transferFrom`. Source and destination funding moves into
-the Safe. Non-direct bridge funding may send from the EOA to the ephemeral bridge holder while the
-Safe remains the spender. Direct bridge routes skip this preparation and use the bridge allowance
-service to authorize the vault from the EOA.
+the Safe. Bridge funding after a source swap may send from the EOA to the ephemeral bridge holder
+while the Safe remains the spender. Bridge routes without source swaps skip this preparation and use
+the bridge allowance service to authorize the vault from the EOA.
 
 Native input does not use an allowance. It is carried by the outer EOA transaction that calls the
 Safe.
@@ -210,9 +216,9 @@ execution may trigger a bounded requote when the failure is known to be safe to 
 
 For composed routes, Nexus ERC-20 deposits execute funding, ephemeral-to-vault permit, and deposit
 calls through the Safe. Mayan ERC-20 funding and permit calls also execute through the Safe, and
-native deposits are EOA-submitted Safe transactions. Direct bridge routes reuse normal bridge
-execution instead: the EOA authorizes the vault, owns and signs the RFF, and sends any native vault
-deposit directly. The bridge intent is signed and submitted only after required allowance work.
+native deposits are EOA-submitted Safe transactions. Bridge routes without source swaps reuse normal
+bridge execution instead: the EOA authorizes the vault, owns and signs the RFF, and sends any native
+vault deposit directly. The bridge intent is signed and submitted only after required allowance work.
 
 ### Destination swaps
 
@@ -263,7 +269,8 @@ Retries are deliberately narrow:
 - No swap call is executed from the EOA or ephemeral account directly.
 - The EOA only submits a swap transaction when native value must enter the Safe.
 - The Safe is deployed before any approval or permit prompt that names it as spender.
-- Direct bridge routes name the vault as spender and do not require a Safe or ephemeral custody.
+- Bridge sources without source swaps name the vault as spender and do not require a source-chain
+  Safe or ephemeral custody.
 - `swapSupported` gates routing availability, not execution mode.
 - Remote bridge custody at the ephemeral address does not make it an execution wallet.
 - Native gas reserve is deducted before source selection; the SDK never consumes 100% of native

--- a/src/swap/swap.md
+++ b/src/swap/swap.md
@@ -5,8 +5,10 @@ authority when this document and code disagree.
 
 ## Core account model
 
-Safe V2 is the only swap execution account. A chain's `swapSupported` deployment flag controls
-whether the chain can participate in routing; it does not select an execution mode.
+Safe V2 is the only account that executes aggregator swaps. A direct bridge route (a bridge with no
+source or destination swap) instead uses the connected EOA as the bridge holder and signer, matching
+the normal bridge flow. A chain's `swapSupported` deployment flag controls whether the chain can
+participate in routing; it does not select an execution mode.
 
 For a connected EOA and the SDK ephemeral account, the SDK predicts one deterministic Safe address:
 
@@ -20,7 +22,8 @@ a Safe transaction, but normal sponsored execution is signed by the ephemeral ow
 EOA still provides user-facing permits, direct approvals when a token cannot be permitted, and native
 value for payable Safe transactions.
 
-The ephemeral address is not an execution wallet. It remains relevant as:
+The ephemeral address is not an execution wallet. Outside the direct bridge route, it remains
+relevant as:
 
 - a Safe owner and SafeTx signer;
 - the signing identity for bridge intents and token permits;
@@ -46,7 +49,7 @@ buildSwapPreflight
   -> createSwapIntent + createSwapPlan
   -> start allowance, permit-capability, and Safe-code cache reads
   -> await onIntent approval
-  -> ensure missing Safes on every execution chain
+  -> ensure missing Safes on every Safe execution chain
   -> prepareSwapExecution (await the accepted route's cache)
   -> executeSwapRoute
        -> source swaps or direct-destination swap
@@ -58,17 +61,17 @@ buildSwapPreflight
 
 Cache warming starts immediately before the intent is exposed to `onIntent`, so its read-only RPC
 work overlaps the user's review time. It includes one bytecode lookup for the derived Safe on each
-execution chain. A refreshed intent reuses the existing warmup when its query data is unchanged; a
-changed query set starts a new warmup. Wallet signatures, approvals, and transactions remain gated
-behind intent acceptance.
+Safe execution chain. Direct bridge source chains do not require this lookup. A refreshed intent
+reuses the existing warmup when its query data is unchanged; a changed query set starts a new
+warmup. Wallet signatures, approvals, and transactions remain gated behind intent acceptance.
 
 ## Deployment-before-wallet-prompt invariant
 
 Immediately after intent approval, `startSafeDeploymentsForChains` starts one idempotent
-`ensureSafeForEphemeral` promise for every chain that may execute:
+`ensureSafeForEphemeral` promise for every chain that may execute through the Safe:
 
 - every source execution chain;
-- every bridge deposit chain;
+- every non-direct bridge deposit chain;
 - the destination chain when a destination token or gas swap exists.
 
 After the shared cache warmup resolves, every chain reads its cached deployment state. Already
@@ -104,6 +107,11 @@ Bridge fill receivers are:
 
 Destination swaps always execute from the Safe and deliver requested token/native output to the EOA.
 
+For a direct bridge route, each source remains in the EOA. The EOA signs the RFF, its address is the
+RFF party, and ERC-20 allowance targets the chain's vault. No EOA-to-ephemeral transfer or Safe
+deployment is prepared. Nexus and Mayan use the normal bridge allowance/executor path; Mayan ERC-20
+collection remains middleware-sponsored, while native deposits are sent by the EOA.
+
 ## Route families
 
 `determineSwapRoute` selects among these shapes:
@@ -124,6 +132,10 @@ selected source prefix: zero when every source already matches the selected sett
 smaller of 0.5% or $0.25 for stable-only conversions, and the smaller of 2% or $1 when any
 non-stable conversion is required. Provider selection happens only for route-relevant remote value;
 direct destination routes do not request a bridge provider.
+
+Direct bridge routing includes provider-specific vault collection fees. Exact In deducts those fees
+from delivery; Exact Out adds them to the selected EOA debit while keeping the requested output
+exact. The public swap intent shape is unchanged.
 
 For general COT routes, the SDK deterministically chooses between USDC and USDT before requesting
 aggregator quotes. Each source that is not already the candidate costs one leg, and a
@@ -152,8 +164,9 @@ For ERC-20 value held by the EOA, preparation builds a deterministic transfer au
 - direct ERC-20 approval otherwise.
 
 The Safe consumes the authorization with `transferFrom`. Source and destination funding moves into
-the Safe. A direct bridge-funding transfer may send from the EOA to the ephemeral bridge holder while
-the Safe remains the spender.
+the Safe. Non-direct bridge funding may send from the EOA to the ephemeral bridge holder while the
+Safe remains the spender. Direct bridge routes skip this preparation and use the bridge allowance
+service to authorize the vault from the EOA.
 
 Native input does not use an allowance. It is carried by the outer EOA transaction that calls the
 Safe.
@@ -195,10 +208,11 @@ execution may trigger a bounded requote when the failure is known to be safe to 
 
 ### Bridge deposits
 
-Nexus ERC-20 deposits execute funding, ephemeral-to-vault permit, and deposit calls through the Safe.
-Mayan ERC-20 funding and permit calls also execute through the Safe. Native deposits are
-EOA-submitted Safe transactions. The bridge intent is signed and submitted only after the required
-pre-deposit work has completed.
+For composed routes, Nexus ERC-20 deposits execute funding, ephemeral-to-vault permit, and deposit
+calls through the Safe. Mayan ERC-20 funding and permit calls also execute through the Safe, and
+native deposits are EOA-submitted Safe transactions. Direct bridge routes reuse normal bridge
+execution instead: the EOA authorizes the vault, owns and signs the RFF, and sends any native vault
+deposit directly. The bridge intent is signed and submitted only after required allowance work.
 
 ### Destination swaps
 
@@ -249,6 +263,7 @@ Retries are deliberately narrow:
 - No swap call is executed from the EOA or ephemeral account directly.
 - The EOA only submits a swap transaction when native value must enter the Safe.
 - The Safe is deployed before any approval or permit prompt that names it as spender.
+- Direct bridge routes name the vault as spender and do not require a Safe or ephemeral custody.
 - `swapSupported` gates routing availability, not execution mode.
 - Remote bridge custody at the ephemeral address does not make it an execution wallet.
 - Native gas reserve is deducted before source selection; the SDK never consumes 100% of native

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -202,6 +202,10 @@ export type BridgeAsset = {
   decimals: number;
   eoaBalance: Decimal; // human-readable decimal amount
   ephemeralBalance: Decimal; // human-readable decimal amount
+  // Direct bridges debit the collection fee from the EOA alongside the bridged amount.
+  // Ephemeral-backed routes omit these fields because their collection fee is sponsored.
+  depositFee?: Decimal;
+  depositFeeRaw?: bigint;
 };
 
 export type NexusFeeModel = {
@@ -227,8 +231,8 @@ export type SwapRoute = {
   // Currency the route settles/bridges in (the destination family for a same-token bridge, else
   // the COT/USDC). Drives the on-failure cleanup sweep's `currencyId`.
   settlementCurrencyId: number;
-  // True iff the same-token direct bridge fired (no source/destination swap). A Nexus same-token
-  // bridge deposits the exact amount directly, so nothing strands → the failure sweep is skipped.
+  // True iff the same-token direct bridge fired (no source/destination swap). It deposits from the
+  // EOA directly, so nothing strands on the ephemeral → the failure sweep is skipped.
   sameTokenBridge: boolean;
   // True iff the direct-destination fast path (Path A) fired: ALL sources on the destination chain,
   // swapped input→toToken directly with no bridge and no destination swap. The whole route is one
@@ -315,6 +319,14 @@ export type SwapRoute = {
   };
   sourceExecutionPaths: Map<number, WalletPath>;
 };
+
+export const isDirectBridgeRoute = (
+  route: Pick<SwapRoute, 'bridge' | 'source' | 'destination'>
+): boolean =>
+  route.bridge !== null &&
+  route.source.swaps.length === 0 &&
+  route.destination.swap.tokenSwap === null &&
+  route.destination.swap.gasSwap === null;
 
 export type AssetsUsedEntry = {
   chainID: number;

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -274,6 +274,13 @@ export type SwapRoute = {
     };
     // Retained so execution can apply the fixed-plus-bps model to actual bridged balances.
     nexusFeeModel?: NexusFeeModel;
+    // Native gas delivered by the bridge itself. Present only when no destination gas swap is
+    // needed; `amountInToken` is the bridged-token value reserved to fund it.
+    destinationGas?: {
+      amount: Decimal;
+      amountRaw: bigint;
+      amountInToken: Decimal;
+    };
     provider: BridgeProvider;
     // Populated only when provider === 'mayan'. Keyed by `${chainID}:${contractAddress.toLowerCase()}`.
     mayanQuotesBySource?: Map<string, MayanQuote>;
@@ -320,11 +327,13 @@ export type SwapRoute = {
   sourceExecutionPaths: Map<number, WalletPath>;
 };
 
+export const isEoaBridgeRoute = (route: Pick<SwapRoute, 'bridge' | 'source'>): boolean =>
+  route.bridge !== null && route.source.swaps.length === 0;
+
 export const isDirectBridgeRoute = (
   route: Pick<SwapRoute, 'bridge' | 'source' | 'destination'>
 ): boolean =>
-  route.bridge !== null &&
-  route.source.swaps.length === 0 &&
+  isEoaBridgeRoute(route) &&
   route.destination.swap.tokenSwap === null &&
   route.destination.swap.gasSwap === null;
 

--- a/tests/flows/characterization/swap-pipeline.test.ts
+++ b/tests/flows/characterization/swap-pipeline.test.ts
@@ -24,6 +24,7 @@ import {
 import { EADDRESS, SWEEPER_ADDRESS } from '../../../src/swap/constants';
 import {
   SwapMode,
+  isDirectBridgeRoute,
   type FlatBalance,
   type SwapIntent,
   type SwapParams,
@@ -723,10 +724,7 @@ const SCENARIOS: ExactOutScenario[] = [
       expectedBridgeRecipient: EOA,
       expectsNativeSweep: false,
       sourceQuoteExpectations: [],
-      eoaToEphemeralTransfers: [
-        { reason: 'bridge', chainId: ARB_CHAIN, tokenAddress: USDC_ARB },
-        { reason: 'bridge', chainId: OP_CHAIN, tokenAddress: USDC_OP },
-      ],
+      eoaToEphemeralTransfers: [],
       bridgeAssetOwnership: [
         { chainId: ARB_CHAIN, hasEoaBalance: true, hasEphemeralBalance: false },
         { chainId: OP_CHAIN, hasEoaBalance: true, hasEphemeralBalance: false },
@@ -1428,9 +1426,10 @@ const expectSafeDeploymentCalls = (result: {
   previewState: SwapPreviewState;
 }) => {
   const { route } = result.previewState;
-  const expectedChainIds = new Set(route.sourceExecutionPaths.keys());
-  for (const asset of route.bridge?.assets ?? []) {
-    expectedChainIds.add(asset.chainID);
+  const expectedChainIds = new Set<number>();
+  if (!isDirectBridgeRoute(route)) {
+    for (const chainId of route.sourceExecutionPaths.keys()) expectedChainIds.add(chainId);
+    for (const asset of route.bridge?.assets ?? []) expectedChainIds.add(asset.chainID);
   }
   if (route.destination.swap.tokenSwap !== null || route.destination.swap.gasSwap !== null) {
     expectedChainIds.add(route.destination.chainId);
@@ -1512,13 +1511,14 @@ const assertScenario = (scenario: ExactOutScenario, result: HarnessResult) => {
     .filter((step) => step.type === 'eoa_to_ephemeral_transfer')
     .map((step) => step.chain.id)
     .sort((left, right) => left - right);
-  // Smart-account-only model: EOA → ephemeral transfer fires for any bridge asset that has
-  // an eoaBalance > 0 (bridge funding flows through the ephemeral).
+  // Direct bridges keep funds in the EOA. Other bridge routes still fund the ephemeral wallet.
   expect(bridgeTransferChainIds).toEqual(
-    scenario.expected.bridgeAssetOwnership
-      .filter((asset) => asset.hasEoaBalance)
-      .map((asset) => asset.chainId)
-      .sort((left, right) => left - right)
+    isDirectBridgeRoute(result.previewState.route)
+      ? []
+      : scenario.expected.bridgeAssetOwnership
+          .filter((asset) => asset.hasEoaBalance)
+          .map((asset) => asset.chainId)
+          .sort((left, right) => left - right)
   );
 
   const usedCotChainIds = result.previewState.route.extras.assetsUsed

--- a/tests/flows/characterization/swap-pipeline.test.ts
+++ b/tests/flows/characterization/swap-pipeline.test.ts
@@ -24,7 +24,7 @@ import {
 import { EADDRESS, SWEEPER_ADDRESS } from '../../../src/swap/constants';
 import {
   SwapMode,
-  isDirectBridgeRoute,
+  isEoaBridgeRoute,
   type FlatBalance,
   type SwapIntent,
   type SwapParams,
@@ -1427,7 +1427,7 @@ const expectSafeDeploymentCalls = (result: {
 }) => {
   const { route } = result.previewState;
   const expectedChainIds = new Set<number>();
-  if (!isDirectBridgeRoute(route)) {
+  if (!isEoaBridgeRoute(route)) {
     for (const chainId of route.sourceExecutionPaths.keys()) expectedChainIds.add(chainId);
     for (const asset of route.bridge?.assets ?? []) expectedChainIds.add(asset.chainID);
   }
@@ -1511,9 +1511,9 @@ const assertScenario = (scenario: ExactOutScenario, result: HarnessResult) => {
     .filter((step) => step.type === 'eoa_to_ephemeral_transfer')
     .map((step) => step.chain.id)
     .sort((left, right) => left - right);
-  // Direct bridges keep funds in the EOA. Other bridge routes still fund the ephemeral wallet.
+  // Bridges without source swaps keep funds in the EOA. Other routes fund the ephemeral wallet.
   expect(bridgeTransferChainIds).toEqual(
-    isDirectBridgeRoute(result.previewState.route)
+    isEoaBridgeRoute(result.previewState.route)
       ? []
       : scenario.expected.bridgeAssetOwnership
           .filter((asset) => asset.hasEoaBalance)

--- a/tests/helpers/swap-characterization.ts
+++ b/tests/helpers/swap-characterization.ts
@@ -810,11 +810,20 @@ export const makeCharMiddleware = (opts: {
       ),
     getQuote: vi.fn().mockResolvedValue({
       fulfillmentBps: 0,
-      sources: [ARB_CHAIN, OP_CHAIN, BASE_CHAIN].map((chainId) => ({
+      sources: [
+        [ARB_CHAIN, USDC_ARB],
+        [OP_CHAIN, USDC_OP],
+        [BASE_CHAIN, USDC_BASE],
+        [ARB_CHAIN, USDT_ARB],
+        [OP_CHAIN, USDT_OP],
+        [BASE_CHAIN, USDT_BASE],
+      ].map(([chainId, tokenAddress]) => ({
         chainId,
-        tokenAddress: ({ [ARB_CHAIN]: USDC_ARB, [OP_CHAIN]: USDC_OP, [BASE_CHAIN]: USDC_BASE }[chainId])!,
+        tokenAddress,
         depositFeeUsd: '0',
         depositFeeToken: '0',
+        depositMayanFeeUsd: '0',
+        depositMayanFeeToken: '0',
       })),
       destination: {
         chainId: BASE_CHAIN,
@@ -936,6 +945,7 @@ export type CharRffRequest = {
   sources: Array<{ chain_id: string; contract_address: Hex; value: string }>;
   destinations: Array<{ contract_address: Hex; value: string }>;
   recipient_address: Hex;
+  parties: Array<{ universe: string; address: Hex }>;
 };
 export const rffRequest = (mw: CharMiddleware): CharRffRequest =>
   (mw.submitRFF.mock.calls[0]?.[0] as { request: CharRffRequest }).request;

--- a/tests/swap/bridge-intent.test.ts
+++ b/tests/swap/bridge-intent.test.ts
@@ -322,6 +322,42 @@ describe('createSwapBridgeIntent', () => {
     expect(intent.destination.nativeToken.contractAddress).toBe(NATIVE_TOKEN.contractAddress);
   });
 
+  it('puts direct-bridge destination gas in the bridge intent', () => {
+    const asset = {
+      ...makeBridgeAsset(ARB_CHAIN, USDC_ARB, '3.5'),
+      eoaBalance: new Decimal('3.5'),
+      ephemeralBalance: new Decimal(0),
+    };
+    const bridge = makeBridge([asset], {
+      amount: new Decimal('3.5'),
+      amounts: {
+        tokenAmount: new Decimal('1'),
+        gasInCot: new Decimal(0),
+        totalAmount: new Decimal('3.5'),
+      },
+      destinationGas: {
+        amount: new Decimal('0.001'),
+        amountRaw: 1_000_000_000_000_000n,
+        amountInToken: new Decimal('2.5'),
+      },
+    } as Partial<NonNullable<SwapRoute['bridge']>>);
+
+    const intent = createSwapBridgeIntent({
+      bridge,
+      assets: bridge.assets,
+      chainList: makeChainList(),
+      recipient: EOA_ADDRESS,
+      ephemeralAddress: EPHEMERAL_ADDRESS,
+      holderAddress: EOA_ADDRESS,
+    });
+
+    expect(intent.destination.amount.toString()).toBe('1');
+    expect(intent.destination.amountRaw).toBe(1_000_000n);
+    expect(intent.destination.nativeAmount.toString()).toBe('0.001');
+    expect(intent.destination.nativeAmountRaw).toBe(1_000_000_000_000_000n);
+    expect(intent.destination.nativeAmountInToken.toString()).toBe('2.5');
+  });
+
   it('derives destination token amount from execution-time assets instead of stale route totals', () => {
     const assets = [makeBridgeAsset(ARB_CHAIN, USDC_ARB, '3.5')];
     const bridge = makeBridge(assets, {

--- a/tests/swap/bridge-intent.test.ts
+++ b/tests/swap/bridge-intent.test.ts
@@ -170,6 +170,47 @@ describe('createSwapBridgeIntent', () => {
     expect(intent.availableSources).toEqual(intent.selectedSources);
   });
 
+  it('uses the EOA holder and separates the collection fee on the direct bridge path', () => {
+    const asset = {
+      ...makeBridgeAsset(ARB_CHAIN, USDC_ARB, '3'),
+      eoaBalance: new Decimal('3'),
+      ephemeralBalance: new Decimal(0),
+      depositFee: new Decimal('0.1'),
+      depositFeeRaw: 100_000n,
+    } as BridgeAsset & { depositFee: Decimal; depositFeeRaw: bigint };
+    const bridge = makeBridge([asset], {
+      amount: new Decimal('3'),
+      amounts: {
+        tokenAmount: new Decimal('2.9'),
+        gasInCot: new Decimal(0),
+        totalAmount: new Decimal('3'),
+      },
+      estimatedFees: {
+        collection: new Decimal('0.1'),
+        fulfilment: new Decimal(0),
+        caGas: new Decimal('0.1'),
+        protocol: new Decimal(0),
+        solver: new Decimal(0),
+      },
+    });
+
+    const intent = createSwapBridgeIntent({
+      bridge,
+      assets: bridge.assets,
+      chainList: makeChainList(),
+      recipient: EOA_ADDRESS,
+      ephemeralAddress: EPHEMERAL_ADDRESS,
+      holderAddress: EOA_ADDRESS,
+    } as Parameters<typeof createSwapBridgeIntent>[0]);
+
+    expect(intent.selectedSources[0]).toMatchObject({
+      holderAddress: EOA_ADDRESS,
+      amountRaw: 2_900_000n,
+      depositFeeRaw: 100_000n,
+    });
+    expect(intent.selectedSources[0].depositFee.toFixed()).toBe('0.1');
+  });
+
   it('recipient is dynamic (EOA or ephemeral)', () => {
     const bridge = makeBridge([makeBridgeAsset(ARB_CHAIN, USDC_ARB)]);
     const chainList = makeChainList();

--- a/tests/swap/characterization/execution-failures.test.ts
+++ b/tests/swap/characterization/execution-failures.test.ts
@@ -38,6 +38,7 @@ const hoisted = vi.hoisted(() => {
   const waitForTransactionReceipt = vi.fn();
   const multicall = vi.fn();
   const getBalance = vi.fn();
+  const watchContractEvent = vi.fn().mockReturnValue(vi.fn());
   const createPublicClient = vi.fn((options?: { chain?: unknown }) => ({
     chain: options?.chain,
     call,
@@ -47,6 +48,7 @@ const hoisted = vi.hoisted(() => {
     waitForTransactionReceipt,
     multicall,
     getBalance,
+    watchContractEvent,
   }));
 
   return {
@@ -57,6 +59,7 @@ const hoisted = vi.hoisted(() => {
     waitForTransactionReceipt,
     multicall,
     getBalance,
+    watchContractEvent,
     createPublicClient,
   };
 });
@@ -123,11 +126,6 @@ const runDirectCotBridge = (
     { onIntent: ({ allow }) => allow() }
   );
 
-const bridgeSubmissionCalls = (middlewareClient: CharMiddleware) =>
-  middlewareClient.createSafeExecuteTx.mock.calls.filter(([request]) =>
-    decodeSafeRequest(request).some((call) => call.fn === 'deposit')
-  );
-
 describe('swap execution failure and retry characterization', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -145,7 +143,7 @@ describe('swap execution failure and retry characterization', () => {
     );
   });
 
-  it('retries a transient permit nonce read before any bridge broadcast', async () => {
+  it('fails a direct EOA bridge before broadcast when its permit nonce read fails', async () => {
     const middlewareClient = makeCharMiddleware({
       balances: [balance(ARB_CHAIN, USDC_ARB, 'USDC', 6, '50')],
     });
@@ -160,42 +158,23 @@ describe('swap execution failure and retry characterization', () => {
       return readContractStub(request);
     });
 
-    await runDirectCotBridge(middlewareClient);
+    await expect(runDirectCotBridge(middlewareClient)).rejects.toThrow(
+      'RPC temporarily unavailable'
+    );
 
-    expect(nonceReads).toBe(3);
-    expect(bridgeSubmissionCalls(middlewareClient)).toHaveLength(1);
+    expect(nonceReads).toBe(1);
+    expect(middlewareClient.submitRFF).not.toHaveBeenCalled();
+    expect(middlewareClient.createSafeExecuteTx).not.toHaveBeenCalled();
   });
 
-  it('does not retry a rejected Safe bridge request', async () => {
-    const middlewareClient = makeCharMiddleware({
-      balances: [balance(ARB_CHAIN, USDC_ARB, 'USDC', 6, '50')],
-    });
-    middlewareClient.createSafeExecuteTx.mockRejectedValueOnce(new Error('not broadcast'));
-
-    await expect(runDirectCotBridge(middlewareClient)).rejects.toThrow('not broadcast');
-
-    const submissions = bridgeSubmissionCalls(middlewareClient);
-    expect(submissions).toHaveLength(1);
-  });
-
-  it('does not retry an ambiguous bridge transport failure', async () => {
-    const middlewareClient = makeCharMiddleware({
-      balances: [balance(ARB_CHAIN, USDC_ARB, 'USDC', 6, '50')],
-    });
-    middlewareClient.createSafeExecuteTx.mockRejectedValueOnce(new Error('request timed out'));
-
-    await expect(runDirectCotBridge(middlewareClient)).rejects.toThrow('request timed out');
-
-    expect(bridgeSubmissionCalls(middlewareClient)).toHaveLength(1);
-  });
-
-  it('submits one Safe bridge request when a transaction hash is returned', async () => {
+  it('never creates a Safe bridge request for a direct EOA bridge', async () => {
     const middlewareClient = makeCharMiddleware({
       balances: [balance(ARB_CHAIN, USDC_ARB, 'USDC', 6, '50')],
     });
     await runDirectCotBridge(middlewareClient);
 
-    expect(bridgeSubmissionCalls(middlewareClient)).toHaveLength(1);
+    expect(middlewareClient.createSafeExecuteTx).not.toHaveBeenCalled();
+    expect(middlewareClient.submitRFF).toHaveBeenCalledTimes(1);
   });
 
   it('reuses Safe funding authorization when a failed source leg is requoted', async () => {

--- a/tests/swap/characterization/lifecycle.test.ts
+++ b/tests/swap/characterization/lifecycle.test.ts
@@ -23,6 +23,7 @@ const hoisted = vi.hoisted(() => {
   const waitForTransactionReceipt = vi.fn();
   const multicall = vi.fn();
   const getBalance = vi.fn();
+  const watchContractEvent = vi.fn().mockReturnValue(vi.fn());
   const createPublicClient = vi.fn((options?: { chain?: unknown }) => ({
     chain: options?.chain,
     call,
@@ -32,6 +33,7 @@ const hoisted = vi.hoisted(() => {
     waitForTransactionReceipt,
     multicall,
     getBalance,
+    watchContractEvent,
   }));
 
   return {
@@ -42,6 +44,7 @@ const hoisted = vi.hoisted(() => {
     waitForTransactionReceipt,
     multicall,
     getBalance,
+    watchContractEvent,
     createPublicClient,
   };
 });
@@ -155,7 +158,7 @@ describe('top-level swap lifecycle characterization', () => {
     );
   });
 
-  it('starts cache reads before showing the intent and reuses them after approval', async () => {
+  it('skips Safe cache reads for a direct EOA bridge', async () => {
     const { deps } = makeHarness();
     let cacheCallsAtApproval = 0;
     let safeCodeReadsAtApproval = 0;
@@ -168,8 +171,8 @@ describe('top-level swap lifecycle characterization', () => {
       },
     });
 
-    expect(cacheCallsAtApproval).toBeGreaterThan(0);
-    expect(safeCodeReadsAtApproval).toBeGreaterThan(0);
+    expect(cacheCallsAtApproval).toBe(0);
+    expect(safeCodeReadsAtApproval).toBe(0);
     expect(hoisted.multicall).toHaveBeenCalledTimes(cacheCallsAtApproval);
     expect(hoisted.getCode).toHaveBeenCalledTimes(safeCodeReadsAtApproval);
   });
@@ -202,7 +205,7 @@ describe('top-level swap lifecycle characterization', () => {
     );
   });
 
-  it('reuses the cache when a refreshed intent has the same query data', async () => {
+  it('keeps Safe cache reads skipped when refreshing a direct EOA bridge', async () => {
     const { deps } = makeHarness();
     let initialCacheCalls = 0;
     let refreshedCacheCalls = 0;
@@ -221,9 +224,9 @@ describe('top-level swap lifecycle characterization', () => {
       },
     });
 
-    expect(initialCacheCalls).toBeGreaterThan(0);
+    expect(initialCacheCalls).toBe(0);
     expect(refreshedCacheCalls).toBe(initialCacheCalls);
-    expect(initialCodeReads).toBeGreaterThan(0);
+    expect(initialCodeReads).toBe(0);
     expect(refreshedCodeReads).toBe(initialCodeReads);
     expect(hoisted.multicall).toHaveBeenCalledTimes(initialCacheCalls);
   });

--- a/tests/swap/characterization/swap.test.ts
+++ b/tests/swap/characterization/swap.test.ts
@@ -76,6 +76,7 @@ vi.mock('@avail-project/nexus-types/rff', async () => {
 });
 
 import { swap as flowSwap } from '../../../src/flows/swap';
+import { ZERO_ADDRESS } from '../../../src/domain';
 import { SwapMode, type FlatBalance } from '../../../src/swap/types';
 import { EADDRESS } from '../../../src/swap/constants';
 import {
@@ -445,22 +446,24 @@ describe('swap execution characterization', () => {
       { onIntent: (d: { allow: () => void }) => d.allow() }
     );
 
-    // Each source chain: ONE bridge-deposit batch (fast-path funding EOA→EPH then approve→deposit) —
-    // no source swap, because USDT is the (dynamic) COT.
+    // With no source swaps, each source stays in the EOA and approves its vault directly. The
+    // destination Safe is still used because the bridge fill feeds a destination token swap.
+    const rff = rffRequest(middlewareClient);
+    expect(sentTxs).toHaveLength(2);
     for (const [chainId, usdt] of [[ARB_CHAIN, USDT_ARB], [OP_CHAIN, USDT_OP]] as const) {
-      const batches = executionBatchesForChain(middlewareClient, chainId);
-      expect(batches.length, `chain ${chainId} batch count`).toBe(1);
-      expectCallSequence(batches[0], [
-        { fn: 'permit', to: usdt, argsMatch: permitOwnerSpender(EOA, PREDICTED_SAFE) },
-        { fn: 'transferFrom', to: usdt, argsMatch: (a) => { eq(EOA)(a[0]); eq(EPH)(a[1]); } },
-        { fn: 'permit', to: usdt, argsMatch: (a) => { eq(EPH)(a[0]); eq(VAULT_BY_CHAIN[chainId])(a[1]); } },
-        { fn: 'deposit', to: VAULT_BY_CHAIN[chainId] },
-      ], `b2 deposit ${chainId}`);
+      expect(executionBatchesForChain(middlewareClient, chainId)).toEqual([]);
+      const tx = sentTxs.find((entry) => entry.chainId === chainId)!;
+      const source = rff.sources.find((entry) => Number(BigInt(entry.chain_id)) === chainId)!;
+      expectCallSequence(
+        [tx.call],
+        [{ fn: 'approve', to: usdt, args: [VAULT_BY_CHAIN[chainId], BigInt(source.value)] }],
+        `${chainId} direct vault approval`
+      );
     }
 
-    // Fill → EPH (Safe V2 dst + dst swap). RFF sources + destination carry USDT, not USDC.
+    // Fill → Safe (dst swap). RFF holder/party is still the EOA and the bridged token is USDT.
     expect(rffRecipient(middlewareClient)).toBe(bytes32Address(PREDICTED_SAFE));
-    const rff = rffRequest(middlewareClient);
+    expect(rff.parties.map((party) => party.address.toLowerCase())).toContain(bytes32Address(EOA));
     const usdtByChain: Record<number, Hex> = { [ARB_CHAIN]: USDT_ARB, [OP_CHAIN]: USDT_OP };
     for (const s of rff.sources) {
       expect(s.contract_address.toLowerCase()).toBe(bytes32Address(usdtByChain[Number(s.chain_id)]));
@@ -474,7 +477,9 @@ describe('swap execution characterization', () => {
     eq(USDT_BASE)(swp.args[0]); // input = the selected settlement token
     eq(WETH)(swp.args[1]); // output = WETH
     eq(EOA)(swp.args[5]); // receiver = EOA
-    expect(sentTxs).toHaveLength(0);
+    expect(
+      middlewareClient.ensureSafeAccount.mock.calls.map(([request]) => request.chainId)
+    ).toEqual([BASE_CHAIN]);
   });
 
   it('EXACT_OUT · Nexus · least-swap settlement (USDT sources → WETH + gas): dst batch pulls USDT for token and gas', async () => {
@@ -513,16 +518,23 @@ describe('swap execution characterization', () => {
       { onIntent: (d: { allow: () => void }) => d.allow() }
     );
 
-    // Source chains only deposit USDT (no source swap). At least one source
-    // funds+deposits; every source batch is deposit-shaped, never a swap.
+    // With no source swaps, selected bridge sources remain in the EOA and approve the vault.
     const sourceBatches = [ARB_CHAIN, OP_CHAIN].flatMap((c) => executionBatchesForChain(middlewareClient, c));
-    expect(sourceBatches.length).toBeGreaterThan(0);
-    for (const b of sourceBatches) {
-      expect(b.some((c) => c.fn === 'swap'), 'no source swap on a settled source chain').toBe(false);
-      expect(b.some((c) => c.fn === 'deposit'), 'source chain deposits USDT').toBe(true);
-    }
-    // RFF carries USDT.
+    expect(sourceBatches).toEqual([]);
     const rff = rffRequest(middlewareClient);
+    expect(sentTxs).toHaveLength(rff.sources.length);
+    const usdtByChain: Record<number, Hex> = { [ARB_CHAIN]: USDT_ARB, [OP_CHAIN]: USDT_OP };
+    for (const source of rff.sources) {
+      const chainId = Number(BigInt(source.chain_id));
+      const tx = sentTxs.find((entry) => entry.chainId === chainId)!;
+      expectCallSequence(
+        [tx.call],
+        [{ fn: 'approve', to: usdtByChain[chainId], args: [VAULT_BY_CHAIN[chainId], BigInt(source.value)] }],
+        `${chainId} direct vault approval`
+      );
+    }
+    expect(rff.parties.map((party) => party.address.toLowerCase())).toContain(bytes32Address(EOA));
+    expect(rffRecipient(middlewareClient)).toBe(bytes32Address(PREDICTED_SAFE));
     expect(rff.destinations[0].contract_address.toLowerCase()).toBe(bytes32Address(USDT_BASE));
 
     // Destination batch: the token swap (→WETH) and the gas swap (→native), BOTH pulling USDT to the EOA.
@@ -537,7 +549,6 @@ describe('swap execution characterization', () => {
     eq(USDT_BASE)(gasSwap!.args[0]);
     eq(EOA)(tokenSwap!.args[5]);
     eq(EOA)(gasSwap!.args[5]);
-    expect(sentTxs).toHaveLength(0);
   });
 
   it('EXACT_IN · Nexus · Safe V2 source → Safe V2 dst token swap', async () => {
@@ -802,16 +813,13 @@ describe('swap execution characterization', () => {
     expect(rffRecipient(middlewareClient)).toBe(bytes32Address(EOA));
   });
 
-  it('EXACT_OUT · Nexus · COT dst + native gas → gas swap (COT→native, taker=wrapper, recv=EOA)', async () => {
-    // Gas top-up is EXACT_OUT-only (EXACT_IN always sets gasSwap=null). toToken==COT so there is no
-    // token swap — only the gas swap. Because a dst swap (the gas swap) exists, BRIDGE_RECEIVER=EPH,
-    // and the gas swap is quoted/executed on the wrapper (taker=EPH) delivering native to the EOA.
+  it('EXACT_OUT · Nexus · COT dst + native gas → bridge intent delivers both to the EOA', async () => {
     const balances: FlatBalance[] = [
       { amount: '1000', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDC', tokenAddress: USDC_ARB, value: 1000, name: 'USD Coin', logo: '' },
     ];
     const chainList = makeCharChainList();
     const middlewareClient = makeCharMiddleware({ balances, provider: 'nexus' });
-    const { wallet } = makeRealEoaWallet();
+    const { wallet, sentTxs } = makeRealEoaWallet();
 
     await flowSwap(
       {
@@ -835,23 +843,22 @@ describe('swap execution characterization', () => {
       { onIntent: (d: { allow: () => void }) => d.allow() }
     );
 
-    // Gas swap present → BRIDGE_RECEIVER = EPH (wrapper runs the dst gas swap).
-    expect(rffRecipient(middlewareClient)).toBe(bytes32Address(PREDICTED_SAFE));
-
-    // Destination batch is the gas swap (COT→native): approve(router)→swap(taker=EPH, recv=EOA)→
-    // transfer leftover COT → EOA. No token swap, no native sweep (native delivered straight to the EOA).
-    const dst = executionBatchesForChain(middlewareClient, BASE_CHAIN);
-    expect(dst.length, 'dst Safe request batch count').toBe(1);
-    const gasSwap = dst[0].find((c) => c.fn === 'swap')!;
-    eq(USDC_BASE)(gasSwap.args[0]); // input = COT
-    eq(EADDRESS as Hex)(gasSwap.args[1]); // output = native
-    eq(PREDICTED_SAFE)(gasSwap.args[4]); // taker = wrapper (needsTokenSwap||needsGasSwap → wrapper)
-    eq(EOA)(gasSwap.args[5]); // receiver = EOA
-    // #86: leftover COT returned by one direct transfer → EOA (not a Sweeper drain), native direct.
-    expect(dst[0].map((c) => c.fn)).toEqual(['approve', 'swap', 'transfer']);
-    const refund = dst[0].find((c) => c.fn === 'transfer')!;
-    eq(USDC_BASE)(refund.to);
-    eq(EOA)(refund.args[0]);
+    const rff = rffRequest(middlewareClient);
+    expect(rffRecipient(middlewareClient)).toBe(bytes32Address(EOA));
+    expect(rff.destinations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ contract_address: bytes32Address(USDC_BASE), value: (500n * 10n ** 6n).toString() }),
+        expect.objectContaining({ contract_address: bytes32Address(ZERO_ADDRESS), value: (1n * 10n ** 16n).toString() }),
+      ])
+    );
+    expect(executionBatchesForChain(middlewareClient, BASE_CHAIN)).toEqual([]);
+    expect(middlewareClient.ensureSafeAccount).not.toHaveBeenCalled();
+    expect(sentTxs).toHaveLength(1);
+    expectCallSequence(
+      [sentTxs[0].call],
+      [{ fn: 'approve', to: USDC_ARB, args: [VAULT_BY_CHAIN[ARB_CHAIN], BigInt(rff.sources[0].value)] }],
+      'direct token-and-gas bridge approval'
+    );
   });
 
   it('EXACT_OUT · Nexus · explicit same-chain COT funds the gas swap directly with no buffered remainder', async () => {
@@ -1797,25 +1804,29 @@ describe('swap execution characterization', () => {
       { onIntent: (d: { allow: () => void }) => d.allow() }
     );
 
-    // Both sources: Mayan COT-direct fast-path (fund EOA→EPH + approve(vault); NO deposit).
+    // Both no-swap sources stay in the EOA and approve their vaults directly.
+    const rff = rffRequest(middlewareClient);
+    expect(sentTxs).toHaveLength(2);
     for (const [chainId, usdc] of [
       [ARB_CHAIN, USDC_ARB],
       [OP_CHAIN, USDC_OP],
     ] as const) {
-      const legs = executionBatchesForChain(middlewareClient, chainId);
-      expect(legs.map((b) => b.map((c) => c.fn)), `chain ${chainId} Mayan leg`).toEqual([
-        ['permit', 'transferFrom', 'permit'],
-      ]);
-      eq(VAULT_BY_CHAIN[chainId])(legs[0][2].args[1]);
-      eq(usdc)(legs[0][2].to);
+      expect(executionBatchesForChain(middlewareClient, chainId)).toEqual([]);
+      const tx = sentTxs.find((entry) => entry.chainId === chainId)!;
+      const source = rff.sources.find((entry) => Number(BigInt(entry.chain_id)) === chainId)!;
+      expectCallSequence(
+        [tx.call],
+        [{ fn: 'approve', to: usdc, args: [VAULT_BY_CHAIN[chainId], BigInt(source.value)] }],
+        `${chainId} direct Mayan vault approval`
+      );
     }
 
     // The RFF bridges both COT legs to the wrapper (a dst swap exists → recv=EPH). The submitRFF
     // mock enforces value == effectiveAmountIn64 per leg, so completion proves the Mayan refresh.
-    const rff = rffRequest(middlewareClient);
     expect(rff.sources).toHaveLength(2);
     for (const s of rff.sources) expect(BigInt(s.value)).toBe(1000n * 10n ** 6n);
     expect(rffRecipient(middlewareClient)).toBe(bytes32Address(PREDICTED_SAFE));
+    expect(rff.parties.map((party) => party.address.toLowerCase())).toContain(bytes32Address(EOA));
 
     // Mayan RFF shape: ONE destination entry PER SOURCE LEG (each SWIFT order delivers
     // independently) — unlike Nexus, which sums both sources into a single destination entry.
@@ -1836,7 +1847,7 @@ describe('swap execution characterization', () => {
     // EXACT_IN resize consumes the complete delivered COT balance.
     expect(swp.args[2] as bigint).toBe(delivered);
     expect(dst[0][0].args[1]).toBe(swp.args[2]); // approve == swap input
-    expect(sentTxs).toHaveLength(0);
+    expect(sentTxs).toHaveLength(2);
   });
 
   it('EXACT_IN · Mayan · native dst swap fails every attempt → stranded COT swept back to the EOA', async () => {
@@ -2164,17 +2175,15 @@ describe('EXACT_OUT coverage expansion', () => {
 
   it('B1 · gas-only funding from a cross-chain COT source → bridge fills the wrapper, gas swap runs', async () => {
     const middlewareClient = makeCharMiddleware({ balances: [usdc(ARB_CHAIN, USDC_ARB, '1000')], provider: 'nexus' });
-    const { wallet } = makeRealEoaWallet();
+    const { wallet, sentTxs } = makeRealEoaWallet();
     await flowSwap(
       { mode: SwapMode.EXACT_OUT as const, data: { sources: [{ chainId: ARB_CHAIN, tokenAddress: USDC_ARB }], toChainId: BASE_CHAIN, toTokenAddress: USDC_BASE, toAmountRaw: 0n, toNativeAmountRaw: 1n * 10n ** 16n } },
       deps(middlewareClient, wallet),
       allow
     );
 
-    // ARB: COT-direct fast-path funding + deposit.
-    expect(executionBatchesForChain(middlewareClient, ARB_CHAIN).map((b) => b.map((c) => c.fn))).toEqual([
-      ['permit', 'transferFrom', 'permit', 'deposit'],
-    ]);
+    expect(executionBatchesForChain(middlewareClient, ARB_CHAIN)).toEqual([]);
+    expect(sentTxs).toHaveLength(1);
     expect(rffRecipient(middlewareClient), 'gas swap runs on the wrapper').toBe(bytes32Address(PREDICTED_SAFE));
     const delivered = BigInt(rffRequest(middlewareClient).destinations[0].value);
     // BASE: gas swap + surplus return, NO handoff (nothing local).
@@ -2214,17 +2223,16 @@ describe('EXACT_OUT coverage expansion', () => {
 
   it('C2 · (−reserve, +gas) cross-chain: the reserved dst COT never moves; gas bridges from ARB', async () => {
     const middlewareClient = makeCharMiddleware({ balances: [usdc(BASE_CHAIN, USDC_BASE, '100'), usdc(ARB_CHAIN, USDC_ARB, '100')], provider: 'nexus' });
-    const { wallet } = makeRealEoaWallet();
+    const { wallet, sentTxs } = makeRealEoaWallet();
     await flowSwap(
       { mode: SwapMode.EXACT_OUT as const, data: { sources: [{ chainId: BASE_CHAIN, tokenAddress: USDC_BASE }, { chainId: ARB_CHAIN, tokenAddress: USDC_ARB }], toChainId: BASE_CHAIN, toTokenAddress: USDC_BASE, toAmountRaw: -(100n * 10n ** 6n), toNativeAmountRaw: 1n * 10n ** 16n } },
       deps(middlewareClient, wallet),
       allow
     );
 
-    // Gas is bridged from ARB; the fully-reserved BASE USDC is untouched.
-    expect(executionBatchesForChain(middlewareClient, ARB_CHAIN).map((b) => b.map((c) => c.fn))).toEqual([
-      ['permit', 'transferFrom', 'permit', 'deposit'],
-    ]);
+    // Gas is bridged from the ARB EOA; the fully-reserved BASE USDC is untouched.
+    expect(executionBatchesForChain(middlewareClient, ARB_CHAIN)).toEqual([]);
+    expect(sentTxs).toHaveLength(1);
     expect(rffRecipient(middlewareClient)).toBe(bytes32Address(PREDICTED_SAFE));
     const dst = executionBatchesForChain(middlewareClient, BASE_CHAIN);
     expect(dst.length).toBe(1);

--- a/tests/swap/characterization/swap.test.ts
+++ b/tests/swap/characterization/swap.test.ts
@@ -15,6 +15,8 @@ const hoisted = vi.hoisted(() => {
   const multicall = vi.fn();
   const getBalance = vi.fn();
   const call = vi.fn();
+  const watchContractEvent = vi.fn().mockReturnValue(vi.fn());
+  const simulateContract = vi.fn().mockImplementation(async (request) => ({ request }));
   const createPublicClient = vi.fn((opts?: { chain?: unknown }) => ({
     chain: opts?.chain,
     call,
@@ -24,6 +26,8 @@ const hoisted = vi.hoisted(() => {
     waitForTransactionReceipt,
     multicall,
     getBalance,
+    watchContractEvent,
+    simulateContract,
   }));
   return {
     call,
@@ -33,6 +37,8 @@ const hoisted = vi.hoisted(() => {
     waitForTransactionReceipt,
     multicall,
     getBalance,
+    watchContractEvent,
+    simulateContract,
     createPublicClient,
   };
 });
@@ -318,31 +324,35 @@ describe('swap execution characterization', () => {
 
     const amt = 1000n * 10n ** 6n;
 
-    // Single bridge batch on ARB (no source swap): fast-path funding (permit+transferFrom EOA→EPH),
-    // then approve(vault)→deposit. #86 bridges the full EPH balance → no sweep.
-    const arb = executionBatchesForChain(middlewareClient, ARB_CHAIN);
-    expect(arb.length, 'ARB Safe request batch count').toBe(1);
+    // Direct bridge custody stays at the EOA. The approval targets the vault and no Safe request
+    // or EOA→ephemeral transfer is created.
+    expect(executionBatchesForChain(middlewareClient, ARB_CHAIN)).toEqual([]);
+    expect(middlewareClient.ensureSafeAccount).not.toHaveBeenCalled();
+    expect(sentTxs).toHaveLength(1);
     expectCallSequence(
-      arb[0],
+      [sentTxs[0].call],
       [
-        { fn: 'permit', to: USDC_ARB, argsMatch: permitOwnerSpender(EOA, PREDICTED_SAFE) },
-        { fn: 'transferFrom', to: USDC_ARB, argsMatch: (a) => { eq(EOA)(a[0]); eq(EPH)(a[1]); expect(a[2]).toBe(amt); } },
-        { fn: 'permit', to: USDC_ARB, argsMatch: (a) => { eq(EPH)(a[0]); eq(VAULT_BY_CHAIN[ARB_CHAIN])(a[1]); expect(a[2]).toBe(amt); } },
-        { fn: 'deposit', to: VAULT_BY_CHAIN[ARB_CHAIN] },
+        {
+          fn: 'approve',
+          to: USDC_ARB,
+          args: [VAULT_BY_CHAIN[ARB_CHAIN], amt],
+        },
       ],
-      'arb fast-path bridge'
+      'arb direct bridge approval'
     );
 
     // No destination swap → BRIDGE_RECEIVER = EOA, and no destination Safe request batch.
     expect(rffRecipient(middlewareClient)).toBe(bytes32Address(EOA));
     expect(executionBatchesForChain(middlewareClient, BASE_CHAIN).length, 'no dst batch').toBe(0);
-    expect(sentTxs).toHaveLength(0);
+    expect(rffRequest(middlewareClient).parties.map((party) => party.address.toLowerCase())).toContain(
+      bytes32Address(EOA)
+    );
   });
 
   it('EXACT_OUT · Nexus · B1 same-token bridge (USDT→USDT) → deposits split across chains, delivered exact, recv=EOA', async () => {
     // B1 EXACT_OUT: every source and the destination share the USDT family (≠ COT) → bridge USDT
     // directly EOA→EOA, no swaps. The exact 3 USDT target (zero-fee quote → gross == target) is split
-    // greedily: ARB (2, full) + OP (1, partial). Each chain runs a fast-path funding + deposit batch.
+    // greedily: ARB (2, full) + OP (1, partial). Each EOA approves its chain's vault directly.
     const balances: FlatBalance[] = [
       { amount: '2', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_ARB, value: 2, name: 'Tether USD', logo: '' },
       { amount: '2', chainID: OP_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_OP, value: 2, name: 'Tether USD', logo: '' },
@@ -372,33 +382,32 @@ describe('swap execution characterization', () => {
       { onIntent: (d: { allow: () => void }) => d.allow() }
     );
 
-    // ARB bridges the full 2 USDT; OP the remaining 1 USDT. Each: fast-path funding (permit+transferFrom
-    // EOA→EPH) then approve(vault)→deposit — no source swap.
-    const arb = executionBatchesForChain(middlewareClient, ARB_CHAIN);
-    expect(arb.length).toBe(1);
-    expectCallSequence(arb[0], [
-      { fn: 'permit', to: USDT_ARB, argsMatch: permitOwnerSpender(EOA, PREDICTED_SAFE) },
-      { fn: 'transferFrom', to: USDT_ARB, argsMatch: (a) => { eq(EOA)(a[0]); eq(EPH)(a[1]); expect(a[2]).toBe(2n * 10n ** 6n); } },
-      { fn: 'permit', to: USDT_ARB, argsMatch: (a) => { eq(EPH)(a[0]); eq(VAULT_BY_CHAIN[ARB_CHAIN])(a[1]); expect(a[2]).toBe(2n * 10n ** 6n); } },
-      { fn: 'deposit', to: VAULT_BY_CHAIN[ARB_CHAIN] },
-    ], 'arb same-token deposit');
-    const op = executionBatchesForChain(middlewareClient, OP_CHAIN);
-    expect(op.length).toBe(1);
-    expectCallSequence(op[0], [
-      { fn: 'permit', to: USDT_OP, argsMatch: permitOwnerSpender(EOA, PREDICTED_SAFE) },
-      { fn: 'transferFrom', to: USDT_OP, argsMatch: (a) => { eq(EOA)(a[0]); eq(EPH)(a[1]); expect(a[2]).toBe(1n * 10n ** 6n); } },
-      { fn: 'permit', to: USDT_OP, argsMatch: (a) => { eq(EPH)(a[0]); eq(VAULT_BY_CHAIN[OP_CHAIN])(a[1]); expect(a[2]).toBe(1n * 10n ** 6n); } },
-      { fn: 'deposit', to: VAULT_BY_CHAIN[OP_CHAIN] },
-    ], 'op same-token deposit');
+    // ARB bridges the full 2 USDT; OP the remaining 1 USDT. Both approvals are direct EOA→vault.
+    expect(executionBatchesForChain(middlewareClient, ARB_CHAIN)).toEqual([]);
+    expect(executionBatchesForChain(middlewareClient, OP_CHAIN)).toEqual([]);
+    expect(middlewareClient.ensureSafeAccount).not.toHaveBeenCalled();
+    expect(sentTxs).toHaveLength(2);
+    const rff = rffRequest(middlewareClient);
+    for (const [chainId, tokenAddress] of [
+      [ARB_CHAIN, USDT_ARB],
+      [OP_CHAIN, USDT_OP],
+    ] as const) {
+      const tx = sentTxs.find((entry) => entry.chainId === chainId)!;
+      const source = rff.sources.find((entry) => Number(BigInt(entry.chain_id)) === chainId)!;
+      expectCallSequence(
+        [tx.call],
+        [{ fn: 'approve', to: tokenAddress, args: [VAULT_BY_CHAIN[chainId], BigInt(source.value)] }],
+        `${chainId} same-token approval`
+      );
+    }
 
     // No dst swap → RFF fills to the EOA, no BASE batch. RFF source values == the split; Σ == the exact
     // 3 USDT delivered (zero fees).
     expect(rffRecipient(middlewareClient)).toBe(bytes32Address(EOA));
     expect(executionBatchesForChain(middlewareClient, BASE_CHAIN).length).toBe(0);
-    const rff = rffRequest(middlewareClient);
     const total = rff.sources.reduce((sum: bigint, s: { value: string }) => sum + BigInt(s.value), 0n);
     expect(total).toBe(3n * 10n ** 6n);
-    expect(sentTxs).toHaveLength(0);
+    expect(rff.parties.map((party) => party.address.toLowerCase())).toContain(bytes32Address(EOA));
   });
 
   it('EXACT_IN · Nexus · least-swap settlement (USDT sources → WETH): no source swaps, dst swap pulls USDT', async () => {
@@ -614,9 +623,9 @@ describe('swap execution characterization', () => {
     expect(sentTxs).toHaveLength(0);
   });
 
-  it('EXACT_IN · Mayan · COT-direct Safe V2 → approve-only (no deposit/sweep), bridge recv=EOA', async () => {
-    // Same inputs as the Nexus COT-direct case but forceMayan. The deposit batch stops at the vault
-    // allowance — the middleware sponsors depositMayan() after the RFF. Pins the Nexus↔Mayan diff.
+  it('EXACT_IN · Mayan · COT-direct EOA → approve-only (no deposit/sweep), bridge recv=EOA', async () => {
+    // Same inputs as the Nexus COT-direct case but forceMayan. The EOA approves the vault and the
+    // middleware sponsors depositMayan() after the RFF. Pins the Nexus↔Mayan diff.
     const balances: FlatBalance[] = [
       { amount: '1000', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDC', tokenAddress: USDC_ARB, value: 1000, name: 'USD Coin', logo: '' },
     ];
@@ -646,17 +655,14 @@ describe('swap execution characterization', () => {
 
     const amt = 1000n * 10n ** 6n;
 
-    // Mayan Safe V2 deposit batch = fund EOA→EPH + approve(vault). NO deposit, NO sweep.
-    const arb = executionBatchesForChain(middlewareClient, ARB_CHAIN);
-    expect(arb.length, 'ARB Mayan Safe request batch count').toBe(1);
+    // Mayan uses the same EOA→vault approval path; its ERC-20 deposit remains middleware-sponsored.
+    expect(executionBatchesForChain(middlewareClient, ARB_CHAIN)).toEqual([]);
+    expect(middlewareClient.ensureSafeAccount).not.toHaveBeenCalled();
+    expect(sentTxs).toHaveLength(1);
     expectCallSequence(
-      arb[0],
-      [
-        { fn: 'permit', to: USDC_ARB, argsMatch: permitOwnerSpender(EOA, PREDICTED_SAFE) },
-        { fn: 'transferFrom', to: USDC_ARB, argsMatch: (a) => { eq(EOA)(a[0]); eq(EPH)(a[1]); expect(a[2]).toBe(amt); } },
-        { fn: 'permit', to: USDC_ARB, argsMatch: (a) => { eq(EPH)(a[0]); eq(VAULT_BY_CHAIN[ARB_CHAIN])(a[1]); expect(a[2]).toBe(amt); } },
-      ],
-      'arb mayan approve-only'
+      [sentTxs[0].call],
+      [{ fn: 'approve', to: USDC_ARB, args: [VAULT_BY_CHAIN[ARB_CHAIN], amt] }],
+      'arb mayan direct approval'
     );
 
     expect(middlewareClient.submitRFF).toHaveBeenCalledTimes(1);
@@ -670,15 +676,10 @@ describe('swap execution characterization', () => {
     expect(rff.sources[0].contract_address.toLowerCase()).toBe(bytes32Address(USDC_ARB));
     expect(rff.destinations[0].contract_address.toLowerCase()).toBe(bytes32Address(USDC_BASE));
     expect(BigInt(rff.destinations[0].value)).toBeGreaterThan(0n);
-
-    // S2 — Mayan approves the vault BEFORE the RFF is registered (middleware sponsors depositMayan after).
-    expect(executionCallOrderWith(middlewareClient, 'permit')).toBeLessThan(
-      middlewareClient.submitRFF.mock.invocationCallOrder[0]
-    );
+    expect(rff.parties.map((party) => party.address.toLowerCase())).toContain(bytes32Address(EOA));
 
     // S5 — only the source chain emits a batch (COT-direct dst, recv=EOA → no destination batch).
-    expect(dispatchedChains(middlewareClient)).toEqual([ARB_CHAIN]);
-    expect(sentTxs).toHaveLength(0);
+    expect(dispatchedChains(middlewareClient)).toEqual([]);
   });
 
   it('EXACT_OUT · Nexus · COT dst skips the destination buffer when no destination swap runs', async () => {
@@ -1235,7 +1236,7 @@ describe('swap execution characterization', () => {
       { onIntent: (d: { allow: () => void }) => d.allow() }
     );
 
-    // The EOA really signed one tx: the payable depositMayan (Safe execTransaction{value}). Decode it out.
+    // The EOA really signed one direct payable depositMayan transaction.
     expect(sentTxs).toHaveLength(1);
     const dep = decodeEoaTx(sentTxs[0].raw);
     expect(dep.value).toBe(1n * 10n ** 18n);
@@ -1266,6 +1267,10 @@ describe('swap execution characterization', () => {
       middlewareClient.submitRFF.mock.invocationCallOrder[0]
     );
     expect(executionBatchesForChain(middlewareClient, ARB_CHAIN).length).toBe(0);
+    expect(middlewareClient.ensureSafeAccount).not.toHaveBeenCalled();
+    expect(rffRequest(middlewareClient).parties.map((party) => party.address.toLowerCase())).toContain(
+      bytes32Address(EOA)
+    );
   });
 
   it('EXACT_IN · Mayan · mixed native + ERC20 sources → COT dst (approve-only legs)', async () => {
@@ -1623,15 +1628,13 @@ describe('swap execution characterization', () => {
     eq(USDC_BASE)(dst[0][2].to); // leftover COT transferred to the EOA
   });
 
-  it('EXACT_IN · Nexus · Safe COT-direct fast-path (no source swap) → bridge recv=EOA', async () => {
-    // COT at the EOA on a Safe V2 chain → no source swap. The Safe is the transferFrom spender,
-    // but sends EOA→EPH directly, followed by EPH→vault permit + deposit.
+  it('EXACT_IN · Nexus · COT-direct fast-path on OP → EOA approves vault', async () => {
     const balances: FlatBalance[] = [
       { amount: '1000', chainID: OP_CHAIN, decimals: 6, symbol: 'USDC', tokenAddress: USDC_OP, value: 1000, name: 'USD Coin', logo: '' },
     ];
     const chainList = makeCharChainList();
     const middlewareClient = makeCharMiddleware({ balances, provider: 'nexus' });
-    const { wallet } = makeRealEoaWallet();
+    const { wallet, sentTxs } = makeRealEoaWallet();
 
     await flowSwap(
       {
@@ -1653,16 +1656,24 @@ describe('swap execution characterization', () => {
       { onIntent: (d: { allow: () => void }) => d.allow() }
     );
 
-    const op = safeBatchesForChain(middlewareClient, OP_CHAIN);
-    expect(op.length).toBe(1); // single bridge batch (no source swap)
-    expect(op[0].map((c) => c.fn)).toEqual([
-      'permit', 'transferFrom', 'permit', 'deposit',
-    ]);
-    permitOwnerSpender(EOA, PREDICTED_SAFE)(op[0][0].args); // Safe is transferFrom spender
-    eq(EPH)(op[0][1].args[1]); // direct EOA→EPH
-    eq(EPH)(op[0][2].args[0]); // EPH permits vault
-    eq(VAULT_BY_CHAIN[OP_CHAIN])(op[0][2].args[1]);
+    expect(safeBatchesForChain(middlewareClient, OP_CHAIN)).toEqual([]);
+    expect(middlewareClient.ensureSafeAccount).not.toHaveBeenCalled();
+    expect(sentTxs).toHaveLength(1);
+    expectCallSequence(
+      [sentTxs[0].call],
+      [
+        {
+          fn: 'approve',
+          to: USDC_OP,
+          args: [VAULT_BY_CHAIN[OP_CHAIN], 1000n * 10n ** 6n],
+        },
+      ],
+      'op direct bridge approval'
+    );
     expect(rffRecipient(middlewareClient)).toBe(bytes32Address(EOA));
+    expect(rffRequest(middlewareClient).parties.map((party) => party.address.toLowerCase())).toContain(
+      bytes32Address(EOA)
+    );
   });
 
   it('EXACT_IN · Nexus · Safe V2 source → Safe V2 destination swap', async () => {

--- a/tests/swap/execution/failure-cleanup.test.ts
+++ b/tests/swap/execution/failure-cleanup.test.ts
@@ -177,13 +177,20 @@ describe('resolveFailureSweepCurrencyId', () => {
     provider?: 'nexus' | 'mayan';
     settlementCurrencyId: number;
     directDestination?: boolean;
-  }) =>
-    ({
+    directBridge?: boolean;
+  }) => {
+    const directBridge = over.directBridge ?? over.sameTokenBridge;
+    return ({
       sameTokenBridge: over.sameTokenBridge,
       settlementCurrencyId: over.settlementCurrencyId,
       directDestination: over.directDestination,
       bridge: over.provider ? { provider: over.provider } : null,
+      source: { swaps: directBridge ? [] : [{}] },
+      destination: {
+        swap: directBridge ? { tokenSwap: null, gasSwap: null } : { tokenSwap: {}, gasSwap: null },
+      },
     }) as never;
+  };
 
   it('skips (null) for a same-token bridge via Nexus — nothing strands', () => {
     expect(
@@ -193,12 +200,25 @@ describe('resolveFailureSweepCurrencyId', () => {
     ).toBeNull();
   });
 
-  it('sweeps the bridged family token for a same-token bridge via Mayan', () => {
+  it('skips cleanup for a same-token bridge via Mayan because custody stays at the EOA', () => {
     expect(
       resolveFailureSweepCurrencyId(
         makeRoute({ sameTokenBridge: true, provider: 'mayan', settlementCurrencyId: CurrencyID.USDT })
       )
-    ).toBe(CurrencyID.USDT);
+    ).toBeNull();
+  });
+
+  it('skips cleanup for a direct COT bridge because custody stays at the EOA', () => {
+    expect(
+      resolveFailureSweepCurrencyId(
+        makeRoute({
+          sameTokenBridge: false,
+          provider: 'nexus',
+          settlementCurrencyId: CurrencyID.USDC,
+          directBridge: true,
+        })
+      )
+    ).toBeNull();
   });
 
   it('sweeps the COT (USDC) for a COT round-trip route', () => {

--- a/tests/swap/execution/orchestrator-contracts.test.ts
+++ b/tests/swap/execution/orchestrator-contracts.test.ts
@@ -70,7 +70,8 @@ describe('executeSwapRoute contracts', () => {
       route.bridge,
       [executedOnly],
       expect.anything(),
-      expect.anything()
+      expect.anything(),
+      false
     );
   });
 

--- a/tests/swap/execution/orchestrator-contracts.test.ts
+++ b/tests/swap/execution/orchestrator-contracts.test.ts
@@ -59,6 +59,7 @@ describe('executeSwapRoute contracts', () => {
     vi.mocked(executeSourceSwaps).mockResolvedValue([executedOnly] as never);
     const route = {
       ...makeRoute(),
+      source: { swaps: [{}], creationTime: Date.now(), srcBuffer: null },
       bridge: {
         assets: [],
       },

--- a/tests/swap/prepare.test.ts
+++ b/tests/swap/prepare.test.ts
@@ -260,6 +260,53 @@ describe('prepareSwapExecution', () => {
     expect(addAllowanceQuery).toHaveBeenCalledWith(DAI_ARB, EOA, SAFE, ARB_CHAIN);
   });
 
+  it('does not prepare Safe custody for a direct bridge', async () => {
+    const route = makeRoute();
+    route.source = { swaps: [], creationTime: Date.now(), srcBuffer: new Decimal(0) };
+    route.sourceExecutionPaths = new Map([[ARB_CHAIN, 'safe']]);
+    route.destination = {
+      ...route.destination,
+      eoaToEphemeral: null,
+      swap: { tokenSwap: null, gasSwap: null },
+    };
+    route.bridge = {
+      provider: 'nexus',
+      amount: new Decimal('3'),
+      amounts: {
+        tokenAmount: new Decimal('3'),
+        gasInCot: new Decimal(0),
+        totalAmount: new Decimal('3'),
+      },
+      assets: [
+        {
+          chainID: ARB_CHAIN,
+          contractAddress: USDC_ARB,
+          decimals: 6,
+          eoaBalance: new Decimal('3'),
+          ephemeralBalance: new Decimal(0),
+        },
+      ],
+      chainID: ARB_CHAIN + 1,
+      decimals: 6,
+      tokenAddress: USDC_ARB,
+      estimatedFees: {
+        collection: new Decimal(0),
+        fulfilment: new Decimal(0),
+        caGas: new Decimal(0),
+        protocol: new Decimal(0),
+        solver: new Decimal(0),
+      },
+    };
+    const addSafeAccountQuery = vi.spyOn(SwapCache.prototype, 'addSafeAccountQuery');
+    const addAllowanceQuery = vi.spyOn(SwapCache.prototype, 'addAllowanceQuery');
+
+    const prepared = await prepareRoute(route, { safeDeploymentPromises: new Map() });
+
+    expect(prepared.eoaToEphemeralTransfers).toEqual([]);
+    expect(addSafeAccountQuery).not.toHaveBeenCalled();
+    expect(addAllowanceQuery).not.toHaveBeenCalled();
+  });
+
   it('builds a source EOA->Safe funding transfer targeting the predicted Safe on Safe V2 source chains', async () => {
     // Parity with v1: the source-swap executor on a Safe V2 chain is the Safe, so the EOA's input
     // ERC20 must be moved EOA -> Safe (and the Safe is the approve/permit spender) before the
@@ -533,15 +580,13 @@ describe('prepareSwapExecution', () => {
     expect(bridgeTransfer?.amount).toBe(5000000n);
   });
 
-  it('authorizes the V2 Safe for a direct COT source when swapSupported is true', async () => {
-    // Even with Safe V2 support, swapSupported selects the V2 Safe as transferFrom spender; only
-    // bridge custody goes to the ephemeral address.
+  it('authorizes the V2 Safe for a bridge followed by a destination swap', async () => {
     const route = makeRoute();
     route.source = { swaps: [], creationTime: Date.now(), srcBuffer: new Decimal(0) };
     route.destination = {
       ...route.destination,
       eoaToEphemeral: null,
-      swap: { tokenSwap: null, gasSwap: null },
+      swap: { tokenSwap: makeQuoteResponse(), gasSwap: null },
     };
     route.bridge = {
       provider: 'nexus',
@@ -630,12 +675,13 @@ describe('prepareSwapExecution', () => {
   it('skips bridge eoa->ephemeral authorization when cached allowance already covers the amount', async () => {
     const route = makeRoute();
     route.sourceExecutionPaths = new Map([[ARB_CHAIN, 'safe']]);
-    // Isolate the bridge: no source swap (this test asserts only on the bridge transfer).
+    // Isolate bridge funding from source-swap funding while retaining a destination swap, so this
+    // is not the direct EOA bridge path.
     route.source = { ...route.source, swaps: [] };
     route.destination = {
       ...route.destination,
       eoaToEphemeral: null,
-      swap: { tokenSwap: null, gasSwap: null },
+      swap: { tokenSwap: makeQuoteResponse(), gasSwap: null },
     };
     route.bridge = {
       provider: 'nexus',
@@ -685,12 +731,12 @@ describe('prepareSwapExecution', () => {
   it('ignores legacy delegation metadata and keeps Safe funding on the permit path', async () => {
     const route = makeRoute();
     route.sourceExecutionPaths = new Map([[ARB_CHAIN, 'safe']]);
-    // Isolate the bridge: no source swap, so the only setCode query is the funding EOA's.
+    // Isolate bridge funding from source-swap funding while retaining a destination swap.
     route.source = { ...route.source, swaps: [] };
     route.destination = {
       ...route.destination,
       eoaToEphemeral: null,
-      swap: { tokenSwap: null, gasSwap: null },
+      swap: { tokenSwap: makeQuoteResponse(), gasSwap: null },
     };
     route.bridge = {
       provider: 'nexus',

--- a/tests/swap/prepare.test.ts
+++ b/tests/swap/prepare.test.ts
@@ -580,7 +580,7 @@ describe('prepareSwapExecution', () => {
     expect(bridgeTransfer?.amount).toBe(5000000n);
   });
 
-  it('authorizes the V2 Safe for a bridge followed by a destination swap', async () => {
+  it('keeps no-source-swap bridge custody in the EOA before a destination swap', async () => {
     const route = makeRoute();
     route.source = { swaps: [], creationTime: Date.now(), srcBuffer: new Decimal(0) };
     route.destination = {
@@ -620,16 +620,10 @@ describe('prepareSwapExecution', () => {
       [{ ...makeChain(ARB_CHAIN, 'Arbitrum'), swapSupported: true }],
       SUPPORTED_TOKEN
     );
-    const expectedSafe = predictSafeAccountAddressV2(EOA, EPH).address;
-
     const prepared = await prepareRoute(route, { chainList });
 
     const bridgeTransfer = prepared.eoaToEphemeralTransfers.find((entry) => entry.reason === 'bridge');
-    expect(bridgeTransfer).toBeDefined();
-    expect(bridgeTransfer!.targetAddress.toLowerCase()).toBe(expectedSafe.toLowerCase());
-    const transferCall = decodeFunctionData({ abi: ERC20ABI, data: bridgeTransfer!.transferCall.data });
-    expect(transferCall.functionName).toBe('transferFrom');
-    expect((transferCall.args?.[1] as Hex).toLowerCase()).toBe(EPH.toLowerCase());
+    expect(bridgeTransfer).toBeUndefined();
   });
 
   it('does not build an eoa->ephemeral transfer for a native bridge asset (paid inline by the EOA)', async () => {
@@ -675,9 +669,7 @@ describe('prepareSwapExecution', () => {
   it('skips bridge eoa->ephemeral authorization when cached allowance already covers the amount', async () => {
     const route = makeRoute();
     route.sourceExecutionPaths = new Map([[ARB_CHAIN, 'safe']]);
-    // Isolate bridge funding from source-swap funding while retaining a destination swap, so this
-    // is not the direct EOA bridge path.
-    route.source = { ...route.source, swaps: [] };
+    // Keep a source swap so this remains the composed Safe-funded bridge path.
     route.destination = {
       ...route.destination,
       eoaToEphemeral: null,
@@ -713,7 +705,9 @@ describe('prepareSwapExecution', () => {
     };
 
     const publicClient = {
-      multicall: vi.fn().mockResolvedValue([{ result: 5000000n }, { result: 5000000n }]),
+      multicall: vi.fn().mockImplementation(async ({ contracts }: { contracts: unknown[] }) =>
+        contracts.map(() => ({ result: 5000000n, status: 'success' }))
+      ),
       getCode: vi.fn().mockResolvedValue(undefined),
       readContract: vi.fn().mockResolvedValue(0n),
     };
@@ -731,8 +725,7 @@ describe('prepareSwapExecution', () => {
   it('ignores legacy delegation metadata and keeps Safe funding on the permit path', async () => {
     const route = makeRoute();
     route.sourceExecutionPaths = new Map([[ARB_CHAIN, 'safe']]);
-    // Isolate bridge funding from source-swap funding while retaining a destination swap.
-    route.source = { ...route.source, swaps: [] };
+    // Keep a source swap so this remains the composed Safe-funded bridge path.
     route.destination = {
       ...route.destination,
       eoaToEphemeral: null,

--- a/tests/swap/route-fast-paths.test.ts
+++ b/tests/swap/route-fast-paths.test.ts
@@ -31,7 +31,6 @@ const classify = (over: {
   members: Member[];
   dstTokenAddress: Hex;
   allowDirectDestination: boolean;
-  hasGasRequest?: boolean;
   toAmountRaw?: bigint;
   mode?: SwapMode;
   cotCurrencyId?: number;
@@ -43,7 +42,6 @@ const classify = (over: {
     dstTokenAddress: over.dstTokenAddress,
     cotCurrencyId: over.cotCurrencyId ?? CurrencyID.USDC,
     allowDirectDestination: over.allowDirectDestination,
-    hasGasRequest: over.hasGasRequest ?? false,
     toAmountRaw: over.toAmountRaw ?? 1_000_000n,
     mode: over.mode ?? SwapMode.EXACT_OUT,
   });
@@ -109,21 +107,6 @@ describe('classifyFastPath', () => {
         mode: SwapMode.EXACT_OUT,
       })
     ).toEqual({ kind: 'same-token-out', familyId: CurrencyID.USDC });
-  });
-
-  it('B1 is disqualified by a gas request → falls back to the default flow (null)', () => {
-    expect(
-      classify({
-        members: [
-          { chainID: ARB_CHAIN, tokenAddress: USDT_ARB },
-          { chainID: OP_CHAIN, tokenAddress: USDT_OP },
-        ],
-        dstTokenAddress: USDT_BASE,
-        allowDirectDestination: true,
-        hasGasRequest: true,
-        mode: SwapMode.EXACT_OUT,
-      })
-    ).toBeNull();
   });
 
   it('B1 does not fire on EXACT_IN (that is the existing buildSameTokenBridgeRoute path)', () => {

--- a/tests/swap/route.test.ts
+++ b/tests/swap/route.test.ts
@@ -121,19 +121,20 @@ const makeGasQuoteResponse = (overrides?: {
 const makeBridgeQuoteResponse = () => ({
   fulfillmentBps: 0,
   sources: [
-    {
-      chainId: ARB_CHAIN,
-      tokenAddress: USDC_ARB,
-      depositFeeUsd: '0',
-      depositFeeToken: '0',
-    },
-    {
-      chainId: OP_CHAIN,
-      tokenAddress: USDC_OP,
-      depositFeeUsd: '0',
-      depositFeeToken: '0',
-    },
-  ],
+    [ARB_CHAIN, USDC_ARB],
+    [OP_CHAIN, USDC_OP],
+    [BASE_CHAIN, USDC_BASE],
+    [ARB_CHAIN, USDT_ARB],
+    [OP_CHAIN, USDT_OP],
+    [BASE_CHAIN, USDT_BASE],
+  ].map(([chainId, tokenAddress]) => ({
+    chainId,
+    tokenAddress,
+    depositFeeUsd: '0',
+    depositFeeToken: '0',
+    depositMayanFeeUsd: '0',
+    depositMayanFeeToken: '0',
+  })),
   destination: {
     chainId: BASE_CHAIN,
     tokenAddress: USDC_BASE,
@@ -866,6 +867,176 @@ describe('determineSwapRoute', () => {
       },
     });
   });
+
+  it('EXACT_IN same-token Nexus debits per-source vault collection fees from delivery', async () => {
+    const getQuote = vi.fn().mockResolvedValue({
+      fulfillmentBps: 0,
+      sources: [
+        {
+          chainId: ARB_CHAIN,
+          tokenAddress: USDT_ARB,
+          depositFeeUsd: '0.1',
+          depositFeeToken: '100000',
+          depositMayanFeeUsd: '0.2',
+          depositMayanFeeToken: '200000',
+        },
+      ],
+      destination: {
+        chainId: BASE_CHAIN,
+        tokenAddress: USDT_BASE,
+        fulfillmentFeeUsd: '0',
+        fulfillmentFeeToken: '0',
+      },
+    });
+    const route = await determineSwapRoute(
+      {
+        mode: SwapMode.EXACT_IN,
+        data: {
+          sources: [{ chainId: ARB_CHAIN, tokenAddress: USDT_ARB, amountRaw: 1_000_000n }],
+          toChainId: BASE_CHAIN,
+          toTokenAddress: USDT_BASE,
+        },
+      },
+      makeRouteOptions({
+        bridgeQuoteResponse: null,
+        chainList: makeSwapChainListWithUsdtCot(),
+        middlewareClient: { ...mockMiddleware, getQuote } as never,
+        balances: [
+          { amount: '1', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_ARB, value: 1, logo: '', name: 'Tether USD' },
+        ],
+        dstTokenInfo: makeDstTokenInfo({ contractAddress: USDT_BASE, decimals: 6, symbol: 'USDT', name: 'Tether USD' }),
+      })
+    );
+
+    expect(route.bridge?.estimatedFees.collection.toFixed()).toBe('0.1');
+    expect(route.bridge?.amounts.tokenAmount.toFixed()).toBe('0.9');
+    expect(route.bridge?.assets[0]).toMatchObject({ depositFeeRaw: 100_000n });
+    expect(route.bridge?.assets[0].depositFee?.toFixed()).toBe('0.1');
+  });
+
+  it('EXACT_IN same-token Mayan quotes only the EOA amount remaining after collection', async () => {
+    const getQuote = vi.fn().mockResolvedValue({
+      fulfillmentBps: 0,
+      sources: [
+        {
+          chainId: ARB_CHAIN,
+          tokenAddress: USDT_ARB,
+          depositFeeUsd: '0.1',
+          depositFeeToken: '100000',
+          depositMayanFeeUsd: '0.2',
+          depositMayanFeeToken: '200000',
+        },
+      ],
+      destination: {
+        chainId: BASE_CHAIN,
+        tokenAddress: USDT_BASE,
+        fulfillmentFeeUsd: '0',
+        fulfillmentFeeToken: '0',
+      },
+    });
+    const getMayanQuotes = vi.fn().mockImplementation(
+      async (request: { sources: Array<{ amount: string }> }) => ({
+        destination: { chainId: BASE_CHAIN, tokenAddress: USDT_BASE },
+        quotes: request.sources.map((source) => ({
+          source: { chainId: ARB_CHAIN, tokenAddress: USDT_ARB, amount: source.amount },
+          mayanQuote: {
+            effectiveAmountIn64: source.amount,
+            minReceived: Number(source.amount) / 1e6,
+            protocolBps: 0,
+          },
+        })),
+      })
+    );
+    const route = await determineSwapRoute(
+      {
+        mode: SwapMode.EXACT_IN,
+        data: {
+          sources: [{ chainId: ARB_CHAIN, tokenAddress: USDT_ARB, amountRaw: 1_000_000n }],
+          toChainId: BASE_CHAIN,
+          toTokenAddress: USDT_BASE,
+        },
+      },
+      makeRouteOptions({
+        bridgeQuoteResponse: null,
+        chainList: makeSwapChainListWithUsdtCot(),
+        middlewareClient: {
+          ...mockMiddleware,
+          getQuote,
+          getBridgeProvider: vi.fn().mockResolvedValue({ provider: 'mayan' }),
+          getMayanQuotes,
+        } as never,
+        balances: [
+          { amount: '1', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_ARB, value: 1, logo: '', name: 'Tether USD' },
+        ],
+        dstTokenInfo: makeDstTokenInfo({ contractAddress: USDT_BASE, decimals: 6, symbol: 'USDT', name: 'Tether USD' }),
+      })
+    );
+
+    expect(getMayanQuotes.mock.calls[0][0].sources[0].amount).toBe('800000');
+    expect(route.bridge?.estimatedFees.collection.toFixed()).toBe('0.2');
+    expect(route.bridge?.amounts.tokenAmount.toFixed()).toBe('0.8');
+  });
+
+  it('EXACT_IN direct COT bridge debits the EOA vault collection fee', async () => {
+    const getQuote = vi.fn().mockResolvedValue({
+      fulfillmentBps: 0,
+      sources: [
+        {
+          chainId: ARB_CHAIN,
+          tokenAddress: USDC_ARB,
+          depositFeeUsd: '0.1',
+          depositFeeToken: '100000',
+          depositMayanFeeUsd: '0.2',
+          depositMayanFeeToken: '200000',
+        },
+      ],
+      destination: {
+        chainId: BASE_CHAIN,
+        tokenAddress: USDC_BASE,
+        fulfillmentFeeUsd: '0',
+        fulfillmentFeeToken: '0',
+      },
+    });
+    const route = await determineSwapRoute(
+      {
+        mode: SwapMode.EXACT_IN,
+        data: {
+          sources: [{ chainId: ARB_CHAIN, tokenAddress: USDC_ARB, amountRaw: 1_000_000n }],
+          toChainId: BASE_CHAIN,
+          toTokenAddress: USDC_BASE,
+        },
+      },
+      makeRouteOptions({
+        bridgeQuoteResponse: null,
+        middlewareClient: { ...mockMiddleware, getQuote } as never,
+        balances: [
+          {
+            amount: '1',
+            chainID: ARB_CHAIN,
+            decimals: 6,
+            symbol: 'USDC',
+            tokenAddress: USDC_ARB,
+            value: 1,
+            logo: '',
+            name: 'USD Coin',
+          },
+        ],
+        dstTokenInfo: makeDstTokenInfo({
+          contractAddress: USDC_BASE,
+          decimals: 6,
+          symbol: 'USDC',
+          name: 'USD Coin',
+        }),
+      })
+    );
+
+    expect(route.sameTokenBridge).toBe(false);
+    expect(route.source.swaps).toEqual([]);
+    expect(route.destination.swap).toEqual({ tokenSwap: null, gasSwap: null });
+    expect(route.bridge?.estimatedFees.collection.toFixed()).toBe('0.1');
+    expect(route.bridge?.amounts.tokenAmount.toFixed()).toBe('0.9');
+    expect(route.bridge?.assets[0]).toMatchObject({ depositFeeRaw: 100_000n });
+  });
   it('EXACT_IN same-token: dst-chain source stays at the EOA and is not bridged', async () => {
     const input: SwapData = {
       mode: SwapMode.EXACT_IN,
@@ -939,6 +1110,53 @@ describe('determineSwapRoute', () => {
     expect(route.destination.inputAmount.max.toString()).toBe('1.5');
     // The F-quote was fetched via getQuote.
     expect(getQuote).toHaveBeenCalled();
+  });
+
+  it('B1 EXACT_OUT adds the EOA vault collection fee to the selected source debit', async () => {
+    const getQuote = vi.fn().mockResolvedValue({
+      fulfillmentBps: 0,
+      sources: [
+        {
+          chainId: ARB_CHAIN,
+          tokenAddress: USDT_ARB,
+          depositFeeUsd: '0.1',
+          depositFeeToken: '100000',
+          depositMayanFeeUsd: '0.2',
+          depositMayanFeeToken: '200000',
+        },
+      ],
+      destination: {
+        chainId: BASE_CHAIN,
+        tokenAddress: USDT_BASE,
+        fulfillmentFeeUsd: '0',
+        fulfillmentFeeToken: '0',
+      },
+    });
+    const route = await determineSwapRoute(
+      {
+        mode: SwapMode.EXACT_OUT,
+        data: {
+          sources: [{ chainId: ARB_CHAIN, tokenAddress: USDT_ARB }],
+          toChainId: BASE_CHAIN,
+          toTokenAddress: USDT_BASE,
+          toAmountRaw: 1_500_000n,
+        },
+      },
+      makeRouteOptions({
+        chainList: makeSwapChainListWithUsdtCot(),
+        middlewareClient: { ...mockMiddleware, getQuote } as never,
+        balances: [
+          { amount: '2', chainID: ARB_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_ARB, value: 2, logo: '', name: 'Tether USD' },
+        ],
+        dstTokenInfo: makeDstTokenInfo({ contractAddress: USDT_BASE, decimals: 6, symbol: 'USDT', name: 'Tether USD' }),
+      })
+    );
+
+    expect(route.bridge?.amount.toFixed()).toBe('1.6');
+    expect(route.bridge?.amounts.tokenAmount.toFixed()).toBe('1.5');
+    expect(route.bridge?.estimatedFees.collection.toFixed()).toBe('0.1');
+    expect(route.bridge?.assets[0].eoaBalance.toFixed()).toBe('1.6');
+    expect(route.bridge?.assets[0].depositFeeRaw).toBe(100_000n);
   });
   it('B1 EXACT_OUT current-COT sources bridge directly with no swap buffer (USDC→USDC)', async () => {
     const input: SwapData = {

--- a/tests/swap/route.test.ts
+++ b/tests/swap/route.test.ts
@@ -1248,6 +1248,41 @@ describe('determineSwapRoute', () => {
     expect(route.bridge!.assets).toHaveLength(1);
     expect(route.bridge!.assets[0].eoaBalance.toString()).toBe(gross.toString());
   });
+  it('B1 EXACT_OUT requests destination gas through the bridge intent', async () => {
+    const input: SwapData = {
+      mode: SwapMode.EXACT_OUT,
+      data: {
+        sources: [{ chainId: OP_CHAIN, tokenAddress: USDT_OP }],
+        toChainId: BASE_CHAIN,
+        toTokenAddress: USDT_BASE,
+        toAmountRaw: 1_000_000n,
+        toNativeAmountRaw: 1_000_000_000_000_000n,
+      },
+    };
+    const route = await determineSwapRoute(input, makeRouteOptions({
+      chainList: makeSwapChainListWithUsdtCot(),
+      middlewareClient: { ...mockMiddleware, getQuote: vi.fn().mockResolvedValue(makeBridgeQuoteResponse()) } as never,
+      oraclePrices: [
+        { universe: 'EVM', chainId: BASE_CHAIN, priceUsd: new Decimal('2500'), tokenAddress: ZERO_ADDRESS, tokenSymbol: 'ETH', tokenDecimals: 18, timestamp: 0 },
+        { universe: 'EVM', chainId: BASE_CHAIN, priceUsd: new Decimal('1'), tokenAddress: USDT_BASE, tokenSymbol: 'USDT', tokenDecimals: 6, timestamp: 0 },
+      ],
+      balances: [{ amount: '5', chainID: OP_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_OP, value: 5, logo: '', name: 'Tether USD' }],
+      dstTokenInfo: makeDstTokenInfo({ contractAddress: USDT_BASE, decimals: 6, symbol: 'USDT', name: 'Tether USD' }),
+    }));
+
+    expect(route.sameTokenBridge).toBe(true);
+    expect(route.source.swaps).toEqual([]);
+    expect(route.destination.swap).toEqual({ tokenSwap: null, gasSwap: null });
+    expect(route.bridge?.destinationGas).toMatchObject({
+      amountRaw: 1_000_000_000_000_000n,
+    });
+    expect(route.bridge?.destinationGas?.amount.toString()).toBe('0.001');
+    expect(route.bridge?.destinationGas?.amountInToken.toString()).toBe('2.5');
+    expect(route.bridge?.amounts.tokenAmount.toString()).toBe('1');
+    expect(route.bridge?.amounts.totalAmount.toString()).toBe('3.5');
+    expect(createSwapIntent(route, input, makeSwapChainListWithUsdtCot()).destination.gas.amount).toBe('0.001');
+    expect(determineDestinationSwaps).not.toHaveBeenCalled();
+  });
   it('B1 EXACT_OUT splits the grossed-up target greedily across family chains', async () => {
     const input: SwapData = {
       mode: SwapMode.EXACT_OUT,
@@ -1383,6 +1418,37 @@ describe('determineSwapRoute', () => {
     expect(route.sameTokenBridge).toBe(true);
     expect(route.bridge!.provider).toBe('mayan');
     expect(route.bridge!.mayanQuotesBySource).toBeDefined();
+  });
+  it('B1 EXACT_OUT sends destination gas on the Mayan bridge quote', async () => {
+    const input: SwapData = {
+      mode: SwapMode.EXACT_OUT,
+      data: {
+        sources: [{ chainId: OP_CHAIN, tokenAddress: USDT_OP }],
+        toChainId: ARB_CHAIN,
+        toTokenAddress: USDT_ARB,
+        toAmountRaw: 1_000_000n,
+        toNativeAmountRaw: 1_000_000_000_000_000n,
+      },
+    };
+    const middleware = mayanMiddleware(1, vi.fn().mockResolvedValue(makeBridgeQuoteResponse()));
+    const route = await determineSwapRoute(input, makeRouteOptions({
+      chainList: makeSwapChainListWithUsdtCot(),
+      middlewareClient: middleware as never,
+      oraclePrices: [
+        { universe: 'EVM', chainId: ARB_CHAIN, priceUsd: new Decimal('2500'), tokenAddress: ZERO_ADDRESS, tokenSymbol: 'ETH', tokenDecimals: 18, timestamp: 0 },
+        { universe: 'EVM', chainId: ARB_CHAIN, priceUsd: new Decimal('1'), tokenAddress: USDT_ARB, tokenSymbol: 'USDT', tokenDecimals: 6, timestamp: 0 },
+      ],
+      balances: [{ amount: '5', chainID: OP_CHAIN, decimals: 6, symbol: 'USDT', tokenAddress: USDT_OP, value: 5, logo: '', name: 'Tether USD' }],
+      dstTokenInfo: makeDstTokenInfo({ contractAddress: USDT_ARB, decimals: 6, symbol: 'USDT', name: 'Tether USD' }),
+    }));
+
+    expect(route.bridge?.provider).toBe('mayan');
+    expect(route.destination.swap).toEqual({ tokenSwap: null, gasSwap: null });
+    expect(middleware.getMayanQuotes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sources: [expect.objectContaining({ gas_drop: 0.001 })],
+      })
+    );
   });
   it('B1 EXACT_OUT explicit same-family sources fail terminally when Mayan undershoots', async () => {
     const input: SwapData = {
@@ -4213,11 +4279,11 @@ describe('determineSwapRoute', () => {
     );
     expect(route.bridge?.amount.toString()).toBe('100');
     expect(route.bridge?.amounts.totalAmount.toString()).toBe('100');
-    // Collection fee = 0 in the smart-account-only model; fulfilment/protocol still applied.
-    expect(route.bridge?.amounts.tokenAmount.toString()).toBe('97.5');
-    expect(route.bridge?.estimatedFees.collection.toString()).toBe('0');
+    // No source swap means the EOA pays the quoted vault collection fee directly.
+    expect(route.bridge?.amounts.tokenAmount.toString()).toBe('95.52');
+    expect(route.bridge?.estimatedFees.collection.toString()).toBe('2');
     expect(route.bridge?.estimatedFees.fulfilment.toString()).toBe('1.5');
-    expect(route.bridge?.estimatedFees.protocol.toString()).toBe('1');
+    expect(route.bridge?.estimatedFees.protocol.toString()).toBe('0.98');
     expect(vi.mocked(destinationSwapWithExactIn)).toHaveBeenCalled();
   });
   it('EXACT_IN coalesces direct COT and swap-produced COT on the same bridge chain', async () => {

--- a/tests/swap/swap-steps-builder.test.ts
+++ b/tests/swap/swap-steps-builder.test.ts
@@ -221,6 +221,11 @@ describe('createSwapPlan', () => {
 
   it('includes eoa_to_ephemeral_transfer only for bridge assets with eoa balance', () => {
     const route = makeRoute({
+      source: {
+        swaps: [makeQuoteResponse(42161)],
+        creationTime: Date.now(),
+        srcBuffer: new Decimal(0),
+      },
       bridge: {
         provider: 'nexus',
         amount: new Decimal(50),

--- a/tests/swap/swap-steps-builder.test.ts
+++ b/tests/swap/swap-steps-builder.test.ts
@@ -265,17 +265,22 @@ describe('createSwapPlan', () => {
     ]);
   });
 
-  it('omits eoa_to_ephemeral_transfer for a direct bridge', () => {
+  it('uses the destination token amount for an EOA bridge fill that also delivers gas', () => {
     const route = makeRoute({
       bridge: {
         provider: 'nexus',
-        amount: new Decimal(5),
+        amount: new Decimal(8),
         amounts: {
           tokenAmount: new Decimal(5),
           gasInCot: new Decimal(0),
-          totalAmount: new Decimal(5),
+          totalAmount: new Decimal(8),
         },
-        assets: [makeBridgeAsset(42161, 5)],
+        destinationGas: {
+          amount: new Decimal('0.001'),
+          amountRaw: 1_000_000_000_000_000n,
+          amountInToken: new Decimal('2.5'),
+        },
+        assets: [{ ...makeBridgeAsset(42161, 8), ephemeralBalance: new Decimal(0) }],
         chainID: 8453,
         decimals: 6,
         tokenAddress: token.contractAddress,
@@ -296,6 +301,8 @@ describe('createSwapPlan', () => {
       'bridge_deposit',
       'bridge_fill',
     ]);
+    expect(plan.steps[1]).toMatchObject({ asset: { amount: '8.000000', amountRaw: 8_000_000n } });
+    expect(plan.steps[2]).toMatchObject({ asset: { amount: '5.000000', amountRaw: 5_000_000n } });
   });
 
   it('omits any public sweep step even for ephemeral destination execution', () => {

--- a/tests/swap/swap-steps-builder.test.ts
+++ b/tests/swap/swap-steps-builder.test.ts
@@ -241,6 +241,13 @@ describe('createSwapPlan', () => {
           solver: new Decimal(0),
         },
       },
+      destination: {
+        chainId: 8453,
+        eoaToEphemeral: null,
+        inputAmount: { min: new Decimal(0), max: new Decimal(0) },
+        swap: withTokenSwap,
+        getDstSwap: async () => null,
+      },
     });
 
     const plan = createSwapPlan(route, chainList);
@@ -250,6 +257,39 @@ describe('createSwapPlan', () => {
         chain: expect.objectContaining({ id: 42161, name: 'Arbitrum' }),
         asset: expect.objectContaining({ amountRaw: 5000000n, amount: '5.000000' }),
       }),
+    ]);
+  });
+
+  it('omits eoa_to_ephemeral_transfer for a direct bridge', () => {
+    const route = makeRoute({
+      bridge: {
+        provider: 'nexus',
+        amount: new Decimal(5),
+        amounts: {
+          tokenAmount: new Decimal(5),
+          gasInCot: new Decimal(0),
+          totalAmount: new Decimal(5),
+        },
+        assets: [makeBridgeAsset(42161, 5)],
+        chainID: 8453,
+        decimals: 6,
+        tokenAddress: token.contractAddress,
+        estimatedFees: {
+          collection: new Decimal(0),
+          fulfilment: new Decimal(0),
+          caGas: new Decimal(0),
+          protocol: new Decimal(0),
+          solver: new Decimal(0),
+        },
+      },
+    });
+
+    const plan = createSwapPlan(route, chainList);
+
+    expect(plan.steps.map((step) => step.type)).toEqual([
+      'bridge_intent_submission',
+      'bridge_deposit',
+      'bridge_fill',
     ]);
   });
 


### PR DESCRIPTION
## Summary

Route swap bridges that do not require source swaps through the connected EOA, using the normal bridge custody path instead of staging funds through the ephemeral account. This covers Exact In and Exact Out, including terminal same-token Exact Out routes that deliver requested destination gas through the bridge.

## Changes
- Use the EOA as the bridge holder and RFF signer when no source swap is required.
- Skip EOA-to-ephemeral transfers and source-chain Safe deployment for EOA-funded bridge routes.
- Fill the EOA directly for terminal routes and the destination Safe when destination execution is required.
- Account for provider collection fees in EOA source debits and support destination gas delivery through Exact Out bridge intents.
- Align swap planning, progress reporting, failure cleanup, documentation, and route characterization tests with the updated custody model.

## Testing
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

## Risk / Impact

Medium. This changes custody, fee accounting, and recipient routing for swap bridge routes without source swaps. Routes containing source swaps retain the existing safe execution path. The primary risks are incorrect provider-fee sizing, bridge recipient selection, and destination-gas delivery; these paths are covered by Exact In, Exact Out, bridge-intent, execution, progress, and characterization tests.