### PR TITLE
swap: align plan previews with authorization and execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1708,6 +1708,7 @@ Swap plans contain the following step types:
 
 | Step Type | Description |
 |-----------|-------------|
+| `allowance` | Authorize an EOA-held ERC-20 with `method: 'approval' \| 'permit'` |
 | `source_swap` | Execute a swap through the Safe on a source chain |
 | `eoa_to_ephemeral_transfer` | Move EOA-held bridge funds to the ephemeral holder when source swaps are required |
 | `bridge_deposit` | Deposit into vault for cross-chain bridge |
@@ -1725,6 +1726,7 @@ type SwapPlan = {
 };
 
 type SwapPlanStep =
+  | SwapAllowanceStep
   | SwapSourceSwapStep
   | SwapEoaToEphemeralTransferStep
   | SwapBridgeDepositStep
@@ -1733,9 +1735,13 @@ type SwapPlanStep =
   | SwapDestinationSwapStep;
 ```
 
-Each step carries contextual metadata such as its chain and tokens. Source and destination swap steps also expose `walletPath: 'safe'`. Progress events report per-step state transitions. The terminal success state varies by step type:
+Each step carries contextual metadata such as its chain and tokens. Swap allowance steps expose
+`method: 'approval' | 'permit'`; source swaps expose `submissionMode: 'eoa' | 'sponsored'` in
+addition to `walletPath: 'safe'`. Source chains are ordered by numeric chain ID, and native-value
+batches are ordered first within a chain and use `submissionMode: 'eoa'`. Progress events report
+per-step state transitions. The terminal success state varies by step type:
 
-- On-chain transaction steps (`allowance_approval`, `source_swap`, `eoa_to_ephemeral_transfer`, `bridge_deposit`, `destination_swap`, `execute_approval`, `execute_transaction`) settle on `confirmed`.
+- On-chain transaction steps (`allowance`, `allowance_approval`, `source_swap`, `eoa_to_ephemeral_transfer`, `bridge_deposit`, `destination_swap`, `execute_approval`, `execute_transaction`) settle on `confirmed`. A permit-only `allowance` can instead settle on `signed` when no authorization transaction is submitted.
 - `vault_deposit` settles on `completed` — it emits `confirmed` as an on-chain intermediate, then `completed` as its terminal-success state.
 - Off-chain orchestration steps (`request_signing`, `request_submission`, `bridge_intent_submission`, `bridge_fill`) settle on `completed`.
 - All steps can emit `failed`.
@@ -1748,7 +1754,7 @@ Each `plan_progress` event carries `type: 'plan_progress'`, `stepType`, `state`,
 
 | Field | On | Meaning |
 |-------|----|---------|
-| `txHash` / `explorerUrl` | on-chain steps in `submitted` / `confirmed` (optional on `failed`): `allowance_approval`, `vault_deposit`, `execute_approval`, `execute_transaction`, and source/destination swap steps | The submitted transaction hash and its explorer URL — use for "View tx" links |
+| `txHash` / `explorerUrl` | on-chain steps in `submitted` / `confirmed` (optional on `failed`): `allowance`, `allowance_approval`, `vault_deposit`, `execute_approval`, `execute_transaction`, and source/destination swap steps | The submitted transaction hash and its explorer URL — use for "View tx" links |
 | `intentRequestHash` | `request_signing` (`completed`), `request_submission`, `bridge_fill` | The intent/RFF hash — use for "View intent" links |
 | `error` | every `failed` state | Failure text (already inlined; the underlying cause is here) |
 | `approvedAmount` / `approvedAmountRaw` | `allowance_approval` | Amount approved at this step |
@@ -1771,7 +1777,7 @@ client.bridge(params, {
 });
 ```
 
-Per-step `step` shapes (all include `id` and `type`): `allowance_approval` → `chain`, `token`, `spender`, `requiredAmount`; `vault_deposit` → `chain`, `asset`, `assetType`, `submissionMode`; `bridge_fill` → `chain`, `asset`; `execute_approval` → `chain`, `token`, `spender`, `amount`; `execute_transaction` → `chain`, `to`. Swap source/destination steps carry `swaps[]` with `input`/`output` token amounts.
+Per-step `step` shapes (all include `id` and `type`): swap `allowance` → `method`, `chain`, `token`, `spender`, `amount`; bridge `allowance_approval` → `chain`, `token`, `spender`, `requiredAmount`; `vault_deposit` → `chain`, `asset`, `assetType`, `submissionMode`; `bridge_fill` → `chain`, `asset`; `execute_approval` → `chain`, `token`, `spender`, `amount`; `execute_transaction` → `chain`, `to`. Swap source/destination steps carry `swaps[]` with `input`/`output` token amounts, and source steps also carry `submissionMode`.
 
 ### Building Progress UIs
 
@@ -2274,17 +2280,18 @@ if (result.bridgeSkipped) {
 Every source and destination swap executes through the deterministic V2 Safe. 
 
 The Safe has the connected EOA and the SDK's ephemeral account as owners with threshold 1. Its
-address is derived once and is deterministic across supported chains. While the intent is displayed,
-the SDK caches whether that address has bytecode on every execution chain. After approval, it skips
+address is derived once and is deterministic across supported chains. Before the intent and plan are
+displayed, the SDK resolves allowance, permit-capability, and Safe bytecode reads so EOA
+authorization steps are accurate. After approval, it skips
 middleware for deployed Safes and concurrently ensures only the missing ones, awaiting the relevant
 deployment before the first permit, approval, or transaction prompt on that chain. A successful
 ensure updates the same cache so later execution does not repeat the bytecode check. This ensures
 wallet UIs see a deployed contract as the spender instead of warning about an approval to an
 undeployed address.
 
-Read-only allowance, permit-capability, and Safe-code cache requests start while the swap intent is
-displayed and are awaited after approval. Refreshing an intent reuses that work when its cache query
-data is unchanged.
+Refreshing an intent resolves the refreshed route's read-only authorization data before emitting its
+replacement plan preview. Wallet signatures, approval transactions, and swap transactions remain
+gated behind intent acceptance.
 
 Token-only Safe transactions are sponsor-broadcast through middleware. Native-value Safe
 transactions are submitted by the EOA because the outer transaction must fund the Safe call. The
@@ -2297,8 +2304,8 @@ Mayan, including routes nested inside `swapAndExecute`. The route does not trans
 the ephemeral holder or require a Safe on its source chains. If a destination swap is required, the
 bridge still fills the destination Safe; otherwise it fills the EOA. Exact-out same-token routes can
 also request destination gas through the bridge intent and fill both outputs directly to the EOA.
-Swap intent fields and plan step types are unchanged; the `eoa_to_ephemeral_transfer` step is simply
-absent.
+The plan includes an EOA vault `allowance` step when authorization is required; the
+`eoa_to_ephemeral_transfer` step remains absent.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -145,8 +145,8 @@ swap(params)
      -> swap/preflight.ts
      -> swap/route.ts: determineSwapRoute(...)
         -> swap/routing/exact-in.ts | exact-out.ts
-     -> createSwapIntent(...)
      -> start allowance, permit-capability, and Safe-code cache reads
+     -> await cache and createSwapIntent(...) + allowance-aware SwapPlan
      -> onIntent({ allow, deny, refresh, intent })
      -> swap/prepare.ts: prepareSwapExecution(...) awaits the accepted route's cache
      -> swap/execution/orchestrator.ts: executeSwapRoute(...)
@@ -165,8 +165,9 @@ source holder, RFF party, and signer; ERC-20 allowance targets the vault; native
 directly by the EOA. It does not prepare EOA-to-ephemeral transfers or deploy a Safe on its source
 chains. The bridge fills the destination Safe when a destination swap is required and the EOA
 otherwise. Terminal same-token Exact Out routes can request destination gas through the bridge
-intent and deliver both token and native outputs directly to the EOA. The public swap intent and
-step types remain unchanged, and `swapAndExecute` inherits the behavior through its nested route.
+intent and deliver both token and native outputs directly to the EOA. The swap plan exposes any
+required EOA vault authorization as an `allowance` step, and `swapAndExecute` inherits the behavior
+through its nested route.
 
 Swap preflight does not request bridge-fee quotes. After terminal direct/same-token paths, routing
 chooses between USDC and USDT by counting required source and destination swap legs; ties retain the
@@ -186,7 +187,8 @@ parallelize non-EOA work such as route requests, public-client reads, per-chain 
 sponsored Safe execution, and receipt waits.
 
 Safe V2 is the only aggregator-swap execution account. The flow derives its address once, then
-checks bytecode on every Safe execution chain as part of the read-only cache warmup while the intent is displayed. After
+checks bytecode on every Safe execution chain as part of the read-only cache warmup before the
+intent and allowance-aware plan are displayed. After
 intent approval, already deployed Safes skip middleware and absent Safes are ensured concurrently.
 A successful ensure marks the shared cache deployed for that chain. Preparation and execution await
 the chain promise before requesting any permit, direct approval, or EOA transaction, so wallet UIs
@@ -218,7 +220,8 @@ If no hooks are provided, the SDK auto-accepts intent and allowance.
 intent is accepted.
 
 For swap operations, the exposed hook is `onIntent(...)`. Swap does not expose a separate
-`onAllowance` hook; allowance and permit handling are part of swap execution preparation.
+`onAllowance` hook; required EOA authorization is included in the swap plan and executed
+automatically after intent acceptance.
 
 Bridge hook internals are split by responsibility:
 

--- a/src/analytics/lifecycle-translator.ts
+++ b/src/analytics/lifecycle-translator.ts
@@ -212,6 +212,7 @@ export function translateSwapEvent(
   if (event.type !== 'plan_progress') return;
 
   const onChainStepTypes = new Set([
+    'allowance',
     'source_swap',
     'eoa_to_ephemeral_transfer',
     'bridge_deposit',

--- a/src/domain/types/index.ts
+++ b/src/domain/types/index.ts
@@ -56,6 +56,8 @@ export type {
 } from './event-common';
 export type { PlanTokenAmount, PlanTokenMetadata } from './plan-common';
 export type {
+  SwapAllowanceProgressEvent,
+  SwapAllowanceStep,
   SwapAndExecuteEvent,
   SwapAndExecutePlan,
   SwapAndExecutePlanConfirmedEvent,

--- a/src/domain/types/swap-events.ts
+++ b/src/domain/types/swap-events.ts
@@ -12,7 +12,7 @@ import type {
   PlanProgressFailedBase,
   StatusEvent,
 } from './event-common';
-import type { PlanTokenAmount } from './plan-common';
+import type { PlanTokenAmount, PlanTokenMetadata } from './plan-common';
 
 export type SwapStatus =
   | 'route_building'
@@ -30,6 +30,20 @@ export type SwapPlan = {
   steps: SwapPlanStep[];
 };
 
+export type SwapAllowanceStep = {
+  type: 'allowance';
+  id: string;
+  method: 'approval' | 'permit';
+  chain: {
+    id: number;
+    name: string;
+    logo: string;
+  };
+  token: PlanTokenMetadata;
+  spender: Hex;
+  amount: PlanTokenAmount;
+};
+
 export type SwapSourceSwapStep = {
   type: 'source_swap';
   id: string;
@@ -39,6 +53,7 @@ export type SwapSourceSwapStep = {
     logo: string;
   };
   walletPath: 'safe';
+  submissionMode: 'eoa' | 'sponsored';
   swaps: {
     input: PlanTokenAmount;
     output: PlanTokenAmount;
@@ -88,6 +103,7 @@ export type SwapDestinationSwapStep = {
 };
 
 export type SwapPlanStep =
+  | SwapAllowanceStep
   | SwapSourceSwapStep
   | SwapEoaToEphemeralTransferStep
   | SwapBridgeDepositStep
@@ -98,6 +114,31 @@ export type SwapPlanStep =
 export type SwapPlanPreviewEvent = PlanPreviewEvent<SwapPlan>;
 export type SwapPlanConfirmedEvent = PlanConfirmedEvent<SwapPlan>;
 export type SwapPlanProgressFailedBase = PlanProgressFailedBase<SwapPlanStep>;
+
+export type SwapAllowanceProgressEvent =
+  | {
+      type: 'plan_progress';
+      stepType: 'allowance';
+      state: 'wallet_prompted' | 'signed';
+      step: SwapAllowanceStep;
+    }
+  | {
+      type: 'plan_progress';
+      stepType: 'allowance';
+      state: 'submitted' | 'confirmed';
+      step: SwapAllowanceStep;
+      txHash: Hex;
+      explorerUrl: string;
+    }
+  | {
+      type: 'plan_progress';
+      stepType: 'allowance';
+      state: 'failed';
+      step: SwapAllowanceStep;
+      txHash?: Hex;
+      explorerUrl?: string;
+      error: string;
+    };
 
 export type SwapSourceSwapProgressEvent =
   | {
@@ -269,6 +310,7 @@ export type SwapDestinationSwapProgressEvent =
     };
 
 export type SwapPlanProgressEvent =
+  | SwapAllowanceProgressEvent
   | SwapSourceSwapProgressEvent
   | SwapEoaToEphemeralTransferProgressEvent
   | SwapBridgeDepositProgressEvent

--- a/src/flows/swap.ts
+++ b/src/flows/swap.ts
@@ -90,27 +90,61 @@ export type SwapPreviewState = {
 const createSwapPreviewStateFromRoute = (
   route: SwapRoute,
   input: SwapData,
-  chainList: SwapDeps['chainList']
+  chainList: SwapDeps['chainList'],
+  authorization?: {
+    cache: SwapCacheWarmup['cache'];
+    eoaAddress: Hex;
+    safeAddress: Hex;
+  }
 ): SwapPreviewState => {
   const intent = createSwapIntent(route, input, chainList);
 
   return {
     route,
     intent,
-    plan: createSwapPlan(route, chainList),
+    plan: createSwapPlan(route, chainList, authorization),
+  };
+};
+
+const buildSwapPreviewStateWithWarmup = async (
+  input: SwapData,
+  context: SwapPreviewContext
+): Promise<{ previewState: SwapPreviewState; cacheWarmup: SwapCacheWarmup }> => {
+  const route = await determineSwapRoute(
+    input,
+    createRouteOptions(context, context.preflight, input)
+  );
+  const safeAccount = predictSafeAccountAddressV2(
+    context.eoaAddress,
+    context.ephemeralWallet.address
+  );
+  const cacheWarmup = startSwapCacheWarmup({
+    chainList: context.chainList,
+    route,
+    source: route.source,
+    destination: route.destination,
+    eoaAddress: context.eoaAddress,
+    ephemeralWallet: context.ephemeralWallet,
+    publicClientList: context.preflight.publicClientList,
+    timing: context.timing,
+    safeAccount,
+  });
+  await cacheWarmup.process;
+  return {
+    previewState: createSwapPreviewStateFromRoute(route, input, context.chainList, {
+      cache: cacheWarmup.cache,
+      eoaAddress: context.eoaAddress,
+      safeAddress: context.safeAddress,
+    }),
+    cacheWarmup,
   };
 };
 
 export const buildSwapPreviewState = async (
   input: SwapData,
   context: SwapPreviewContext
-): Promise<SwapPreviewState> => {
-  const route = await determineSwapRoute(
-    input,
-    createRouteOptions(context, context.preflight, input)
-  );
-  return createSwapPreviewStateFromRoute(route, input, context.chainList);
-};
+): Promise<SwapPreviewState> =>
+  (await buildSwapPreviewStateWithWarmup(input, context)).previewState;
 
 const waitForIntentApproval = (
   onIntent: NonNullable<SwapFlowOptions['onIntent']>,
@@ -118,7 +152,7 @@ const waitForIntentApproval = (
   input: SwapData,
   deps: SwapDeps,
   safeAddress: Hex,
-  onPreviewStateUpdated?: (nextPreviewState: SwapPreviewState) => void
+  onPreviewStateUpdated?: (nextPreviewState: SwapPreviewState, cacheWarmup: SwapCacheWarmup) => void
 ): Promise<SwapPreviewState> => {
   return new Promise<SwapPreviewState>((resolve, reject) => {
     let accepted = false;
@@ -152,7 +186,7 @@ const waitForIntentApproval = (
         middlewareClient: deps.middlewareClient,
       });
 
-      currentPreviewState = await buildSwapPreviewState(refreshedInput, {
+      const refreshed = await buildSwapPreviewStateWithWarmup(refreshedInput, {
         chainList: deps.chainList,
         eoaAddress: deps.evm.address,
         ephemeralWallet: deps.swap.ephemeralWallet,
@@ -163,7 +197,8 @@ const waitForIntentApproval = (
         preflight,
         safeAddress,
       });
-      onPreviewStateUpdated?.(currentPreviewState);
+      currentPreviewState = refreshed.previewState;
+      onPreviewStateUpdated?.(currentPreviewState, refreshed.cacheWarmup);
       return currentPreviewState.intent;
     };
 
@@ -235,26 +270,25 @@ const runSwapFlow = async (
       )
     )
   );
+  let cacheWarmup = startSwapCacheWarmup({
+    chainList: deps.chainList,
+    route,
+    source: route.source,
+    destination: route.destination,
+    eoaAddress: deps.evm.address,
+    ephemeralWallet: deps.swap.ephemeralWallet,
+    publicClientList: preflight.publicClientList,
+    timing: deps.timing,
+    safeAccount,
+  });
+  await cacheWarmup.process;
   let previewState = await withTimingSpan(deps.timing, 'flow.swap.create_intent', async () =>
-    createSwapPreviewStateFromRoute(route, input, deps.chainList)
+    createSwapPreviewStateFromRoute(route, input, deps.chainList, {
+      cache: cacheWarmup.cache,
+      eoaAddress: deps.evm.address,
+      safeAddress: safeAccount.address,
+    })
   );
-
-  const warmCacheForRoute = (nextRoute: SwapRoute, previous?: SwapCacheWarmup): SwapCacheWarmup =>
-    startSwapCacheWarmup(
-      {
-        chainList: deps.chainList,
-        route: nextRoute,
-        source: nextRoute.source,
-        destination: nextRoute.destination,
-        eoaAddress: deps.evm.address,
-        ephemeralWallet: deps.swap.ephemeralWallet,
-        publicClientList: preflight.publicClientList,
-        timing: deps.timing,
-        safeAccount,
-      },
-      previous
-    );
-  let cacheWarmup = warmCacheForRoute(route);
 
   emitStatus('route_ready');
   emitPlanPreview(previewState.plan);
@@ -269,10 +303,10 @@ const runSwapFlow = async (
           input,
           deps,
           safeAccount.address,
-          (nextPreviewState) => {
+          (nextPreviewState, nextCacheWarmup) => {
             previewState = nextPreviewState;
             route = nextPreviewState.route;
-            cacheWarmup = warmCacheForRoute(route, cacheWarmup);
+            cacheWarmup = nextCacheWarmup;
             emitPlanPreview(nextPreviewState.plan);
           }
         )

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,8 @@ export type {
   Shortfall,
   StatusEvent,
   SupportedChainsAndTokensResult,
+  SwapAllowanceProgressEvent,
+  SwapAllowanceStep,
   SwapAndExecuteEvent,
   SwapAndExecuteIntent,
   SwapAndExecuteOnIntentHookData,

--- a/src/services/step-ids.ts
+++ b/src/services/step-ids.ts
@@ -23,6 +23,12 @@ export const createExecuteTransactionStepId = (chainId: number, to: Hex): string
 
 export const createSourceSwapStepId = (chainId: number): string => `source_swap:${chainId}`;
 
+export const createSwapAllowanceStepId = (
+  reason: 'source' | 'destination' | 'bridge',
+  chainId: number,
+  tokenAddress: Hex
+): string => `allowance:${reason}:${chainId}:${normalizeAddress(tokenAddress)}`;
+
 export const createEoaToEphemeralTransferStepId = (chainId: number): string =>
   `eoa_to_ephemeral_transfer:${chainId}`;
 

--- a/src/swap/execution/bridge.ts
+++ b/src/swap/execution/bridge.ts
@@ -39,6 +39,7 @@ import {
 import {
   createBridgeDepositStepId,
   createEoaToEphemeralTransferStepId,
+  createSwapAllowanceStepId,
 } from '../../services/step-ids';
 import { minutesFromNow } from '../../services/time';
 import { withTimingSpan } from '../../services/timing';
@@ -260,14 +261,6 @@ const resolveFundingTransferCalls = async (
     authorizationKind,
     amountRaw: transfer.amount.toString(),
   });
-  if (transfer.authorization) {
-    ctx.onProgress?.({
-      stepType: 'eoa_to_ephemeral_transfer',
-      chainId: asset.chainID,
-      state: 'wallet_prompted',
-    });
-  }
-
   let lastError: unknown;
   for (let attempt = 1; attempt <= MAX_BRIDGE_FUNDING_ATTEMPTS; attempt++) {
     try {
@@ -278,6 +271,8 @@ const resolveFundingTransferCalls = async (
         eoaAddress: ctx.eoaAddress,
         eoaWallet: ctx.eoaWallet,
         publicClient,
+        cache: ctx.cache,
+        onProgress: ctx.onProgress,
         safeDeploymentPromise,
       });
       logger.debug('swap.execute.bridge.funding.completed', {
@@ -429,7 +424,9 @@ const runMayanEphemeralBridge = async (
 
   const runApprove = (asset: BridgeAsset, fundingCalls: SafeCall[]) =>
     (async () => {
-      ctx.onProgress?.({ stepType: 'bridge_deposit', chainId: asset.chainID, state: 'started' });
+      if (!hasEoaFunding(asset)) {
+        ctx.onProgress?.({ stepType: 'bridge_deposit', chainId: asset.chainID, state: 'started' });
+      }
 
       const totalBalanceRaw = mulDecimals(
         asset.eoaBalance.plus(asset.ephemeralBalance),
@@ -489,6 +486,7 @@ const runMayanEphemeralBridge = async (
           txHash,
           explorerUrl,
         });
+        ctx.onProgress?.({ stepType: 'bridge_deposit', chainId: asset.chainID, state: 'started' });
       }
       ctx.onProgress?.({
         stepType: 'bridge_deposit',
@@ -925,6 +923,27 @@ const executeEoaBridgePath = async (
       evm: { address: ctx.eoaAddress, walletClient: ctx.eoaWallet },
     },
     dstChain,
+    onProgress: (update) => {
+      const base = {
+        stepType: 'allowance' as const,
+        stepId: createSwapAllowanceStepId('bridge', update.chainId, update.tokenAddress),
+        chainId: update.chainId,
+      };
+      if (update.state === 'submitted' || update.state === 'confirmed') {
+        ctx.onProgress?.({
+          ...base,
+          state: update.state,
+          txHash: update.txHash,
+          explorerUrl: update.explorerUrl,
+        });
+        return;
+      }
+      if (update.state === 'failed') {
+        ctx.onProgress?.({ ...base, state: 'failed', error: update.error });
+        return;
+      }
+      ctx.onProgress?.({ ...base, state: 'wallet_prompted' });
+    },
   });
 
   const result = await executeBridgeFromIntent(intent, {
@@ -1050,11 +1069,15 @@ const executeEphemeralBridgePath = async (
       logger.debug('swap.execute.bridge.deposit_sbc_build.started', {
         chainId: asset.chainID,
       });
-      ctx.onProgress?.({
-        stepType: 'bridge_deposit',
-        chainId: asset.chainID,
-        state: 'started',
-      });
+      const includesFundingTransfer =
+        hasEoaFunding(asset) && !isNativeAddress(asset.contractAddress);
+      if (!includesFundingTransfer) {
+        ctx.onProgress?.({
+          stepType: 'bridge_deposit',
+          chainId: asset.chainID,
+          state: 'started',
+        });
+      }
 
       const chainIndex = depositRequest.sources.findIndex(
         (source) => Number(source.chainID) === asset.chainID
@@ -1128,13 +1151,18 @@ const executeEphemeralBridgePath = async (
       }
       const explorerUrl = createExplorerTxURL(txHash, chain.blockExplorers?.default?.url ?? '');
 
-      if (hasEoaFunding(asset) && !nativeAsset) {
+      if (includesFundingTransfer) {
         ctx.onProgress?.({
           stepType: 'eoa_to_ephemeral_transfer',
           chainId: asset.chainID,
           state: 'submitted',
           txHash,
           explorerUrl,
+        });
+        ctx.onProgress?.({
+          stepType: 'bridge_deposit',
+          chainId: asset.chainID,
+          state: 'started',
         });
       }
 
@@ -1152,7 +1180,7 @@ const executeEphemeralBridgePath = async (
         label: 'Bridge deposit',
       });
 
-      if (hasEoaFunding(asset) && !nativeAsset) {
+      if (includesFundingTransfer) {
         ctx.onProgress?.({
           stepType: 'eoa_to_ephemeral_transfer',
           chainId: asset.chainID,

--- a/src/swap/execution/destination-swap.ts
+++ b/src/swap/execution/destination-swap.ts
@@ -69,6 +69,7 @@ const buildDestinationCalls = async (
     | 'chainList'
     | 'eoaAddress'
     | 'eoaWallet'
+    | 'onProgress'
     | 'ephemeralWallet'
     | 'publicClientList'
     | 'cache'
@@ -98,6 +99,8 @@ const buildDestinationCalls = async (
           eoaAddress: ctx.eoaAddress,
           eoaWallet: ctx.eoaWallet,
           publicClient: ctx.publicClientList.get(destination.chainId),
+          cache: ctx.cache,
+          onProgress: ctx.onProgress,
           safeDeploymentPromise: requireSafeDeployment(
             ctx.safeDeploymentPromises,
             destination.chainId

--- a/src/swap/execution/direct-destination.ts
+++ b/src/swap/execution/direct-destination.ts
@@ -25,6 +25,7 @@ import {
   sizeDirectDestinationExactOut,
 } from '../algorithms/direct-destination-size';
 import { DIRECT_DST_QUOTE_TTL_MS, SRC_BUFFER_MAX_USD, SRC_BUFFER_PCT } from '../constants';
+import { isNativeSourceSwap, orderSourceSwaps } from '../source-order';
 import type {
   ExecutionContext,
   OraclePriceResponse,
@@ -49,10 +50,7 @@ type FundingAuthorization = {
   approvalMined: boolean;
 };
 
-const isNativeInput = (swap: QuoteResponse) => isNativeAddress(swap.quote.input.contractAddress);
-
-const sortSwaps = (swaps: QuoteResponse[]) =>
-  [...swaps].sort((left, right) => Number(isNativeInput(right)) - Number(isNativeInput(left)));
+const isNativeInput = isNativeSourceSwap;
 
 const toMetadataSwap = (swap: QuoteResponse) => ({
   inputAmount: swap.quote.input.amountRaw,
@@ -138,7 +136,7 @@ const buildCalls = async (input: {
 }): Promise<SafeCall[]> => {
   const { swaps, chainId, targetAddress, ctx, authorizations, routeTimeInputs, oraclePrices } =
     input;
-  const orderedSwaps = sortSwaps(swaps);
+  const orderedSwaps = orderSourceSwaps(swaps);
   const chain = ctx.chainList.getChainByID(chainId);
   const publicClient = ctx.publicClientList.get(chainId);
   const tokenTotals = new Map<
@@ -227,6 +225,8 @@ const buildCalls = async (input: {
         eoaAddress: ctx.eoaAddress,
         eoaWallet: ctx.eoaWallet,
         publicClient,
+        cache: ctx.cache,
+        onProgress: ctx.onProgress,
         safeDeploymentPromise: requireSafeDeployment(ctx.safeDeploymentPromises, chainId),
       })
     );

--- a/src/swap/execution/eoa-to-ephemeral.ts
+++ b/src/swap/execution/eoa-to-ephemeral.ts
@@ -1,10 +1,11 @@
 import type { Hex, PublicClient, WalletClient } from 'viem';
 import { type Chain, getLogger } from '../../domain';
 import { confirmStepReceipt, switchChain } from '../../services/evm';
+import { createExplorerTxURL } from '../../services/explorer';
 import type { SafeCall } from '../../services/safe';
-import { createEoaToEphemeralTransferStepId } from '../../services/step-ids';
+import { createSwapAllowanceStepId } from '../../services/step-ids';
 import type { EnsureSafeAccountV2Response } from '../safe/types';
-import type { PreparedEoaToEphemeralTransfer } from '../types';
+import type { PreparedEoaToEphemeralTransfer, SwapExecutionProgressUpdate } from '../types';
 import type { SwapCache } from '../wallet/cache';
 import {
   buildDirectApprovalRequest,
@@ -25,6 +26,7 @@ type ResolvePreparedFundingTransferCallsInput = {
   >;
   cache?: Pick<SwapCache, 'getAllowance'> & Partial<Pick<SwapCache, 'setAllowance'>>;
   safeDeploymentPromise: Promise<EnsureSafeAccountV2Response>;
+  onProgress?: (update: SwapExecutionProgressUpdate) => void;
 };
 
 const ensureDirectApproval = async (
@@ -52,6 +54,17 @@ const ensureDirectApproval = async (
     tokenAddress: input.transfer.tokenAddress,
     amountRaw: input.transfer.amount.toString(),
   });
+  const stepId = createSwapAllowanceStepId(
+    input.transfer.reason,
+    input.chain.id,
+    input.transfer.tokenAddress
+  );
+  input.onProgress?.({
+    stepType: 'allowance',
+    stepId,
+    chainId: input.chain.id,
+    state: 'wallet_prompted',
+  });
   await switchChain(input.eoaWallet, input.chain);
   const txHash = await input.eoaWallet.writeContract(
     buildDirectApprovalRequest({
@@ -68,9 +81,18 @@ const ensureDirectApproval = async (
     tokenAddress: input.transfer.tokenAddress,
     txHash,
   });
+  const explorerUrl = createExplorerTxURL(txHash, input.chain.blockExplorers?.default?.url);
+  input.onProgress?.({
+    stepType: 'allowance',
+    stepId,
+    chainId: input.chain.id,
+    state: 'submitted',
+    txHash,
+    explorerUrl,
+  });
   await confirmStepReceipt(input.publicClient, txHash, input.chain.id, {
-    stepId: createEoaToEphemeralTransferStepId(input.chain.id),
-    stepType: 'eoa_to_ephemeral_transfer',
+    stepId,
+    stepType: 'allowance',
     label: 'EOA approval',
   });
   input.cache?.setAllowance?.(
@@ -84,6 +106,14 @@ const ensureDirectApproval = async (
     chainId: input.chain.id,
     tokenAddress: input.transfer.tokenAddress,
     txHash,
+  });
+  input.onProgress?.({
+    stepType: 'allowance',
+    stepId,
+    chainId: input.chain.id,
+    state: 'confirmed',
+    txHash,
+    explorerUrl,
   });
 };
 
@@ -103,36 +133,73 @@ export const resolvePreparedFundingTransferCalls = async (
   });
 
   const authorization = input.transfer.authorization;
-  if (authorization?.kind === 'permit') {
-    logger.debug('swap.execute.funding.permit_started', {
-      chainId: input.chain.id,
-      tokenAddress: input.transfer.tokenAddress,
-      amountRaw: input.transfer.amount.toString(),
-    });
-    const permitCall = await materializePermitAuthorizationCall({
-      chain: input.chain,
-      authorization,
-      tokenAddress: input.transfer.tokenAddress,
-      tokenDecimals: input.tokenDecimals,
-      amount: input.transfer.amount,
-      eoaAddress: input.eoaAddress,
-      eoaWallet: input.eoaWallet,
-      // The Safe is the permit spender.
-      ephemeralAddress: input.transfer.targetAddress,
-      publicClient: input.publicClient as PublicClient,
-    });
-    if (!permitCall) {
-      throw new Error(`Missing permit calldata for ${input.transfer.tokenAddress}`);
+  try {
+    if (authorization?.kind === 'permit') {
+      const needsSignature = authorization.call === null;
+      const stepId = createSwapAllowanceStepId(
+        input.transfer.reason,
+        input.chain.id,
+        input.transfer.tokenAddress
+      );
+      if (needsSignature) {
+        input.onProgress?.({
+          stepType: 'allowance',
+          stepId,
+          chainId: input.chain.id,
+          state: 'wallet_prompted',
+        });
+      }
+      logger.debug('swap.execute.funding.permit_started', {
+        chainId: input.chain.id,
+        tokenAddress: input.transfer.tokenAddress,
+        amountRaw: input.transfer.amount.toString(),
+      });
+      const permitCall = await materializePermitAuthorizationCall({
+        chain: input.chain,
+        authorization,
+        tokenAddress: input.transfer.tokenAddress,
+        tokenDecimals: input.tokenDecimals,
+        amount: input.transfer.amount,
+        eoaAddress: input.eoaAddress,
+        eoaWallet: input.eoaWallet,
+        // The Safe is the permit spender.
+        ephemeralAddress: input.transfer.targetAddress,
+        publicClient: input.publicClient as PublicClient,
+      });
+      if (!permitCall) {
+        throw new Error(`Missing permit calldata for ${input.transfer.tokenAddress}`);
+      }
+      calls.push(permitCall);
+      if (needsSignature) {
+        input.onProgress?.({
+          stepType: 'allowance',
+          stepId,
+          chainId: input.chain.id,
+          state: 'signed',
+        });
+      }
+      logger.debug('swap.execute.funding.permit_completed', {
+        chainId: input.chain.id,
+        tokenAddress: input.transfer.tokenAddress,
+      });
     }
-    calls.push(permitCall);
-    logger.debug('swap.execute.funding.permit_completed', {
-      chainId: input.chain.id,
-      tokenAddress: input.transfer.tokenAddress,
-    });
-  }
 
-  if (input.transfer.authorization?.kind === 'approve') {
-    await ensureDirectApproval(input);
+    if (authorization?.kind === 'approve') {
+      await ensureDirectApproval(input);
+    }
+  } catch (error) {
+    input.onProgress?.({
+      stepType: 'allowance',
+      stepId: createSwapAllowanceStepId(
+        input.transfer.reason,
+        input.chain.id,
+        input.transfer.tokenAddress
+      ),
+      chainId: input.chain.id,
+      state: 'failed',
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
   }
 
   calls.push(input.transfer.transferCall);

--- a/src/swap/execution/source-swaps.ts
+++ b/src/swap/execution/source-swaps.ts
@@ -10,7 +10,6 @@ import {
   NexusError,
   UserActionError,
 } from '../../domain/errors';
-import { isNativeAddress } from '../../services/addresses';
 import { confirmStepReceipt } from '../../services/evm';
 import { createExplorerTxURL } from '../../services/explorer';
 import { isUserRejectedRequest } from '../../services/is-user-rejected-request';
@@ -26,6 +25,7 @@ import {
   QuoteSeriousness,
   QuoteType,
 } from '../aggregators/types';
+import { groupSourceSwapsByChain, isNativeSourceSwap, orderSourceSwaps } from '../source-order';
 import type {
   BridgeAsset,
   ExecutionContext,
@@ -60,10 +60,7 @@ type ConfirmedSourceChain = DispatchedSourceChain & {
   txHash: Hex;
 };
 
-const isNativeInput = (swap: QuoteResponse) => isNativeAddress(swap.quote.input.contractAddress);
-
-const sortSourceSwaps = (swaps: QuoteResponse[]) =>
-  [...swaps].sort((left, right) => Number(isNativeInput(left)) * -1 + Number(isNativeInput(right)));
+const isNativeInput = isNativeSourceSwap;
 
 const getPreparedSourceTransfer = (
   swap: QuoteResponse,
@@ -88,6 +85,7 @@ const buildSourceCalls = async (
     | 'eoaAddress'
     | 'eoaWallet'
     | 'publicClientList'
+    | 'onProgress'
     | 'safeAddress'
     | 'safeDeploymentPromises'
   >,
@@ -98,7 +96,7 @@ const buildSourceCalls = async (
   const publicClient = ctx.publicClientList.get(chainId);
   const chain = ctx.chainList.getChainByID(chainId);
 
-  for (const swap of sortSourceSwaps(chainSwaps)) {
+  for (const swap of orderSourceSwaps(chainSwaps)) {
     const parsedQuote = getParsedQuote(swap, ctx.preparedExecution?.parsedQuotes);
     const nativeInput = isNativeInput(swap);
 
@@ -123,6 +121,7 @@ const buildSourceCalls = async (
             eoaWallet: ctx.eoaWallet,
             publicClient,
             cache: ctx.cache,
+            onProgress: ctx.onProgress,
             safeDeploymentPromise: requireSafeDeployment(ctx.safeDeploymentPromises, chainId),
           }))
         );
@@ -438,21 +437,8 @@ export const executeSourceSwaps = async (
 ): Promise<BridgeAsset[]> => {
   if (source.swaps.length === 0) return [];
 
-  // Group swaps by chainId
-  const byChain = new Map<number, QuoteResponse[]>();
-  for (const swap of source.swaps) {
-    let bucket = byChain.get(swap.chainID);
-    if (!bucket) {
-      bucket = [];
-      byChain.set(swap.chainID, bucket);
-    }
-    bucket.push(swap);
-  }
-
   const confirmedResults = new Map<number, ConfirmedSourceChain>();
-  let pendingChains = new Map(
-    [...byChain.entries()].map(([chainId, chainSwaps]) => [chainId, sortSourceSwaps(chainSwaps)])
-  );
+  let pendingChains = new Map(groupSourceSwapsByChain(source.swaps));
   let lastError: Error | null = null;
 
   for (let attempt = 0; attempt < 2 && pendingChains.size > 0; attempt++) {

--- a/src/swap/prepare.ts
+++ b/src/swap/prepare.ts
@@ -53,7 +53,6 @@ type SwapCacheWarmupInput = SwapCacheInput & {
 
 export type SwapCacheWarmup = {
   cache: SwapCache;
-  key: string;
   process: Promise<void>;
   chainIds: readonly number[];
   safeChainIds: readonly number[];
@@ -120,7 +119,7 @@ const queueDeterministicTransferQueries = (
 const getPreparationDetails = (
   input: Pick<
     PrepareSwapExecutionInput,
-    'route' | 'source' | 'destination' | 'eoaAddress' | 'ephemeralWallet'
+    'chainList' | 'route' | 'source' | 'destination' | 'eoaAddress' | 'ephemeralWallet'
   > & { safeAddress: Hex }
 ) => {
   const directDestinationExtras =
@@ -158,7 +157,7 @@ const getPreparationDetails = (
           chainId: input.destination.chainId,
           tokenAddress: input.destination.eoaToEphemeral.contractAddress,
           amount: input.destination.eoaToEphemeral.amount,
-          eagerPermit: true,
+          eagerPermit: false,
           targetAddress: safeAddress,
         },
       ]
@@ -180,16 +179,34 @@ const getPreparationDetails = (
           },
         ];
       }) ?? []);
+  const directBridgeAuthorizationSpecs: DeterministicTransferSpec[] = isEoaBridgeRoute(input.route)
+    ? (input.route.bridge?.assets.flatMap((asset) => {
+        if (asset.eoaBalance.isZero() || isNativeAddress(asset.contractAddress)) return [];
+        return [
+          {
+            reason: 'bridge',
+            chainId: asset.chainID,
+            tokenAddress: asset.contractAddress,
+            tokenDecimals: asset.decimals,
+            amount: mulDecimals(asset.eoaBalance, asset.decimals),
+            eagerPermit: false,
+            targetAddress: input.chainList.getVaultContractAddress(asset.chainID),
+          },
+        ];
+      }) ?? [])
+    : [];
+  const deterministicTransferSpecs = [
+    ...sourceTransferSpecs,
+    ...destinationTransferSpecs,
+    ...bridgeTransferSpecs,
+  ];
 
   return {
     directDestinationExtras,
     directDestinationExactOut,
     destinationQuotes,
-    deterministicTransferSpecs: [
-      ...sourceTransferSpecs,
-      ...destinationTransferSpecs,
-      ...bridgeTransferSpecs,
-    ],
+    deterministicTransferSpecs,
+    authorizationSpecs: [...deterministicTransferSpecs, ...directBridgeAuthorizationSpecs],
     safeAddress,
   };
 };
@@ -222,7 +239,7 @@ const queueSwapCacheQueries = (
             tokenAddress: holding.tokenAddress,
             spender: details.safeAddress,
           }))
-      : details.deterministicTransferSpecs.map((transfer) => ({
+      : details.authorizationSpecs.map((transfer) => ({
           chainId: transfer.chainId,
           tokenAddress: transfer.tokenAddress,
           spender: transfer.targetAddress,
@@ -272,32 +289,15 @@ const startSwapCacheProcess = (
     { tags: { chain_count: requiredChainIds.size } }
   );
 
-export const startSwapCacheWarmup = (
-  input: SwapCacheWarmupInput,
-  previous?: SwapCacheWarmup
-): SwapCacheWarmup => {
+export const startSwapCacheWarmup = (input: SwapCacheWarmupInput): SwapCacheWarmup => {
   const cache = new SwapCache(input.chainList, input.safeAccount);
   const safeChainIds = getSafeExecutionChainIds(input.route);
-  for (const chainId of safeChainIds) {
-    if (previous?.cache.getSafeAccount(chainId)?.deployed) {
-      cache.setSafeDeployed(chainId, true);
-    }
-  }
   const details = getPreparationDetails({ ...input, safeAddress: input.safeAccount.address });
   const requiredChainIds = queueSwapCacheQueries({ ...input, cache }, details);
-  const key = cache.getPendingQueryKey();
-
-  if (previous?.key === key) {
-    return previous;
-  }
   const process = startSwapCacheProcess({ ...input, cache }, requiredChainIds);
-  // The user may deny or refresh while this runs. Observe early rejection now; awaiting the
-  // original promise after acceptance still preserves its failure.
-  void process.catch(() => undefined);
 
   return {
     cache,
-    key,
     process,
     chainIds: [...requiredChainIds],
     safeChainIds,

--- a/src/swap/progress.ts
+++ b/src/swap/progress.ts
@@ -1,5 +1,6 @@
 import type { SwapEvent, SwapPlan, SwapPlanProgressEvent, SwapStatus } from '../domain';
 import {
+  getSwapAllowanceStep,
   getSwapBridgeDepositStep,
   getSwapBridgeFillStep,
   getSwapBridgeIntentSubmissionStep,
@@ -72,6 +73,41 @@ export const createSwapProgressEmitter = (emit: SwapParams['emit']) => {
     const plan = getExecutionPlan(state.latestPreviewPlan, state.confirmedPlan);
 
     switch (update.stepType) {
+      case 'allowance': {
+        const step = getSwapAllowanceStep(plan, update.stepId);
+        if (update.state === 'wallet_prompted' || update.state === 'signed') {
+          emitPlanProgress({
+            type: 'plan_progress',
+            stepType: 'allowance',
+            state: update.state,
+            step,
+          });
+          return;
+        }
+        if (update.state === 'submitted' || update.state === 'confirmed') {
+          emitPlanProgress({
+            type: 'plan_progress',
+            stepType: 'allowance',
+            state: update.state,
+            step,
+            txHash: update.txHash,
+            explorerUrl: update.explorerUrl,
+          });
+          return;
+        }
+        if (update.state === 'failed') {
+          emitPlanProgress({
+            type: 'plan_progress',
+            stepType: 'allowance',
+            state: 'failed',
+            step,
+            ...(update.txHash ? { txHash: update.txHash } : {}),
+            ...(update.explorerUrl ? { explorerUrl: update.explorerUrl } : {}),
+            error: update.error,
+          });
+        }
+        return;
+      }
       case 'source_swap': {
         const step = getSwapSourceSwapStep(plan, update.chainId);
         if (update.state === 'wallet_prompted' || update.state === 'started') {

--- a/src/swap/source-order.ts
+++ b/src/swap/source-order.ts
@@ -1,0 +1,25 @@
+import { isNativeAddress } from '../services/addresses';
+import type { QuoteResponse } from './aggregators/types';
+
+export const isNativeSourceSwap = (swap: QuoteResponse): boolean =>
+  isNativeAddress(swap.quote.input.contractAddress);
+
+export const orderSourceSwaps = (swaps: QuoteResponse[]): QuoteResponse[] =>
+  [...swaps].sort(
+    (left, right) => Number(isNativeSourceSwap(right)) - Number(isNativeSourceSwap(left))
+  );
+
+export const groupSourceSwapsByChain = (
+  swaps: QuoteResponse[]
+): Array<[number, QuoteResponse[]]> => {
+  const grouped = new Map<number, QuoteResponse[]>();
+  for (const swap of swaps) {
+    const chainSwaps = grouped.get(swap.chainID);
+    if (chainSwaps) chainSwaps.push(swap);
+    else grouped.set(swap.chainID, [swap]);
+  }
+
+  return [...grouped.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([chainId, chainSwaps]) => [chainId, orderSourceSwaps(chainSwaps)]);
+};

--- a/src/swap/swap-steps-builder.ts
+++ b/src/swap/swap-steps-builder.ts
@@ -1,10 +1,11 @@
-import { formatUnits } from 'viem';
+import { formatUnits, type Hex } from 'viem';
 import type {
   BridgeFillStep,
   Chain,
   ChainListType,
   PlanTokenAmount,
   PlanTokenMetadata,
+  SwapAllowanceStep,
   SwapBridgeDepositStep,
   SwapBridgeIntentSubmissionStep,
   SwapDestinationSwapStep,
@@ -13,6 +14,7 @@ import type {
   SwapPlanStep,
   SwapSourceSwapStep,
 } from '../domain';
+import { isNativeAddress } from '../services/addresses';
 import { mulDecimals } from '../services/math';
 import {
   createBridgeDepositStepId,
@@ -21,9 +23,19 @@ import {
   createDestinationSwapStepId,
   createEoaToEphemeralTransferStepId,
   createSourceSwapStepId,
+  createSwapAllowanceStepId,
 } from '../services/step-ids';
 import type { QuoteResponse } from './aggregators/types';
+import { groupSourceSwapsByChain, isNativeSourceSwap } from './source-order';
 import { isEoaBridgeRoute, type SwapRoute } from './types';
+import type { SwapCache } from './wallet/cache';
+import { getTransferAuthorizationKind } from './wallet/transfer-authorization';
+
+type SwapPlanAuthorizationContext = {
+  cache: Pick<SwapCache, 'getAllowance' | 'getPermit'>;
+  eoaAddress: Hex;
+  safeAddress: Hex;
+};
 
 const toPlanTokenAmount = (
   metadata: PlanTokenMetadata,
@@ -48,19 +60,6 @@ const toChainDisplay = (chain: Chain) => {
   };
 };
 
-const groupSourceSwapsByChain = (route: SwapRoute): Map<number, QuoteResponse[]> => {
-  const grouped = new Map<number, QuoteResponse[]>();
-  for (const quote of route.source.swaps) {
-    const entries = grouped.get(quote.chainID);
-    if (entries) {
-      entries.push(quote);
-    } else {
-      grouped.set(quote.chainID, [quote]);
-    }
-  }
-  return new Map([...grouped.entries()].sort(([left], [right]) => left - right));
-};
-
 const createSourceSwapStep = (
   chainList: ChainListType,
   chainId: number,
@@ -71,6 +70,7 @@ const createSourceSwapStep = (
     id: createSourceSwapStepId(chainId),
     chain: toChainDisplay(chainList.getChainByID(chainId)),
     walletPath: 'safe',
+    submissionMode: quotesResponse.some(isNativeSourceSwap) ? 'eoa' : 'sponsored',
     swaps: [],
   };
 
@@ -82,6 +82,51 @@ const createSourceSwapStep = (
   }
 
   return swapSourceSwapStep;
+};
+
+const createAllowanceStep = (
+  chainList: ChainListType,
+  context: SwapPlanAuthorizationContext,
+  input: {
+    reason: 'source' | 'destination' | 'bridge';
+    chainId: number;
+    tokenAddress: Hex;
+    amountRaw: bigint;
+    spender: Hex;
+    permitAllowed?: boolean;
+  }
+): SwapAllowanceStep | null => {
+  const kind = getTransferAuthorizationKind({
+    cache: context.cache,
+    tokenAddress: input.tokenAddress,
+    ownerAddress: context.eoaAddress,
+    spenderAddress: input.spender,
+    chainId: input.chainId,
+    amount: input.amountRaw,
+    permitAllowed: input.permitAllowed,
+  });
+  if (!kind) return null;
+
+  const token = chainList.getTokenByAddress(input.chainId, input.tokenAddress);
+  return {
+    type: 'allowance',
+    id: createSwapAllowanceStepId(input.reason, input.chainId, input.tokenAddress),
+    method: kind === 'approve' ? 'approval' : 'permit',
+    chain: toChainDisplay(chainList.getChainByID(input.chainId)),
+    token,
+    spender: input.spender,
+    amount: toPlanTokenAmount(token, input.amountRaw),
+  };
+};
+
+const pushAllowanceStep = (
+  steps: SwapPlanStep[],
+  seenIds: Set<string>,
+  step: SwapAllowanceStep | null
+) => {
+  if (!step || seenIds.has(step.id)) return;
+  seenIds.add(step.id);
+  steps.push(step);
 };
 
 const createBridgeTransferStep = (
@@ -190,10 +235,31 @@ const createDestinationSwapStep = (
   return dstSwapStep;
 };
 
-export const createSwapPlan = (route: SwapRoute, chainList: ChainListType): SwapPlan => {
+export const createSwapPlan = (
+  route: SwapRoute,
+  chainList: ChainListType,
+  authorization?: SwapPlanAuthorizationContext
+): SwapPlan => {
   const steps: SwapPlanStep[] = [];
+  const allowanceIds = new Set<string>();
 
-  for (const [chainId, quotes] of groupSourceSwapsByChain(route).entries()) {
+  for (const [chainId, quotes] of groupSourceSwapsByChain(route.source.swaps)) {
+    if (authorization) {
+      for (const quote of quotes) {
+        if (isNativeSourceSwap(quote)) continue;
+        pushAllowanceStep(
+          steps,
+          allowanceIds,
+          createAllowanceStep(chainList, authorization, {
+            reason: 'source',
+            chainId,
+            tokenAddress: quote.quote.input.contractAddress,
+            amountRaw: quote.quote.input.amountRaw,
+            spender: authorization.safeAddress,
+          })
+        );
+      }
+    }
     steps.push(createSourceSwapStep(chainList, chainId, quotes));
   }
 
@@ -201,20 +267,72 @@ export const createSwapPlan = (route: SwapRoute, chainList: ChainListType): Swap
     const sortedAssets = [...route.bridge.assets].sort(
       (left, right) => left.chainID - right.chainID
     );
-    steps.push(createBridgeIntentSubmissionStep());
-    for (const asset of sortedAssets) {
-      // Non-direct routes stage EOA bridge holdings on the ephemeral wallet. Direct routes deposit
-      // from the EOA and therefore omit the custody-transfer step.
-      if (!isEoaBridgeRoute(route) && asset.eoaBalance.gt(0)) {
-        steps.push(createBridgeTransferStep(chainList, asset));
+    const directEoaBridge = isEoaBridgeRoute(route);
+    const bridgeAllowance = (asset: (typeof sortedAssets)[number]) =>
+      authorization && asset.eoaBalance.gt(0) && !isNativeAddress(asset.contractAddress)
+        ? createAllowanceStep(chainList, authorization, {
+            reason: 'bridge',
+            chainId: asset.chainID,
+            tokenAddress: asset.contractAddress,
+            amountRaw: mulDecimals(asset.eoaBalance, asset.decimals),
+            spender: directEoaBridge
+              ? chainList.getVaultContractAddress(asset.chainID)
+              : authorization.safeAddress,
+            permitAllowed: !directEoaBridge || asset.chainID !== 1,
+          })
+        : null;
+    const appendBridgeAssetSteps = (assets: typeof sortedAssets, includeAllowance: boolean) => {
+      for (const asset of assets) {
+        if (includeAllowance) {
+          pushAllowanceStep(steps, allowanceIds, bridgeAllowance(asset));
+        }
+        // Non-direct routes stage EOA bridge holdings on the ephemeral wallet. Direct routes
+        // deposit from the EOA, while native value stays at the EOA until its payable deposit.
+        if (!directEoaBridge && asset.eoaBalance.gt(0) && !isNativeAddress(asset.contractAddress)) {
+          steps.push(createBridgeTransferStep(chainList, asset));
+        }
+        steps.push(createBridgeDepositStep(chainList, asset));
       }
-      steps.push(createBridgeDepositStep(chainList, asset));
+    };
+
+    if (route.bridge.provider === 'mayan' && !directEoaBridge) {
+      appendBridgeAssetSteps(
+        sortedAssets.filter((asset) => !isNativeAddress(asset.contractAddress)),
+        true
+      );
+      steps.push(createBridgeIntentSubmissionStep());
+      appendBridgeAssetSteps(
+        sortedAssets.filter((asset) => isNativeAddress(asset.contractAddress)),
+        false
+      );
+    } else {
+      if (directEoaBridge) {
+        for (const asset of sortedAssets) {
+          pushAllowanceStep(steps, allowanceIds, bridgeAllowance(asset));
+        }
+      }
+      steps.push(createBridgeIntentSubmissionStep());
+      appendBridgeAssetSteps(sortedAssets, !directEoaBridge);
     }
     steps.push(createBridgeFillStep(chainList, route.bridge));
   }
 
   const destinationSwapStep = createDestinationSwapStep(chainList, route);
   if (destinationSwapStep) {
+    const destinationTransfer = route.destination.eoaToEphemeral;
+    if (authorization && destinationTransfer) {
+      pushAllowanceStep(
+        steps,
+        allowanceIds,
+        createAllowanceStep(chainList, authorization, {
+          reason: 'destination',
+          chainId: route.destination.chainId,
+          tokenAddress: destinationTransfer.contractAddress,
+          amountRaw: destinationTransfer.amount,
+          spender: authorization.safeAddress,
+        })
+      );
+    }
     steps.push(destinationSwapStep);
   }
 
@@ -242,6 +360,13 @@ export const getSwapSourceSwapStep = (plan: SwapPlan, chainId: number): SwapSour
     plan,
     (step): step is SwapSourceSwapStep => step.type === 'source_swap' && step.chain.id === chainId,
     `Swap plan is missing source_swap step for chain ${chainId}`
+  );
+
+export const getSwapAllowanceStep = (plan: SwapPlan, stepId: string): SwapAllowanceStep =>
+  findStep(
+    plan,
+    (step): step is SwapAllowanceStep => step.type === 'allowance' && step.id === stepId,
+    `Swap plan is missing allowance step ${stepId}`
   );
 
 export const getSwapEoaToEphemeralTransferStep = (

--- a/src/swap/swap-steps-builder.ts
+++ b/src/swap/swap-steps-builder.ts
@@ -94,6 +94,7 @@ const createAllowanceStep = (
     amountRaw: bigint;
     spender: Hex;
     permitAllowed?: boolean;
+    token?: PlanTokenMetadata;
   }
 ): SwapAllowanceStep | null => {
   const kind = getTransferAuthorizationKind({
@@ -107,7 +108,7 @@ const createAllowanceStep = (
   });
   if (!kind) return null;
 
-  const token = chainList.getTokenByAddress(input.chainId, input.tokenAddress);
+  const token = input.token ?? chainList.getTokenByAddress(input.chainId, input.tokenAddress);
   return {
     type: 'allowance',
     id: createSwapAllowanceStepId(input.reason, input.chainId, input.tokenAddress),
@@ -256,6 +257,7 @@ export const createSwapPlan = (
             tokenAddress: quote.quote.input.contractAddress,
             amountRaw: quote.quote.input.amountRaw,
             spender: authorization.safeAddress,
+            token: quote.quote.input,
           })
         );
       }
@@ -268,19 +270,34 @@ export const createSwapPlan = (
       (left, right) => left.chainID - right.chainID
     );
     const directEoaBridge = isEoaBridgeRoute(route);
-    const bridgeAllowance = (asset: (typeof sortedAssets)[number]) =>
-      authorization && asset.eoaBalance.gt(0) && !isNativeAddress(asset.contractAddress)
-        ? createAllowanceStep(chainList, authorization, {
-            reason: 'bridge',
-            chainId: asset.chainID,
-            tokenAddress: asset.contractAddress,
-            amountRaw: mulDecimals(asset.eoaBalance, asset.decimals),
-            spender: directEoaBridge
-              ? chainList.getVaultContractAddress(asset.chainID)
-              : authorization.safeAddress,
-            permitAllowed: !directEoaBridge || asset.chainID !== 1,
-          })
-        : null;
+    const bridgeAllowance = (asset: (typeof sortedAssets)[number]) => {
+      if (!authorization || asset.eoaBalance.lte(0) || isNativeAddress(asset.contractAddress)) {
+        return null;
+      }
+      const balance = route.extras.balances.find(
+        (entry) =>
+          entry.chainID === asset.chainID &&
+          entry.tokenAddress.toLowerCase() === asset.contractAddress.toLowerCase()
+      );
+      return createAllowanceStep(chainList, authorization, {
+        reason: 'bridge',
+        chainId: asset.chainID,
+        tokenAddress: asset.contractAddress,
+        amountRaw: mulDecimals(asset.eoaBalance, asset.decimals),
+        spender: directEoaBridge
+          ? chainList.getVaultContractAddress(asset.chainID)
+          : authorization.safeAddress,
+        permitAllowed: !directEoaBridge || asset.chainID !== 1,
+        token: balance
+          ? {
+              contractAddress: asset.contractAddress,
+              decimals: balance.decimals,
+              logo: balance.logo,
+              symbol: balance.symbol,
+            }
+          : undefined,
+      });
+    };
     const appendBridgeAssetSteps = (assets: typeof sortedAssets, includeAllowance: boolean) => {
       for (const asset of assets) {
         if (includeAllowance) {
@@ -321,6 +338,9 @@ export const createSwapPlan = (
   if (destinationSwapStep) {
     const destinationTransfer = route.destination.eoaToEphemeral;
     if (authorization && destinationTransfer) {
+      const destinationInput =
+        route.destination.swap.tokenSwap?.quote.input ??
+        route.destination.swap.gasSwap?.quote.input;
       pushAllowanceStep(
         steps,
         allowanceIds,
@@ -330,6 +350,7 @@ export const createSwapPlan = (
           tokenAddress: destinationTransfer.contractAddress,
           amountRaw: destinationTransfer.amount,
           spender: authorization.safeAddress,
+          token: destinationInput,
         })
       );
     }

--- a/src/swap/swap.md
+++ b/src/swap/swap.md
@@ -46,8 +46,8 @@ The high-level flow is:
 ```text
 buildSwapPreflight
   -> determineSwapRoute
-  -> createSwapIntent + createSwapPlan
   -> start allowance, permit-capability, and Safe-code cache reads
+  -> await cache and createSwapIntent + allowance-aware createSwapPlan
   -> await onIntent approval
   -> ensure missing Safes on every Safe execution chain
   -> prepareSwapExecution (await the accepted route's cache)
@@ -59,11 +59,12 @@ buildSwapPreflight
   -> finalize result
 ```
 
-Cache warming starts immediately before the intent is exposed to `onIntent`, so its read-only RPC
-work overlaps the user's review time. It includes one bytecode lookup for the derived Safe on each
-Safe execution chain. Bridge source chains without source swaps do not require this lookup. A refreshed intent
-reuses the existing warmup when its query data is unchanged; a changed query set starts a new
-warmup. Wallet signatures, approvals, and transactions remain gated behind intent acceptance.
+Cache warming resolves before the intent and plan are exposed to `onIntent`, allowing the preview to
+include only required EOA authorization and distinguish `approval` from `permit`. It includes one
+bytecode lookup for the derived Safe on each Safe execution chain. Bridge source chains without
+source swaps skip that lookup but still resolve ERC-20 vault authorization. A refreshed intent
+resolves the refreshed route's cache before emitting its replacement preview. Wallet signatures,
+approvals, and transactions remain gated behind intent acceptance.
 
 ## Deployment-before-wallet-prompt invariant
 
@@ -158,7 +159,7 @@ but creates no plan step or transaction. Max-amount haircuts apply only to the r
 ## Preparation
 
 `prepareSwapExecution` uses the Safe derived at flow start as the owner/spender for every swap quote.
-The pre-intent cache batches only the reads still needed by Safe execution:
+The pre-intent cache batches reads needed by the plan and execution:
 
 - ERC-20 allowances;
 - token permit support and version;
@@ -171,8 +172,9 @@ For ERC-20 value held by the EOA, preparation builds a deterministic transfer au
 
 The Safe consumes the authorization with `transferFrom`. Source and destination funding moves into
 the Safe. Bridge funding after a source swap may send from the EOA to the ephemeral bridge holder
-while the Safe remains the spender. Bridge routes without source swaps skip this preparation and use
-the bridge allowance service to authorize the vault from the EOA.
+while the Safe remains the spender. Bridge routes without source swaps skip Safe custody preparation
+and use the bridge allowance service to authorize the vault from the EOA; the same resolved
+authorization is represented in the public plan.
 
 Native input does not use an allowance. It is carried by the outer EOA transaction that calls the
 Safe.
@@ -208,8 +210,10 @@ inner values must equal the outer native value. The SDK rejects mismatches befor
 
 ### Source swaps
 
-Each chain groups its source legs into one Safe batch. ERC-20 legs prepend prepared funding and
-aggregator allowance calls as needed. Native legs are EOA-submitted Safe transactions. Failed source
+Source chains execute in ascending numeric chain-ID order, matching the plan. Each chain groups its
+source legs into one Safe batch, with native-value legs first. ERC-20 legs prepend prepared funding
+and aggregator allowance calls as needed. Native-value batches are EOA-submitted Safe transactions.
+Failed source
 execution may trigger a bounded requote when the failure is known to be safe to retry.
 
 ### Bridge deposits

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -402,6 +402,29 @@ export type ExecutionContext = {
 
 export type SwapExecutionProgressUpdate =
   | {
+      stepType: 'allowance';
+      stepId: string;
+      chainId: number;
+      state: 'wallet_prompted' | 'signed';
+    }
+  | {
+      stepType: 'allowance';
+      stepId: string;
+      chainId: number;
+      state: 'submitted' | 'confirmed';
+      txHash: Hex;
+      explorerUrl: string;
+    }
+  | {
+      stepType: 'allowance';
+      stepId: string;
+      chainId: number;
+      state: 'failed';
+      error: string;
+      txHash?: Hex;
+      explorerUrl?: string;
+    }
+  | {
       stepType: 'source_swap';
       chainId: number;
       state: 'wallet_prompted' | 'started';

--- a/src/swap/wallet/cache.ts
+++ b/src/swap/wallet/cache.ts
@@ -77,29 +77,6 @@ export class SwapCache {
     this.queries.push({ type: 'safe_account', chainId });
   }
 
-  getPendingQueryKey(): string {
-    return [
-      ...new Set(
-        this.queries.map((query) => {
-          if (query.type === 'safe_account') {
-            return `safe_account:${query.chainId}:${this.safeAccount?.address.toLowerCase()}`;
-          }
-          if (query.type === 'permit') {
-            return `permit:${permitKey(query.token, query.chainId)}`;
-          }
-          return `allowance:${allowanceKey(
-            query.token,
-            query.owner,
-            query.spender,
-            query.chainId
-          )}`;
-        })
-      ),
-    ]
-      .sort()
-      .join('|');
-  }
-
   // ---------------------------------------------------------------------------
   // Process all queued queries
   // ---------------------------------------------------------------------------

--- a/src/swap/wallet/transfer-authorization.ts
+++ b/src/swap/wallet/transfer-authorization.ts
@@ -16,9 +16,6 @@ import type { PreparedAuthorizationCall, PublicClientList } from '../types';
 import type { SwapCache } from './cache';
 
 const logger = getLogger();
-// Destination permits are signed before source + bridge execution, whose fill wait alone can take
-// five minutes. A 15-minute window keeps the signature finite without expiring mid-flow.
-
 const DAI_PERMIT_ABI = [
   {
     type: 'function',
@@ -198,9 +195,15 @@ export const buildTransferAuthorization = async (input: {
     chainId
   );
   const permit = input.cache.getPermit(input.tokenAddress, chainId);
-  const permitUnsupported = !permit || permit.permitVariant === PermitVariant.Unsupported;
-  const decision =
-    currentAllowance >= input.amount ? 'none' : permitUnsupported ? 'approve' : 'permit';
+  const kind = getTransferAuthorizationKind({
+    cache: input.cache,
+    tokenAddress: input.tokenAddress,
+    ownerAddress: input.eoaAddress,
+    spenderAddress: input.ephemeralAddress,
+    chainId,
+    amount: input.amount,
+  });
+  const decision = kind ?? 'none';
 
   logger.debug('swap.prepare.transfer_authorization.decision', {
     chainId,
@@ -213,10 +216,10 @@ export const buildTransferAuthorization = async (input: {
     decision,
   });
 
-  if (currentAllowance >= input.amount) {
+  if (!kind) {
     return null;
   }
-  if (permitUnsupported) {
+  if (kind === 'approve') {
     return {
       // Unsupported permits require a paid EOA approve(spender=Safe) before transferFrom.
       kind: 'approve',
@@ -231,6 +234,9 @@ export const buildTransferAuthorization = async (input: {
       },
       permit: null,
     };
+  }
+  if (!permit) {
+    throw new Error(`Missing cached permit details for ${input.tokenAddress} on ${chainId}`);
   }
 
   if (!input.eagerPermit) {
@@ -306,3 +312,30 @@ export const buildDirectApprovalRequest = (input: {
   chain: input.chain,
   functionName: 'approve' as const,
 });
+
+export const getTransferAuthorizationKind = (input: {
+  cache: Pick<SwapCache, 'getAllowance' | 'getPermit'>;
+  tokenAddress: Hex;
+  ownerAddress: Hex;
+  spenderAddress: Hex;
+  chainId: number;
+  amount: bigint;
+  permitAllowed?: boolean;
+}): 'approve' | 'permit' | null => {
+  if (
+    input.cache.getAllowance(
+      input.tokenAddress,
+      input.ownerAddress,
+      input.spenderAddress,
+      input.chainId
+    ) >= input.amount
+  ) {
+    return null;
+  }
+  const permit = input.cache.getPermit(input.tokenAddress, input.chainId);
+  return input.permitAllowed !== false &&
+    permit &&
+    permit.permitVariant !== PermitVariant.Unsupported
+    ? 'permit'
+    : 'approve';
+};

--- a/tests/flows/characterization/swap-pipeline.test.ts
+++ b/tests/flows/characterization/swap-pipeline.test.ts
@@ -1822,7 +1822,7 @@ describe('swap pipeline characterization', () => {
     );
 
     expect(destinationTransfer?.authorization?.kind).toBe('permit');
-    expect(destinationTransfer?.authorization?.call).not.toBeNull();
+    expect(destinationTransfer?.authorization?.call).toBeNull();
 
     const sbcCalls = getSubmittedExecutionCallsForChain(result.middlewareClient, BASE_CHAIN);
     const tokenCallNames = sbcCalls

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -11,6 +11,8 @@ import type {
   ListIntentsResult,
   OperationName,
   SwapAndExecuteResult,
+  SwapAllowanceProgressEvent,
+  SwapAllowanceStep,
   SwapMaxResult,
   SwapResult as SwapResultType,
   SwapResult,
@@ -29,6 +31,8 @@ describe('public api exports', () => {
     const txResult = {} as TxResult;
     const bridgeAndExecuteResult = {} as BridgeAndExecuteResult;
     const swapAndExecuteResult = {} as SwapAndExecuteResult;
+    const swapAllowanceStep = {} as SwapAllowanceStep;
+    const swapAllowanceProgress = {} as SwapAllowanceProgressEvent;
 
     expect(IntentStatus.Created).toBe('created');
     expect(params).toEqual({ page: 1, status: 'created' });
@@ -40,6 +44,8 @@ describe('public api exports', () => {
     expectTypeOf(txResult).toMatchTypeOf<TxResult>();
     expectTypeOf(bridgeAndExecuteResult).toMatchTypeOf<BridgeAndExecuteResult>();
     expectTypeOf(swapAndExecuteResult).toMatchTypeOf<SwapAndExecuteResult>();
+    expectTypeOf(swapAllowanceStep.method).toEqualTypeOf<'approval' | 'permit'>();
+    expectTypeOf(swapAllowanceProgress.step).toMatchTypeOf<SwapAllowanceStep>();
 
     if (bridgeAndExecuteResult.bridgeSkipped) {
       expectTypeOf(bridgeAndExecuteResult.bridgeResult).toEqualTypeOf<undefined>();

--- a/tests/swap/characterization/lifecycle.test.ts
+++ b/tests/swap/characterization/lifecycle.test.ts
@@ -2,6 +2,7 @@
 // signing paths are real; only injected network boundaries are deterministic.
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Hex } from 'viem';
+import type { SwapPlan } from '../../../src/domain';
 import { swap } from '../../../src/flows/swap';
 import { SwapMode, type FlatBalance, type SwapIntent } from '../../../src/swap/types';
 import {
@@ -158,12 +159,20 @@ describe('top-level swap lifecycle characterization', () => {
     );
   });
 
-  it('skips Safe cache reads for a direct EOA bridge', async () => {
+  it('resolves direct EOA bridge authorization before approval without Safe cache reads', async () => {
     const { deps } = makeHarness();
     let cacheCallsAtApproval = 0;
     let safeCodeReadsAtApproval = 0;
+    let previewPlan: SwapPlan | undefined;
+    const allowanceStates: string[] = [];
 
     await swap(input, deps, {
+      onEvent: (event) => {
+        if (event.type === 'plan_preview') previewPlan = event.plan;
+        if (event.type === 'plan_progress' && event.step.type === 'allowance') {
+          allowanceStates.push(event.state);
+        }
+      },
       onIntent: ({ allow }) => {
         cacheCallsAtApproval = hoisted.multicall.mock.calls.length;
         safeCodeReadsAtApproval = hoisted.getCode.mock.calls.length;
@@ -171,10 +180,18 @@ describe('top-level swap lifecycle characterization', () => {
       },
     });
 
-    expect(cacheCallsAtApproval).toBe(0);
+    expect(cacheCallsAtApproval).toBeGreaterThan(0);
     expect(safeCodeReadsAtApproval).toBe(0);
     expect(hoisted.multicall).toHaveBeenCalledTimes(cacheCallsAtApproval);
     expect(hoisted.getCode).toHaveBeenCalledTimes(safeCodeReadsAtApproval);
+    expect(previewPlan?.steps[0]).toMatchObject({
+      type: 'allowance',
+      method: 'permit',
+      chain: { id: ARB_CHAIN },
+    });
+    expect(allowanceStates).toEqual(
+      expect.arrayContaining(['wallet_prompted', 'submitted', 'confirmed'])
+    );
   });
 
   it('refreshes balances, oracle prices, intent, and plan preview before approval', async () => {
@@ -205,7 +222,7 @@ describe('top-level swap lifecycle characterization', () => {
     );
   });
 
-  it('keeps Safe cache reads skipped when refreshing a direct EOA bridge', async () => {
+  it('refreshes direct bridge authorization while keeping Safe cache reads skipped', async () => {
     const { deps } = makeHarness();
     let initialCacheCalls = 0;
     let refreshedCacheCalls = 0;
@@ -224,11 +241,11 @@ describe('top-level swap lifecycle characterization', () => {
       },
     });
 
-    expect(initialCacheCalls).toBe(0);
-    expect(refreshedCacheCalls).toBe(initialCacheCalls);
+    expect(initialCacheCalls).toBeGreaterThan(0);
+    expect(refreshedCacheCalls).toBeGreaterThan(initialCacheCalls);
     expect(initialCodeReads).toBe(0);
     expect(refreshedCodeReads).toBe(initialCodeReads);
-    expect(hoisted.multicall).toHaveBeenCalledTimes(initialCacheCalls);
+    expect(hoisted.multicall).toHaveBeenCalledTimes(refreshedCacheCalls);
   });
 
   it('returns the accepted intent when refresh is called after allow', async () => {

--- a/tests/swap/execution/eoa-to-ephemeral.test.ts
+++ b/tests/swap/execution/eoa-to-ephemeral.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Hex, PublicClient, WalletClient } from 'viem';
+
+vi.mock('../../../src/services/allowance-utils', () => ({
+  signPermitForAddressAndValue: vi.fn(),
+}));
+
+import { signPermitForAddressAndValue } from '../../../src/services/allowance-utils';
 import { resolvePreparedFundingTransferCalls } from '../../../src/swap/execution/eoa-to-ephemeral';
+import { PermitVariant } from '../../../src/domain/permits';
 import type { EnsureSafeAccountV2Response } from '../../../src/swap/safe/types';
 import type { PreparedEoaToEphemeralTransfer } from '../../../src/swap/types';
 
@@ -62,5 +69,107 @@ describe('resolvePreparedFundingTransferCalls', () => {
     await resolution;
 
     expect(eoaWallet.writeContract).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits the complete EOA approval lifecycle as an allowance step', async () => {
+    const onProgress = vi.fn();
+    const eoaWallet = {
+      getChainId: vi.fn().mockResolvedValue(CHAIN_ID),
+      writeContract: vi.fn().mockResolvedValue('0xapproval'),
+    } as unknown as WalletClient;
+    const publicClient = {
+      getTransactionReceipt: vi.fn().mockRejectedValue(new Error('not found')),
+      waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: 'success' }),
+      readContract: vi.fn(),
+    } as unknown as PublicClient;
+    const transfer: PreparedEoaToEphemeralTransfer = {
+      reason: 'source',
+      chainId: CHAIN_ID,
+      tokenAddress: TOKEN,
+      amount: 1_000_000n,
+      targetAddress: SAFE,
+      authorization: {
+        kind: 'approve',
+        call: { to: TOKEN, data: '0x', value: 0n },
+        permit: null,
+      },
+      transferCall: { to: TOKEN, data: '0x', value: 0n },
+    };
+
+    await resolvePreparedFundingTransferCalls({
+      transfer,
+      tokenDecimals: 6,
+      chain: {
+        id: CHAIN_ID,
+        name: 'Citrea',
+        blockExplorers: { default: { name: 'Explorer', url: 'https://explorer.example' } },
+      } as never,
+      eoaAddress: EOA,
+      eoaWallet,
+      publicClient,
+      safeDeploymentPromise: Promise.resolve({} as EnsureSafeAccountV2Response),
+      onProgress,
+    });
+
+    expect(onProgress.mock.calls.map(([update]) => update.state)).toEqual([
+      'wallet_prompted',
+      'submitted',
+      'confirmed',
+    ]);
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stepType: 'allowance',
+        stepId: `allowance:source:${CHAIN_ID}:${TOKEN}`,
+        state: 'submitted',
+        txHash: '0xapproval',
+      })
+    );
+  });
+
+  it('emits a signed terminal state for a permit authorization', async () => {
+    vi.mocked(signPermitForAddressAndValue).mockResolvedValue(
+      (`0x${'11'.repeat(64)}1b`) as Hex
+    );
+    const onProgress = vi.fn();
+    const transfer: PreparedEoaToEphemeralTransfer = {
+      reason: 'destination',
+      chainId: CHAIN_ID,
+      tokenAddress: TOKEN,
+      amount: 1_000_000n,
+      targetAddress: SAFE,
+      authorization: {
+        kind: 'permit',
+        call: null,
+        permit: {
+          signature: null,
+          permitVariant: PermitVariant.EIP2612Canonical,
+          permitContractVersion: 1,
+        },
+      },
+      transferCall: { to: TOKEN, data: '0x', value: 0n },
+    };
+
+    await resolvePreparedFundingTransferCalls({
+      transfer,
+      tokenDecimals: 6,
+      chain: { id: CHAIN_ID, name: 'Citrea' } as never,
+      eoaAddress: EOA,
+      eoaWallet: {} as WalletClient,
+      publicClient: { readContract: vi.fn() } as unknown as PublicClient,
+      safeDeploymentPromise: Promise.resolve({} as EnsureSafeAccountV2Response),
+      onProgress,
+    });
+
+    expect(onProgress.mock.calls.map(([update]) => update.state)).toEqual([
+      'wallet_prompted',
+      'signed',
+    ]);
+    expect(onProgress).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        stepType: 'allowance',
+        stepId: `allowance:destination:${CHAIN_ID}:${TOKEN}`,
+        state: 'signed',
+      })
+    );
   });
 });

--- a/tests/swap/execution/source-contracts.test.ts
+++ b/tests/swap/execution/source-contracts.test.ts
@@ -233,6 +233,39 @@ describe('executeSourceSwaps contracts', () => {
     expect(calls.filter((call) => call.data === '0xtransferFrom')).toHaveLength(1);
   });
 
+  it('dispatches source chains in the same canonical order as the plan', async () => {
+    const arbitrumQuote = makeQuote();
+    const optimismQuote = { ...makeQuote(), chainID: 10 };
+    const { context, createSafeExecuteTx } = makeContext();
+    context.safeDeploymentPromises = new Map([
+      [CHAIN_ID, Promise.resolve({})],
+      [10, Promise.resolve({})],
+    ]) as never;
+    context.sourceExecutionPaths = new Map([
+      [CHAIN_ID, 'safe'],
+      [10, 'safe'],
+    ]);
+    vi.mocked(context.chainList.getChainByID).mockImplementation(
+      (chainId) => ({ id: chainId, name: `Chain ${chainId}` }) as never
+    );
+
+    await executeSourceSwaps(
+      {
+        swaps: [arbitrumQuote, optimismQuote],
+        creationTime: Date.now(),
+        srcBuffer: new Decimal(0),
+      },
+      context,
+      metadata(),
+      [arbitrumQuote.aggregator]
+    );
+
+    expect(createSafeExecuteTx.mock.calls.map(([request]) => request.chainId)).toEqual([
+      10,
+      CHAIN_ID,
+    ]);
+  });
+
   it('treats a rejected permit authorization as terminal before dispatch', async () => {
     const quote = makeQuote();
     quote.aggregator = {
@@ -259,6 +292,16 @@ describe('executeSourceSwaps contracts', () => {
 
     expect(createSafeExecuteTx).not.toHaveBeenCalled();
     expect(quote.aggregator.getQuotes).not.toHaveBeenCalled();
+    expect(context.onProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stepType: 'allowance',
+        stepId: `allowance:source:${CHAIN_ID}:${INPUT}`,
+        state: 'wallet_prompted',
+      })
+    );
+    expect(context.onProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ stepType: 'allowance', state: 'failed' })
+    );
   });
 
   it('treats a rejected source dispatch as a transaction rejection', async () => {

--- a/tests/swap/prepare.test.ts
+++ b/tests/swap/prepare.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Decimal from 'decimal.js';
 import { decodeFunctionData, type Hex, type PublicClient, type WalletClient } from 'viem';
 import type { PrivateKeyAccount } from 'viem/accounts';
-import ERC20ABI, { ERC20PermitABI } from '../../src/abi/erc20';
+import ERC20ABI from '../../src/abi/erc20';
 import { prepareSwapExecution, startSwapCacheWarmup } from '../../src/swap/prepare';
 import { predictSafeAccountAddressV2 } from '../../src/swap/safe/predict';
 import type { EnsureSafeAccountV2Response } from '../../src/swap/safe/types';
@@ -260,7 +260,7 @@ describe('prepareSwapExecution', () => {
     expect(addAllowanceQuery).toHaveBeenCalledWith(DAI_ARB, EOA, SAFE, ARB_CHAIN);
   });
 
-  it('does not prepare Safe custody for a direct bridge', async () => {
+  it('warms EOA vault authorization without preparing Safe custody for a direct bridge', async () => {
     const route = makeRoute();
     route.source = { swaps: [], creationTime: Date.now(), srcBuffer: new Decimal(0) };
     route.sourceExecutionPaths = new Map([[ARB_CHAIN, 'safe']]);
@@ -298,13 +298,20 @@ describe('prepareSwapExecution', () => {
       },
     };
     const addSafeAccountQuery = vi.spyOn(SwapCache.prototype, 'addSafeAccountQuery');
+    const addPermitQuery = vi.spyOn(SwapCache.prototype, 'addPermitQuery');
     const addAllowanceQuery = vi.spyOn(SwapCache.prototype, 'addAllowanceQuery');
 
     const prepared = await prepareRoute(route, { safeDeploymentPromises: new Map() });
 
     expect(prepared.eoaToEphemeralTransfers).toEqual([]);
     expect(addSafeAccountQuery).not.toHaveBeenCalled();
-    expect(addAllowanceQuery).not.toHaveBeenCalled();
+    expect(addPermitQuery).toHaveBeenCalledWith(USDC_ARB, ARB_CHAIN);
+    expect(addAllowanceQuery).toHaveBeenCalledWith(
+      USDC_ARB,
+      EOA,
+      '0x0000000000000000000000000000000000000000',
+      ARB_CHAIN
+    );
   });
 
   it('builds a source EOA->Safe funding transfer targeting the predicted Safe on Safe V2 source chains', async () => {
@@ -338,11 +345,8 @@ describe('prepareSwapExecution', () => {
     expect(transferCall.args?.[2]).toBe(3000000000n);
   });
 
-  it('builds deterministic destination eoaToEphemeral transfer preparation and eagerly signs its permit', async () => {
-    const route = makeRoute();
-    const chainList = makeSupportedChainList();
-
-    const prepared = await prepareRoute(route, { chainList });
+  it('defers destination permit signing until the destination allowance step executes', async () => {
+    const prepared = await prepareRoute(makeRoute());
 
     const destinationTransfer = prepared.eoaToEphemeralTransfers.find(
       (entry) => entry.reason === 'destination'
@@ -355,49 +359,28 @@ describe('prepareSwapExecution', () => {
       throw new Error('Expected destination permit authorization to exist');
     }
 
-    const permitCall = decodeFunctionData({
-      abi: ERC20PermitABI,
-      data: destinationTransfer.authorization.call!.data,
-    });
-    expect(permitCall.functionName).toBe('permit');
-    expect(destinationTransfer.authorization.permit.signature).toMatch(/^0x[0-9a-f]+$/i);
-    expect(signPermitForAddressAndValue).toHaveBeenCalledWith(
-      expect.objectContaining({ tokenAddress: USDC_ARB }),
-      chainList.getChainByID(ARB_CHAIN),
-      expect.anything(),
-      expect.anything(),
-      expect.objectContaining({ address: EOA }),
-      predictSafeAccountAddressV2(EOA, EPH).address,
-      500000000n,
-      expect.anything()
-    );
+    expect(destinationTransfer.authorization.call).toBeNull();
+    expect(destinationTransfer.authorization.permit.signature).toBeNull();
+    expect(signPermitForAddressAndValue).not.toHaveBeenCalled();
   });
 
-  it('waits for the destination Safe deployment before eagerly signing its permit', async () => {
-    const route = makeRoute();
-    let resolveDeployment!: () => void;
-    const deployment = new Promise<EnsureSafeAccountV2Response>((resolve) => {
-      resolveDeployment = () =>
-        resolve({
-          chainId: ARB_CHAIN,
-          eoaAddress: EOA,
-          ephemeralAddress: EPH,
-          address: predictSafeAccountAddressV2(EOA, EPH).address,
-          factoryAddress: '0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67',
-          exists: true,
-        });
-    });
+  it('does not wait for destination Safe deployment before returning lazy permit preparation', async () => {
+    const neverDeployed = new Promise<EnsureSafeAccountV2Response>(() => undefined);
 
-    const preparation = prepareRoute(route, {
-      safeDeploymentPromises: new Map([[ARB_CHAIN, deployment]]),
-    });
+    const prepared = await Promise.race([
+      prepareRoute(makeRoute(), {
+        safeDeploymentPromises: new Map([[ARB_CHAIN, neverDeployed]]),
+      }),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('preparation waited for deployment')), 100)
+      ),
+    ]);
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(
+      prepared.eoaToEphemeralTransfers.find((entry) => entry.reason === 'destination')
+        ?.authorization
+    ).toMatchObject({ kind: 'permit', call: null });
     expect(signPermitForAddressAndValue).not.toHaveBeenCalled();
-    resolveDeployment();
-    await preparation;
-
-    expect(signPermitForAddressAndValue).toHaveBeenCalledTimes(1);
   });
 
   it('skips source and destination eoa->ephemeral authorization when cached allowance already covers the amount', async () => {

--- a/tests/swap/progress.test.ts
+++ b/tests/swap/progress.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import type { Hex } from 'viem';
+import type { SwapEvent, SwapPlan } from '../../src/domain';
+import { createSwapProgressEmitter } from '../../src/swap/progress';
+
+const STEP_ID =
+  'allowance:source:10:0x0000000000000000000000000000000000000001';
+
+const makePlan = (method: 'approval' | 'permit'): SwapPlan => ({
+  hasBridge: false,
+  hasDestinationSwap: false,
+  steps: [
+    {
+      type: 'allowance',
+      id: STEP_ID,
+      method,
+      chain: { id: 10, name: 'Optimism', logo: '' },
+      token: {
+        contractAddress: '0x0000000000000000000000000000000000000001',
+        symbol: 'USDC',
+        decimals: 6,
+      },
+      spender: '0x0000000000000000000000000000000000000002',
+      amount: {
+        contractAddress: '0x0000000000000000000000000000000000000001',
+        symbol: 'USDC',
+        decimals: 6,
+        amount: '1',
+        amountRaw: 1_000_000n,
+      },
+    },
+  ],
+});
+
+describe('createSwapProgressEmitter', () => {
+  it('maps EOA approval updates onto the matching allowance plan step', () => {
+    const events: SwapEvent[] = [];
+    const emitter = createSwapProgressEmitter((event) => events.push(event));
+    emitter.emitPlanConfirmed(makePlan('approval'));
+
+    emitter.emitExecutionProgress({
+      stepType: 'allowance',
+      stepId: STEP_ID,
+      chainId: 10,
+      state: 'wallet_prompted',
+    });
+    emitter.emitExecutionProgress({
+      stepType: 'allowance',
+      stepId: STEP_ID,
+      chainId: 10,
+      state: 'submitted',
+      txHash: '0xapproval' as Hex,
+      explorerUrl: 'https://explorer.example/tx/0xapproval',
+    });
+
+    expect(events.slice(1)).toEqual([
+      expect.objectContaining({
+        type: 'plan_progress',
+        stepType: 'allowance',
+        state: 'wallet_prompted',
+        step: expect.objectContaining({ id: STEP_ID, method: 'approval' }),
+      }),
+      expect.objectContaining({
+        type: 'plan_progress',
+        stepType: 'allowance',
+        state: 'submitted',
+        txHash: '0xapproval',
+        step: expect.objectContaining({ id: STEP_ID }),
+      }),
+    ]);
+  });
+
+  it('maps a signed permit onto the matching allowance plan step', () => {
+    const events: SwapEvent[] = [];
+    const emitter = createSwapProgressEmitter((event) => events.push(event));
+    emitter.emitPlanConfirmed(makePlan('permit'));
+
+    emitter.emitExecutionProgress({
+      stepType: 'allowance',
+      stepId: STEP_ID,
+      chainId: 10,
+      state: 'signed',
+    });
+
+    expect(events[1]).toMatchObject({
+      type: 'plan_progress',
+      stepType: 'allowance',
+      state: 'signed',
+      step: { id: STEP_ID, method: 'permit' },
+    });
+  });
+});

--- a/tests/swap/swap-steps-builder.test.ts
+++ b/tests/swap/swap-steps-builder.test.ts
@@ -273,6 +273,42 @@ describe('createSwapPlan', () => {
     });
   });
 
+  it('builds source allowance metadata for tokens outside the static chain list', () => {
+    const inputAddress = '0x00000000000000000000000000000000000000dd' as Hex;
+    const route = makeRoute({
+      source: {
+        swaps: [makeQuoteResponse(42161, inputAddress)],
+        creationTime: Date.now(),
+        srcBuffer: new Decimal(0),
+      },
+      sourceExecutionPaths: new Map([[42161, 'safe']]),
+    });
+    const strictChainList = {
+      ...chainList,
+      getTokenByAddress: (chainId: number, address: Hex) => {
+        if (address.toLowerCase() === inputAddress.toLowerCase()) {
+          throw new Error(`Token ${address} is not in the static list`);
+        }
+        return chainList.getTokenByAddress(chainId, address);
+      },
+    };
+
+    const plan = createSwapPlan(
+      route,
+      strictChainList,
+      makeAuthorization(PermitVariant.Unsupported)
+    );
+
+    expect(plan.steps[0]).toMatchObject({
+      type: 'allowance',
+      token: {
+        contractAddress: inputAddress,
+        decimals: 6,
+        symbol: 'PEPE',
+      },
+    });
+  });
+
   it('omits allowance steps when the existing EOA allowance covers the transfer', () => {
     const route = makeRoute({
       source: {
@@ -502,6 +538,55 @@ describe('createSwapPlan', () => {
       method: 'approval',
       spender: '0x0000000000000000000000000000000000000000',
       amount: { amountRaw: 5000000n },
+    });
+  });
+
+  it('builds direct bridge allowance metadata from routed balances', () => {
+    const assetAddress = '0x00000000000000000000000000000000000000ee' as Hex;
+    const asset = { ...makeBridgeAsset(42161, 5), contractAddress: assetAddress, decimals: 18 };
+    const route = makeRoute({
+      bridge: makeBridge([asset], { tokenAddress: assetAddress, decimals: 18 }),
+      extras: {
+        aggregators: [],
+        oraclePrices: [],
+        assetsUsed: [],
+        balances: [
+          {
+            amount: '5',
+            chainID: 42161,
+            decimals: 18,
+            logo: '',
+            name: 'Wrapped Ether',
+            symbol: 'WETH',
+            tokenAddress: assetAddress,
+            value: 15_000,
+          },
+        ],
+      },
+    });
+    const strictChainList = {
+      ...chainList,
+      getTokenByAddress: (_chainId: number, address: Hex) => {
+        if (address.toLowerCase() === assetAddress.toLowerCase()) {
+          throw new Error(`Token ${address} is not in the static list`);
+        }
+        return token;
+      },
+    };
+
+    const plan = createSwapPlan(
+      route,
+      strictChainList,
+      makeAuthorization(PermitVariant.Unsupported)
+    );
+
+    expect(plan.steps[0]).toMatchObject({
+      type: 'allowance',
+      token: {
+        contractAddress: assetAddress,
+        decimals: 18,
+        symbol: 'WETH',
+      },
     });
   });
 

--- a/tests/swap/swap-steps-builder.test.ts
+++ b/tests/swap/swap-steps-builder.test.ts
@@ -2,9 +2,11 @@ import Decimal from 'decimal.js';
 import { describe, expect, it } from 'vitest';
 import type { Hex } from 'viem';
 import { createSwapPlan } from '../../src/swap/swap-steps-builder';
+import { EADDRESS } from '../../src/swap/constants';
 import type { BridgeAsset, DestinationSwap, SwapRoute } from '../../src/swap/types';
 import { SwapMode } from '../../src/swap/types';
 import { CurrencyID } from '../../src/swap/cot';
+import { PermitVariant } from '../../src/domain/permits';
 import type { Aggregator, Holding, Quote } from '../../src/swap/aggregators/types';
 import { makeChain, makeChainList } from '../helpers/chains';
 import { quoteFixture } from '../helpers/quote';
@@ -78,11 +80,14 @@ const makeRoute = (overrides: Partial<SwapRoute> = {}): SwapRoute => ({
   ...overrides,
 });
 
-const makeQuoteResponse = (chainID: number) => ({
+const makeQuoteResponse = (
+  chainID: number,
+  inputAddress: Hex = '0x00000000000000000000000000000000000000aa'
+) => ({
   chainID,
   quote: quoteFixture({
     input: {
-      contractAddress: '0x00000000000000000000000000000000000000aa' as Hex,
+      contractAddress: inputAddress,
       amount: '50000',
       amountRaw: 50000000000n,
       decimals: 6,
@@ -124,6 +129,43 @@ const makeBridgeAsset = (chainID: number, eoaBalance: number): BridgeAsset => ({
   ephemeralBalance: new Decimal(10),
 });
 
+const makeBridge = (
+  assets: BridgeAsset[],
+  overrides: Partial<NonNullable<SwapRoute['bridge']>> = {}
+): NonNullable<SwapRoute['bridge']> => ({
+  provider: 'nexus',
+  amount: new Decimal(5),
+  amounts: {
+    tokenAmount: new Decimal(5),
+    gasInCot: new Decimal(0),
+    totalAmount: new Decimal(5),
+  },
+  assets,
+  chainID: 8453,
+  decimals: 6,
+  tokenAddress: token.contractAddress,
+  estimatedFees: {
+    collection: new Decimal(0),
+    fulfilment: new Decimal(0),
+    caGas: new Decimal(0),
+    protocol: new Decimal(0),
+    solver: new Decimal(0),
+  },
+  ...overrides,
+});
+
+const makeAuthorization = (permitVariant: PermitVariant) => ({
+  cache: {
+    getAllowance: () => 0n,
+    getPermit: () => ({
+      permitVariant,
+      permitContractVersion: permitVariant === PermitVariant.Unsupported ? 0 : 1,
+    }),
+  },
+  eoaAddress: '0xaaaa000000000000000000000000000000000001' as Hex,
+  safeAddress: '0xbbbb000000000000000000000000000000000002' as Hex,
+});
+
 describe('createSwapPlan', () => {
   it('returns source-only steps without synthetic lifecycle markers', () => {
     const route = makeRoute({
@@ -141,6 +183,7 @@ describe('createSwapPlan', () => {
         id: 'source_swap:42161',
         chain: expect.objectContaining({ id: 42161, name: 'Arbitrum' }),
         walletPath: 'safe',
+        submissionMode: 'sponsored',
         swaps: [
           expect.objectContaining({
             input: expect.objectContaining({
@@ -157,6 +200,133 @@ describe('createSwapPlan', () => {
         ],
       }),
     ]);
+  });
+
+  it('uses the execution order and marks native-value batches as EOA-submitted', () => {
+    const erc20 = makeQuoteResponse(42161, token.contractAddress);
+    const native = makeQuoteResponse(42161, EADDRESS);
+    const route = makeRoute({
+      source: {
+        swaps: [erc20, makeQuoteResponse(10, token.contractAddress), native],
+        creationTime: Date.now(),
+        srcBuffer: new Decimal(0),
+      },
+      sourceExecutionPaths: new Map([
+        [42161, 'safe'],
+        [10, 'safe'],
+      ]),
+    });
+
+    const plan = createSwapPlan(route, chainList);
+    const sourceSteps = plan.steps.filter((step) => step.type === 'source_swap');
+
+    expect(sourceSteps.map((step) => step.chain.id)).toEqual([10, 42161]);
+    expect(sourceSteps[0]).toMatchObject({ submissionMode: 'sponsored' });
+    expect(sourceSteps[1]).toMatchObject({
+      submissionMode: 'eoa',
+      swaps: [
+        { input: { contractAddress: EADDRESS } },
+        { input: { contractAddress: token.contractAddress } },
+      ],
+    });
+  });
+
+  it('precedes source swaps with one allowance step per required EOA authorization', () => {
+    const route = makeRoute({
+      source: {
+        swaps: [
+          makeQuoteResponse(42161, token.contractAddress),
+          makeQuoteResponse(10, token.contractAddress),
+        ],
+        creationTime: Date.now(),
+        srcBuffer: new Decimal(0),
+      },
+      sourceExecutionPaths: new Map([
+        [42161, 'safe'],
+        [10, 'safe'],
+      ]),
+    });
+    const plan = createSwapPlan(route, chainList, {
+      cache: {
+        getAllowance: () => 0n,
+        getPermit: (_tokenAddress: Hex, chainId: number) => ({
+          permitVariant:
+            chainId === 10 ? PermitVariant.EIP2612Canonical : PermitVariant.Unsupported,
+          permitContractVersion: chainId === 10 ? 1 : 0,
+        }),
+      },
+      eoaAddress: '0xaaaa000000000000000000000000000000000001',
+      safeAddress: '0xbbbb000000000000000000000000000000000002',
+    });
+
+    expect(plan.steps.map((step) => [step.type, 'method' in step ? step.method : null])).toEqual([
+      ['allowance', 'permit'],
+      ['source_swap', null],
+      ['allowance', 'approval'],
+      ['source_swap', null],
+    ]);
+    expect(plan.steps[0]).toMatchObject({
+      chain: { id: 10 },
+      token: { contractAddress: token.contractAddress },
+      spender: '0xbbbb000000000000000000000000000000000002',
+      amount: { amountRaw: 50000000000n },
+    });
+  });
+
+  it('omits allowance steps when the existing EOA allowance covers the transfer', () => {
+    const route = makeRoute({
+      source: {
+        swaps: [makeQuoteResponse(10, token.contractAddress)],
+        creationTime: Date.now(),
+        srcBuffer: new Decimal(0),
+      },
+      sourceExecutionPaths: new Map([[10, 'safe']]),
+    });
+
+    const plan = createSwapPlan(route, chainList, {
+      cache: {
+        getAllowance: () => 50000000000n,
+        getPermit: () => ({
+          permitVariant: PermitVariant.Unsupported,
+          permitContractVersion: 0,
+        }),
+      },
+      eoaAddress: '0xaaaa000000000000000000000000000000000001',
+      safeAddress: '0xbbbb000000000000000000000000000000000002',
+    });
+
+    expect(plan.steps.map((step) => step.type)).toEqual(['source_swap']);
+  });
+
+  it('places destination funding allowance before the destination swap', () => {
+    const route = makeRoute({
+      destination: {
+        chainId: 8453,
+        eoaToEphemeral: { contractAddress: token.contractAddress, amount: 100000000n },
+        inputAmount: { min: new Decimal(100), max: new Decimal(100) },
+        swap: withTokenSwap,
+        getDstSwap: async () => null,
+      },
+    });
+
+    const plan = createSwapPlan(route, chainList, {
+      cache: {
+        getAllowance: () => 0n,
+        getPermit: () => ({
+          permitVariant: PermitVariant.EIP2612Canonical,
+          permitContractVersion: 1,
+        }),
+      },
+      eoaAddress: '0xaaaa000000000000000000000000000000000001',
+      safeAddress: '0xbbbb000000000000000000000000000000000002',
+    });
+
+    expect(plan.steps.map((step) => step.type)).toEqual(['allowance', 'destination_swap']);
+    expect(plan.steps[0]).toMatchObject({
+      method: 'permit',
+      chain: { id: 8453 },
+      amount: { amountRaw: 100000000n },
+    });
   });
 
   it('builds bridge and destination steps with deterministic ids', () => {
@@ -262,6 +432,122 @@ describe('createSwapPlan', () => {
         chain: expect.objectContaining({ id: 42161, name: 'Arbitrum' }),
         asset: expect.objectContaining({ amountRaw: 5000000n, amount: '5.000000' }),
       }),
+    ]);
+  });
+
+  it('places composed bridge funding allowance where execution requests it', () => {
+    const route = makeRoute({
+      source: {
+        swaps: [makeQuoteResponse(42161)],
+        creationTime: Date.now(),
+        srcBuffer: new Decimal(0),
+      },
+      bridge: makeBridge([makeBridgeAsset(42161, 5)]),
+    });
+
+    const authorization = makeAuthorization(PermitVariant.EIP2612Canonical);
+    const plan = createSwapPlan(route, chainList, authorization);
+
+    expect(plan.steps.map((step) => step.type)).toEqual([
+      'allowance',
+      'source_swap',
+      'bridge_intent_submission',
+      'allowance',
+      'eoa_to_ephemeral_transfer',
+      'bridge_deposit',
+      'bridge_fill',
+    ]);
+    expect(plan.steps[3]).toMatchObject({
+      id: `allowance:bridge:42161:${token.contractAddress}`,
+      method: 'permit',
+      spender: '0xbbbb000000000000000000000000000000000002',
+      amount: { amountRaw: 5000000n },
+    });
+
+    const mayanPlan = createSwapPlan(
+      { ...route, bridge: { ...route.bridge!, provider: 'mayan' } },
+      chainList,
+      authorization
+    );
+    expect(mayanPlan.steps.map((step) => step.type)).toEqual([
+      'allowance',
+      'source_swap',
+      'allowance',
+      'eoa_to_ephemeral_transfer',
+      'bridge_deposit',
+      'bridge_intent_submission',
+      'bridge_fill',
+    ]);
+  });
+
+  it('places direct EOA bridge allowance before intent submission', () => {
+    const route = makeRoute({
+      bridge: makeBridge([makeBridgeAsset(42161, 5)]),
+    });
+
+    const plan = createSwapPlan(
+      route,
+      chainList,
+      makeAuthorization(PermitVariant.Unsupported)
+    );
+
+    expect(plan.steps.map((step) => step.type)).toEqual([
+      'allowance',
+      'bridge_intent_submission',
+      'bridge_deposit',
+      'bridge_fill',
+    ]);
+    expect(plan.steps[0]).toMatchObject({
+      id: `allowance:bridge:42161:${token.contractAddress}`,
+      method: 'approval',
+      spender: '0x0000000000000000000000000000000000000000',
+      amount: { amountRaw: 5000000n },
+    });
+  });
+
+  it('does not model native bridge value as an EOA-to-ephemeral transfer', () => {
+    const route = makeRoute({
+      source: {
+        swaps: [makeQuoteResponse(42161)],
+        creationTime: Date.now(),
+        srcBuffer: new Decimal(0),
+      },
+      bridge: makeBridge(
+        [
+          {
+            ...makeBridgeAsset(42161, 5),
+            contractAddress: EADDRESS,
+            decimals: 18,
+            ephemeralBalance: new Decimal(0),
+          },
+        ],
+        { decimals: 18, tokenAddress: EADDRESS }
+      ),
+    });
+
+    const plan = createSwapPlan(
+      route,
+      chainList,
+      makeAuthorization(PermitVariant.Unsupported)
+    );
+
+    expect(plan.steps.map((step) => step.type)).toEqual([
+      'allowance',
+      'source_swap',
+      'bridge_intent_submission',
+      'bridge_deposit',
+      'bridge_fill',
+    ]);
+
+    const mayanPlan = createSwapPlan(
+      { ...route, bridge: { ...route.bridge!, provider: 'mayan' } },
+      chainList
+    );
+    expect(mayanPlan.steps.map((step) => step.type)).toEqual([
+      'source_swap',
+      'bridge_intent_submission',
+      'bridge_deposit',
+      'bridge_fill',
     ]);
   });
 

--- a/tests/swap/wallet/cache.test.ts
+++ b/tests/swap/wallet/cache.test.ts
@@ -113,14 +113,12 @@ describe('SwapCache', () => {
     });
   });
 
-  it('keeps the Safe query key stable while skipping code reads for a known deployment', async () => {
+  it('skips code reads for a known Safe deployment', async () => {
     cache = new SwapCache(chainList, { address: SAFE, factoryAddress: SAFE_FACTORY });
     cache.addSafeAccountQuery(CHAIN_ID);
-    const pendingKey = cache.getPendingQueryKey();
     cache.setSafeDeployed(CHAIN_ID);
     const client = makePublicClient();
 
-    expect(cache.getPendingQueryKey()).toBe(pendingKey);
     await cache.process({ [CHAIN_ID]: client } as unknown as CacheClients);
 
     expect(client.getCode).not.toHaveBeenCalled();

--- a/tests/types/swap-events-surface.test.ts
+++ b/tests/types/swap-events-surface.test.ts
@@ -2,6 +2,8 @@ import type {
   BridgeFillStep,
   PlanTokenAmount,
   StatusEvent,
+  SwapAllowanceProgressEvent,
+  SwapAllowanceStep,
   SwapAndExecuteEvent,
   SwapAndExecutePlan,
   SwapAndExecutePlanStep,
@@ -26,6 +28,7 @@ declare const swapAndExecutePlan: SwapAndExecutePlan;
 declare const swapEvent: SwapEvent;
 declare const swapAndExecuteEvent: SwapAndExecuteEvent;
 declare const sourceSwapStep: Extract<SwapPlanStep, { type: 'source_swap' }>;
+declare const allowanceStep: Extract<SwapPlanStep, { type: 'allowance' }>;
 declare const bridgeFillStep: Extract<SwapPlanStep, { type: 'bridge_fill' }>;
 declare const destinationSwapStep: Extract<SwapAndExecutePlanStep, { type: 'destination_swap' }>;
 
@@ -37,6 +40,9 @@ swapPlan.hasDestinationSwap satisfies boolean;
 swapAndExecutePlan.steps satisfies SwapAndExecutePlanStep[];
 swapAndExecutePlan.swapRequired satisfies boolean;
 sourceSwapStep satisfies SwapSourceSwapStep;
+sourceSwapStep.submissionMode satisfies 'eoa' | 'sponsored';
+allowanceStep satisfies SwapAllowanceStep;
+allowanceStep.method satisfies 'approval' | 'permit';
 bridgeFillStep satisfies BridgeFillStep;
 destinationSwapStep.walletPath satisfies 'ephemeral' | 'safe';
 
@@ -50,6 +56,12 @@ if (swapEvent.type === 'plan_preview') {
 
 if (swapEvent.type === 'plan_progress' && swapEvent.stepType === 'bridge_fill') {
   swapEvent.step satisfies BridgeFillStep;
+}
+
+if (swapEvent.type === 'plan_progress' && swapEvent.stepType === 'allowance') {
+  swapEvent satisfies SwapAllowanceProgressEvent;
+  swapEvent.step satisfies SwapAllowanceStep;
+  swapEvent.step.method satisfies 'approval' | 'permit';
 }
 
 if (swapAndExecuteEvent.type === 'plan_progress' && swapAndExecuteEvent.stepType === 'destination_swap') {


### PR DESCRIPTION
## Summary

Align swap plan previews with runtime execution order and expose EOA token authorization as a first-class swap step. Plans now identify whether an allowance uses an approval or permit and whether source batches are EOA-submitted or sponsored.

## Changes
- Use one canonical source ordering for planning and execution: ascending chain ID with native-value legs first within each chain.
- Add the public `allowance` swap step with `method: 'approval' | 'permit'` for source, destination, composed bridge, and direct EOA bridge authorization.
- Resolve allowance and permit capability before emitting plan previews, including refreshed previews, and omit authorization steps when existing allowance is sufficient.
- Add allowance progress events for wallet prompts, permit signatures, approval submission and confirmation, and failures.
- Mark native-value source batches with `submissionMode: 'eoa'`, keep native bridge value at the EOA, and align bridge step ordering with actual Nexus and Mayan execution.
- Defer destination permit signing until its allowance step executes and update public exports, analytics, documentation, and characterization coverage.

## Testing
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` 

## Risk / Impact

Medium. This adds fields and a new member to the public swap plan/progress unions, changes source and bridge step ordering, and moves read-only authorization resolution before plan preview. Wallet writes remain gated behind intent acceptance. The primary risks are incorrect allowance classification, progress-to-step mapping, and ordering regressions across native, sponsored, direct-bridge, and composed-bridge paths; these are covered by unit, type-surface, lifecycle, execution-contract, and characterization tests.