### PR TITLE
swap: align plan steps with swap execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1708,6 +1708,7 @@ Swap plans contain the following step types:
 
 | Step Type | Description |
 |-----------|-------------|
+| `allowance` | Authorize an EOA-held ERC-20 for the Safe or bridge vault |
 | `source_swap` | Execute a swap through the Safe on a source chain |
 | `eoa_to_ephemeral_transfer` | Move EOA-held bridge funds to the ephemeral holder when source swaps are required |
 | `bridge_deposit` | Deposit into vault for cross-chain bridge |
@@ -1725,6 +1726,7 @@ type SwapPlan = {
 };
 
 type SwapPlanStep =
+  | SwapAllowanceStep
   | SwapSourceSwapStep
   | SwapEoaToEphemeralTransferStep
   | SwapBridgeDepositStep
@@ -1732,6 +1734,11 @@ type SwapPlanStep =
   | BridgeFillStep
   | SwapDestinationSwapStep;
 ```
+
+In `plan_preview`, an `allowance` step is provisional and omits `method`. After intent approval,
+`plan_confirmed` removes allowances that are already sufficient and sets each remaining step's
+`method` to `approval` or `permit`. Authorization continues to report progress through its adjacent
+transfer, swap, or bridge step rather than a separate allowance progress event.
 
 Each step carries contextual metadata such as its chain and tokens. Source and destination swap steps also expose `walletPath: 'safe'`. Progress events report per-step state transitions. The terminal success state varies by step type:
 
@@ -1771,7 +1778,7 @@ client.bridge(params, {
 });
 ```
 
-Per-step `step` shapes (all include `id` and `type`): `allowance_approval` → `chain`, `token`, `spender`, `requiredAmount`; `vault_deposit` → `chain`, `asset`, `assetType`, `submissionMode`; `bridge_fill` → `chain`, `asset`; `execute_approval` → `chain`, `token`, `spender`, `amount`; `execute_transaction` → `chain`, `to`. Swap source/destination steps carry `swaps[]` with `input`/`output` token amounts.
+Per-step `step` shapes (all include `id` and `type`): swap `allowance` → `method?`, `chain`, `token`, `spender`, `amount`; bridge `allowance_approval` → `chain`, `token`, `spender`, `requiredAmount`; `vault_deposit` → `chain`, `asset`, `assetType`, `submissionMode`; `bridge_fill` → `chain`, `asset`; `execute_approval` → `chain`, `token`, `spender`, `amount`; `execute_transaction` → `chain`, `to`. Swap source/destination steps carry `swaps[]` with `input`/`output` token amounts.
 
 ### Building Progress UIs
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -148,6 +148,7 @@ swap(params)
      -> createSwapIntent(...)
      -> start allowance, permit-capability, and Safe-code cache reads
      -> onIntent({ allow, deny, refresh, intent })
+     -> await cache and confirm the plan with required allowance methods
      -> swap/prepare.ts: prepareSwapExecution(...) awaits the accepted route's cache
      -> swap/execution/orchestrator.ts: executeSwapRoute(...)
         -> executeSourceSwaps(...) | executeDirectDestinationExactOut(...)
@@ -218,7 +219,9 @@ If no hooks are provided, the SDK auto-accepts intent and allowance.
 intent is accepted.
 
 For swap operations, the exposed hook is `onIntent(...)`. Swap does not expose a separate
-`onAllowance` hook; allowance and permit handling are part of swap execution preparation.
+`onAllowance` hook. The preview plan shows potential EOA allowance steps without a method; after
+intent approval, the confirmed plan removes satisfied allowances and resolves the rest to
+`approval` or `permit` before swap execution preparation.
 
 Bridge hook internals are split by responsibility:
 

--- a/example/browser/DESIGN.md
+++ b/example/browser/DESIGN.md
@@ -430,7 +430,12 @@ The steps card (`.exec-steps`) — second white card, only this scrolls internal
 
 The `rawState` field on `NormalizedStep` captures the SDK's raw state string (`"wallet_prompted"`, `"started"`, `"submitted"`, `"confirmed"`, `"failed"`) so the UI can tell wallet-prompt steps apart from automated / server-side execution. The previous blanket "Approve in wallet" sub-text was misleading for steps like `bridge_fill` / `vault_deposit` / `destination_swap` / `request_submission` that don't need a wallet popup.
 
-Steps stay in **natural execution order**. The active step shows a chevron toggle in place; **collapsed** (the default) renders only that active row, **expanded** reveals the full plan with the active row still in its real position — never lifted to the top. A `useEffect` with `setInterval(setNow(Date.now()), 1000)` ticks every second so "X sec ago" stays fresh.
+Swap `allowance` steps use their amount and confirmed `method` to render an Authorize, Approve, or
+Permit label. Because the SDK emits their progress through the adjacent execution step, a leading
+allowance becomes active when execution starts, later allowances activate after the preceding step,
+and each completes when the following planned step starts.
+
+Steps stay in **natural execution order**. The active step shows a chevron toggle in place; **collapsed** (the default) renders completed allowance rows plus the active row, while **expanded** reveals the full plan with the active row still in its real position — never lifted to the top. A `useEffect` with `setInterval(setNow(Date.now()), 1000)` ticks every second so "X sec ago" stays fresh.
 
 **Success body (`<CompletedBody>`)** — the gif hero swaps to `.exec-success-hero`: large destination token icon with a small `var(--accent)` check-badge overlay (`.exec-success-check`), "You received" eyebrow, big amount + small symbol, `on <Chain> · completed in <N>s` meta line. Duration is `state.completedAt − state.startedAt`.
 

--- a/example/browser/src/components/FlowModal.tsx
+++ b/example/browser/src/components/FlowModal.tsx
@@ -26,6 +26,7 @@ import {
 import { getTokenLogoUrl } from "../lib/logos";
 import { D, pctOf, sum, toFixed, trimDp } from "../lib/math";
 import { truncateAddress } from "../lib/format";
+import { getVisibleExecutionSteps } from "../lib/execution-progress";
 
 /* ── Shared icons ─────────────────────────────────────────────────── */
 
@@ -597,7 +598,7 @@ function ExecutingBody({
   const steps = state.steps;
   const activeStep = steps.find((s) => s.state === "active" || s.state === "submitted");
   const showToggle = activeStep !== undefined && steps.length > 1;
-  const visibleSteps = !activeStep || expanded ? steps : [activeStep];
+  const visibleSteps = getVisibleExecutionSteps(steps, expanded);
 
   return (
     <>
@@ -1026,4 +1027,3 @@ export function FlowModal({
     </Dialog.Root>
   );
 }
-

--- a/example/browser/src/hooks/useExecutionProgress.ts
+++ b/example/browser/src/hooks/useExecutionProgress.ts
@@ -13,8 +13,10 @@ import type {
 type RawStep = {
   id: string;
   type: string;
+  method?: "approval" | "permit";
   chain?: { id: number; name: string; logo: string };
   asset?: { symbol: string; amount: string; logo?: string };
+  amount?: { symbol: string; amount: string; logo?: string };
   token?: { symbol: string; logo?: string };
   swaps?: Array<{
     input: { symbol: string; amount: string; logo?: string };
@@ -24,6 +26,11 @@ type RawStep = {
 };
 
 const STEP_LABELS: Record<string, (step: RawStep) => string> = {
+  allowance: (s) => {
+    const action = s.method === "permit" ? "Permit" : s.method === "approval" ? "Approve" : "Authorize";
+    const amount = s.amount?.amount ? `${s.amount.amount} ` : "";
+    return `${action} ${amount}${s.token?.symbol ?? "token"} on ${s.chain?.name ?? "chain"}`;
+  },
   source_swap: (s) => `Swap on ${s.chain?.name ?? "source"}`,
   eoa_to_ephemeral_transfer: (s) => `Transfer on ${s.chain?.name ?? "chain"}`,
   bridge_deposit: (s) => `Deposit to bridge on ${s.chain?.name ?? "chain"}`,
@@ -39,6 +46,9 @@ const STEP_LABELS: Record<string, (step: RawStep) => string> = {
 };
 
 function extractToken(step: RawStep): NormalizedStep["token"] {
+  if (step.amount) {
+    return { symbol: step.amount.symbol, amount: step.amount.amount, logo: step.amount.logo };
+  }
   if (step.asset) {
     return { symbol: step.asset.symbol, amount: step.asset.amount, logo: step.asset.logo };
   }
@@ -190,6 +200,13 @@ export function useExecutionProgress(operationType: OperationType) {
         const phase = mapStatusToPhase(ev.status);
         if (phase) {
           draft.phase = phase;
+          if (ev.status === "executing") {
+            const firstPending = draft.steps.find((step) => step.state === "pending");
+            if (firstPending?.type === "allowance") {
+              firstPending.state = "active";
+              firstPending.rawState = "started";
+            }
+          }
           // On completion, mark any remaining active/submitted steps as done
           if (phase === "completed") {
             if (draft.completedAt === undefined) draft.completedAt = Date.now();
@@ -216,9 +233,25 @@ export function useExecutionProgress(operationType: OperationType) {
           : draft.steps.find((s) => s.type === ev.stepType && s.state !== "done");
 
         if (target) {
+          if (ev.state !== "failed") {
+            const completedAt = Date.now();
+            for (const previous of draft.steps.slice(0, draft.steps.indexOf(target))) {
+              if (previous.type === "allowance" && previous.state !== "done") {
+                previous.state = "done";
+                previous.completedAt ??= completedAt;
+              }
+            }
+          }
           const prevState = target.state;
           target.state = mapProgressState(ev.state ?? "active");
           target.rawState = ev.state;
+          if (target.state === "done") {
+            const next = draft.steps[draft.steps.indexOf(target) + 1];
+            if (next?.type === "allowance" && next.state === "pending") {
+              next.state = "active";
+              next.rawState = "started";
+            }
+          }
           if (ev.txHash) target.txHash = ev.txHash;
           if (ev.explorerUrl) target.explorerUrl = ev.explorerUrl;
           if (ev.error) target.error = ev.error;

--- a/example/browser/src/lib/execution-progress.ts
+++ b/example/browser/src/lib/execution-progress.ts
@@ -1,0 +1,12 @@
+import type { NormalizedStep } from "./types";
+
+export function getVisibleExecutionSteps(
+  steps: NormalizedStep[],
+  expanded: boolean,
+): NormalizedStep[] {
+  const active = steps.find((step) => step.state === "active" || step.state === "submitted");
+  if (!active || expanded) return steps;
+  return steps.filter(
+    (step) => step === active || (step.type === "allowance" && step.state === "done"),
+  );
+}

--- a/skills/nexus-core/SKILL.md
+++ b/skills/nexus-core/SKILL.md
@@ -251,6 +251,13 @@ const exactOutResult = await client.swapWithExactOut(
 
 Most swap quotes are valid for roughly 30 seconds. If `onIntent` displays an intent while waiting for user confirmation, use an async timeout that waits 20 seconds after each `refresh()` completes, render the returned intent, and stop refreshing before `allow()` or `deny()`. See [Displayed Intent Freshness](#displayed-intent-freshness-required-for-interactive-approval).
 
+Swap plans expose EOA-held ERC-20 authorization as an `allowance` step. In `plan_preview`, the
+step is provisional and omits `method`. After intent approval, `plan_confirmed` removes the step
+when the existing allowance already covers the required amount; no wallet approval or permit
+prompt is expected in that case. Remaining allowance steps set `method` to `approval` or `permit`.
+Authorization progress is reported through the adjacent swap, transfer, or bridge step rather than
+through a separate allowance progress event.
+
 **Calculate Maximum Swappable** — populate a "Max" button before calling `swapWithExactIn`:
 
 ```ts
@@ -913,6 +920,8 @@ import {
   type SwapResult,
   type SwapMaxResult,
   type SwapEvent,
+  type SwapPlan,
+  type SwapAllowanceStep,
   type SwapAndExecuteParams,
   type SwapAndExecuteResult,
   type SwapAndExecuteEvent,

--- a/src/abi/erc20.ts
+++ b/src/abi/erc20.ts
@@ -62,6 +62,21 @@ const ABI = [
     type: 'function',
   },
   {
+    name: 'eip712Domain',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [
+      { name: 'fields', type: 'bytes1' },
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+      { name: 'salt', type: 'bytes32' },
+      { name: 'extensions', type: 'uint256[]' },
+    ],
+  },
+  {
     constant: false,
     inputs: [
       {

--- a/src/domain/types/index.ts
+++ b/src/domain/types/index.ts
@@ -56,6 +56,7 @@ export type {
 } from './event-common';
 export type { PlanTokenAmount, PlanTokenMetadata } from './plan-common';
 export type {
+  SwapAllowanceStep,
   SwapAndExecuteEvent,
   SwapAndExecutePlan,
   SwapAndExecutePlanConfirmedEvent,

--- a/src/domain/types/swap-events.ts
+++ b/src/domain/types/swap-events.ts
@@ -12,7 +12,7 @@ import type {
   PlanProgressFailedBase,
   StatusEvent,
 } from './event-common';
-import type { PlanTokenAmount } from './plan-common';
+import type { PlanTokenAmount, PlanTokenMetadata } from './plan-common';
 
 export type SwapStatus =
   | 'route_building'
@@ -28,6 +28,20 @@ export type SwapPlan = {
   hasBridge: boolean;
   hasDestinationSwap: boolean;
   steps: SwapPlanStep[];
+};
+
+export type SwapAllowanceStep = {
+  type: 'allowance';
+  id: string;
+  method?: 'approval' | 'permit';
+  chain: {
+    id: number;
+    name: string;
+    logo: string;
+  };
+  token: PlanTokenMetadata;
+  spender: Hex;
+  amount: PlanTokenAmount;
 };
 
 export type SwapSourceSwapStep = {
@@ -88,6 +102,7 @@ export type SwapDestinationSwapStep = {
 };
 
 export type SwapPlanStep =
+  | SwapAllowanceStep
   | SwapSourceSwapStep
   | SwapEoaToEphemeralTransferStep
   | SwapBridgeDepositStep

--- a/src/flows/swap.ts
+++ b/src/flows/swap.ts
@@ -90,14 +90,15 @@ export type SwapPreviewState = {
 const createSwapPreviewStateFromRoute = (
   route: SwapRoute,
   input: SwapData,
-  chainList: SwapDeps['chainList']
+  chainList: SwapDeps['chainList'],
+  authorization: { eoaAddress: Hex; safeAddress: Hex }
 ): SwapPreviewState => {
   const intent = createSwapIntent(route, input, chainList);
 
   return {
     route,
     intent,
-    plan: createSwapPlan(route, chainList),
+    plan: createSwapPlan(route, chainList, authorization),
   };
 };
 
@@ -109,7 +110,7 @@ export const buildSwapPreviewState = async (
     input,
     createRouteOptions(context, context.preflight, input)
   );
-  return createSwapPreviewStateFromRoute(route, input, context.chainList);
+  return createSwapPreviewStateFromRoute(route, input, context.chainList, context);
 };
 
 const waitForIntentApproval = (
@@ -236,7 +237,10 @@ const runSwapFlow = async (
     )
   );
   let previewState = await withTimingSpan(deps.timing, 'flow.swap.create_intent', async () =>
-    createSwapPreviewStateFromRoute(route, input, deps.chainList)
+    createSwapPreviewStateFromRoute(route, input, deps.chainList, {
+      eoaAddress: deps.evm.address,
+      safeAddress: safeAccount.address,
+    })
   );
 
   const warmCacheForRoute = (nextRoute: SwapRoute, previous?: SwapCacheWarmup): SwapCacheWarmup =>
@@ -283,7 +287,14 @@ const runSwapFlow = async (
   route = approval.route;
 
   emitStatus('approved');
-  emitPlanConfirmed(previewState.plan);
+  await cacheWarmup.process;
+  emitPlanConfirmed(
+    createSwapPlan(route, deps.chainList, {
+      cache: cacheWarmup.cache,
+      eoaAddress: deps.evm.address,
+      safeAddress: safeAccount.address,
+    })
+  );
   const routePath = route.directDestination
     ? 'direct_destination'
     : route.sameTokenBridge

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,7 @@ export type {
   Shortfall,
   StatusEvent,
   SupportedChainsAndTokensResult,
+  SwapAllowanceStep,
   SwapAndExecuteEvent,
   SwapAndExecuteIntent,
   SwapAndExecuteOnIntentHookData,

--- a/src/services/allowance-utils.ts
+++ b/src/services/allowance-utils.ts
@@ -151,6 +151,35 @@ const PolygonDomain = [
   { name: 'salt', type: 'bytes32' },
 ] as const;
 
+export const getPermitDomainName = async (
+  tokenAddress: Address,
+  publicClient: PublicClient
+): Promise<string> => {
+  const contract = getContract({
+    abi: ERC20ABI,
+    address: tokenAddress,
+    client: { public: publicClient },
+  });
+
+  try {
+    const [, name] = await contract.read.eip712Domain();
+    return name;
+  } catch {
+    try {
+      return await contract.read.name();
+    } catch {
+      logger.error(
+        'signPermit:failed to read token name',
+        new ExecutionError(ERROR_CODES.EXEC_ERC20_NAME_READ_FAILED, 'Failed to read token name', {
+          context: { service: 'rpc' },
+          details: { tokenAddress },
+        })
+      );
+      return '';
+    }
+  }
+};
+
 export async function signPermitForAddressAndValue(
   cur: PermitCurrency,
   chain: Chain,
@@ -171,16 +200,7 @@ export async function signPermitForAddressAndValue(
 
   const walletAddress = account.address;
   const deadline = ddl;
-  const tokenNameRequest = contract.read.name().catch(() => {
-    logger.error(
-      'signPermit:failed to read token name',
-      new ExecutionError(ERROR_CODES.EXEC_ERC20_NAME_READ_FAILED, 'Failed to read token name', {
-        context: { service: 'rpc' },
-        details: { tokenAddress: cur.tokenAddress },
-      })
-    );
-    return '';
-  });
+  const tokenNameRequest = getPermitDomainName(cur.tokenAddress, publicClient);
   let nonceRequest: Promise<bigint>;
 
   switch (cur.permitVariant) {

--- a/src/swap/execution/direct-destination.ts
+++ b/src/swap/execution/direct-destination.ts
@@ -25,6 +25,7 @@ import {
   sizeDirectDestinationExactOut,
 } from '../algorithms/direct-destination-size';
 import { DIRECT_DST_QUOTE_TTL_MS, SRC_BUFFER_MAX_USD, SRC_BUFFER_PCT } from '../constants';
+import { orderSourceSwaps } from '../source-order';
 import type {
   ExecutionContext,
   OraclePriceResponse,
@@ -50,9 +51,6 @@ type FundingAuthorization = {
 };
 
 const isNativeInput = (swap: QuoteResponse) => isNativeAddress(swap.quote.input.contractAddress);
-
-const sortSwaps = (swaps: QuoteResponse[]) =>
-  [...swaps].sort((left, right) => Number(isNativeInput(right)) - Number(isNativeInput(left)));
 
 const toMetadataSwap = (swap: QuoteResponse) => ({
   inputAmount: swap.quote.input.amountRaw,
@@ -138,7 +136,7 @@ const buildCalls = async (input: {
 }): Promise<SafeCall[]> => {
   const { swaps, chainId, targetAddress, ctx, authorizations, routeTimeInputs, oraclePrices } =
     input;
-  const orderedSwaps = sortSwaps(swaps);
+  const orderedSwaps = orderSourceSwaps(swaps);
   const chain = ctx.chainList.getChainByID(chainId);
   const publicClient = ctx.publicClientList.get(chainId);
   const tokenTotals = new Map<

--- a/src/swap/execution/source-swaps.ts
+++ b/src/swap/execution/source-swaps.ts
@@ -26,6 +26,7 @@ import {
   QuoteSeriousness,
   QuoteType,
 } from '../aggregators/types';
+import { orderSourceSwaps } from '../source-order';
 import type {
   BridgeAsset,
   ExecutionContext,
@@ -62,9 +63,6 @@ type ConfirmedSourceChain = DispatchedSourceChain & {
 
 const isNativeInput = (swap: QuoteResponse) => isNativeAddress(swap.quote.input.contractAddress);
 
-const sortSourceSwaps = (swaps: QuoteResponse[]) =>
-  [...swaps].sort((left, right) => Number(isNativeInput(left)) * -1 + Number(isNativeInput(right)));
-
 const getPreparedSourceTransfer = (
   swap: QuoteResponse,
   transfers: PreparedEoaToEphemeralTransfer[] | undefined
@@ -98,7 +96,7 @@ const buildSourceCalls = async (
   const publicClient = ctx.publicClientList.get(chainId);
   const chain = ctx.chainList.getChainByID(chainId);
 
-  for (const swap of sortSourceSwaps(chainSwaps)) {
+  for (const swap of orderSourceSwaps(chainSwaps)) {
     const parsedQuote = getParsedQuote(swap, ctx.preparedExecution?.parsedQuotes);
     const nativeInput = isNativeInput(swap);
 
@@ -451,7 +449,9 @@ export const executeSourceSwaps = async (
 
   const confirmedResults = new Map<number, ConfirmedSourceChain>();
   let pendingChains = new Map(
-    [...byChain.entries()].map(([chainId, chainSwaps]) => [chainId, sortSourceSwaps(chainSwaps)])
+    [...byChain.entries()]
+      .sort(([left], [right]) => left - right)
+      .map(([chainId, chainSwaps]) => [chainId, orderSourceSwaps(chainSwaps)])
   );
   let lastError: Error | null = null;
 

--- a/src/swap/prepare.ts
+++ b/src/swap/prepare.ts
@@ -205,6 +205,19 @@ const queueSwapCacheQueries = (
     input.cache.addSafeAccountQuery(chainId);
   }
 
+  if (isEoaBridgeRoute(input.route)) {
+    for (const asset of input.route.bridge?.assets ?? []) {
+      if (asset.eoaBalance.lte(0) || isNativeAddress(asset.contractAddress)) continue;
+      requiredChainIds.add(asset.chainID);
+      input.cache.addAllowanceQuery(
+        asset.contractAddress,
+        input.eoaAddress,
+        input.chainList.getVaultContractAddress(asset.chainID),
+        asset.chainID
+      );
+    }
+  }
+
   queueParsedQuoteQueries(input.cache, input.source.swaps, details.safeAddress, requiredChainIds);
   queueParsedQuoteQueries(
     input.cache,

--- a/src/swap/progress.ts
+++ b/src/swap/progress.ts
@@ -60,8 +60,8 @@ export const createSwapProgressEmitter = (emit: SwapParams['emit']) => {
     emitSwapEvent(event);
   };
 
-  const emitPlanConfirmed = (fallbackPlan: SwapPlan) => {
-    state.confirmedPlan = state.latestPreviewPlan ?? fallbackPlan;
+  const emitPlanConfirmed = (plan: SwapPlan) => {
+    state.confirmedPlan = plan;
     emitSwapEvent({
       type: 'plan_confirmed',
       plan: state.confirmedPlan,

--- a/src/swap/source-order.ts
+++ b/src/swap/source-order.ts
@@ -1,0 +1,9 @@
+import { isNativeAddress } from '../services/addresses';
+import type { QuoteResponse } from './aggregators/types';
+
+export const orderSourceSwaps = (swaps: QuoteResponse[]): QuoteResponse[] =>
+  [...swaps].sort(
+    (left, right) =>
+      Number(isNativeAddress(right.quote.input.contractAddress)) -
+      Number(isNativeAddress(left.quote.input.contractAddress))
+  );

--- a/src/swap/swap-steps-builder.ts
+++ b/src/swap/swap-steps-builder.ts
@@ -1,10 +1,11 @@
-import { formatUnits } from 'viem';
+import { formatUnits, type Hex } from 'viem';
 import type {
   BridgeFillStep,
   Chain,
   ChainListType,
   PlanTokenAmount,
   PlanTokenMetadata,
+  SwapAllowanceStep,
   SwapBridgeDepositStep,
   SwapBridgeIntentSubmissionStep,
   SwapDestinationSwapStep,
@@ -13,6 +14,7 @@ import type {
   SwapPlanStep,
   SwapSourceSwapStep,
 } from '../domain';
+import { isNativeAddress } from '../services/addresses';
 import { mulDecimals } from '../services/math';
 import {
   createBridgeDepositStepId,
@@ -23,7 +25,16 @@ import {
   createSourceSwapStepId,
 } from '../services/step-ids';
 import type { QuoteResponse } from './aggregators/types';
+import { orderSourceSwaps } from './source-order';
 import { isEoaBridgeRoute, type SwapRoute } from './types';
+import type { SwapCache } from './wallet/cache';
+import { getTransferAuthorizationKind } from './wallet/transfer-authorization';
+
+type SwapPlanAuthorizationContext = {
+  cache?: Pick<SwapCache, 'getAllowance' | 'getPermit'>;
+  eoaAddress: Hex;
+  safeAddress: Hex;
+};
 
 const toPlanTokenAmount = (
   metadata: PlanTokenMetadata,
@@ -74,7 +85,7 @@ const createSourceSwapStep = (
     swaps: [],
   };
 
-  for (const response of quotesResponse) {
+  for (const response of orderSourceSwaps(quotesResponse)) {
     swapSourceSwapStep.swaps.push({
       input: response.quote.input,
       output: response.quote.output,
@@ -82,6 +93,46 @@ const createSourceSwapStep = (
   }
 
   return swapSourceSwapStep;
+};
+
+const createAllowanceStep = (
+  chainList: ChainListType,
+  input: {
+    reason: 'source' | 'destination' | 'bridge';
+    chainId: number;
+    token: PlanTokenMetadata;
+    amountRaw: bigint;
+    humanAmount?: string;
+    spender: Hex;
+    permitAllowed?: boolean;
+  },
+  authorization?: SwapPlanAuthorizationContext
+): SwapAllowanceStep | null => {
+  if (!authorization) return null;
+  const method = authorization.cache
+    ? getTransferAuthorizationKind({
+        currentAllowance: authorization.cache.getAllowance(
+          input.token.contractAddress,
+          authorization.eoaAddress,
+          input.spender,
+          input.chainId
+        ),
+        requiredAllowance: input.amountRaw,
+        permit: authorization.cache.getPermit(input.token.contractAddress, input.chainId),
+        permitAllowed: input.permitAllowed,
+      })
+    : undefined;
+  if (authorization.cache && !method) return null;
+
+  return {
+    type: 'allowance',
+    id: `allowance:${input.reason}:${input.chainId}:${input.token.contractAddress.toLowerCase()}`,
+    ...(method ? { method: method === 'approve' ? 'approval' : method } : {}),
+    chain: toChainDisplay(chainList.getChainByID(input.chainId)),
+    token: input.token,
+    spender: input.spender,
+    amount: toPlanTokenAmount(input.token, input.amountRaw, input.humanAmount),
+  };
 };
 
 const createBridgeTransferStep = (
@@ -190,10 +241,52 @@ const createDestinationSwapStep = (
   return dstSwapStep;
 };
 
-export const createSwapPlan = (route: SwapRoute, chainList: ChainListType): SwapPlan => {
+const getBridgeTokenMetadata = (
+  route: SwapRoute,
+  chainList: ChainListType,
+  asset: NonNullable<SwapRoute['bridge']>['assets'][number]
+): PlanTokenMetadata => {
+  const balance = route.extras.balances.find(
+    (entry) =>
+      entry.chainID === asset.chainID &&
+      entry.tokenAddress.toLowerCase() === asset.contractAddress.toLowerCase()
+  );
+  return balance
+    ? {
+        contractAddress: asset.contractAddress,
+        decimals: balance.decimals,
+        logo: balance.logo,
+        symbol: balance.symbol,
+      }
+    : chainList.getTokenByAddress(asset.chainID, asset.contractAddress);
+};
+
+export const createSwapPlan = (
+  route: SwapRoute,
+  chainList: ChainListType,
+  authorization?: SwapPlanAuthorizationContext
+): SwapPlan => {
   const steps: SwapPlanStep[] = [];
 
   for (const [chainId, quotes] of groupSourceSwapsByChain(route).entries()) {
+    if (authorization) {
+      for (const quote of quotes) {
+        if (isNativeAddress(quote.quote.input.contractAddress)) continue;
+        const allowance = createAllowanceStep(
+          chainList,
+          {
+            reason: 'source',
+            chainId,
+            token: quote.quote.input,
+            amountRaw: quote.quote.input.amountRaw,
+            humanAmount: quote.quote.input.amount,
+            spender: authorization.safeAddress,
+          },
+          authorization
+        );
+        if (allowance) steps.push(allowance);
+      }
+    }
     steps.push(createSourceSwapStep(chainList, chainId, quotes));
   }
 
@@ -201,11 +294,46 @@ export const createSwapPlan = (route: SwapRoute, chainList: ChainListType): Swap
     const sortedAssets = [...route.bridge.assets].sort(
       (left, right) => left.chainID - right.chainID
     );
+    const directEoaBridge = isEoaBridgeRoute(route);
+    if (directEoaBridge) {
+      for (const asset of sortedAssets) {
+        if (asset.eoaBalance.lte(0) || isNativeAddress(asset.contractAddress)) continue;
+        const allowance = createAllowanceStep(
+          chainList,
+          {
+            reason: 'bridge',
+            chainId: asset.chainID,
+            token: getBridgeTokenMetadata(route, chainList, asset),
+            amountRaw: mulDecimals(asset.eoaBalance, asset.decimals),
+            humanAmount: asset.eoaBalance.toFixed(asset.decimals),
+            spender: chainList.getVaultContractAddress(asset.chainID),
+            permitAllowed: false,
+          },
+          authorization
+        );
+        if (allowance) steps.push(allowance);
+      }
+    }
     steps.push(createBridgeIntentSubmissionStep());
     for (const asset of sortedAssets) {
       // Non-direct routes stage EOA bridge holdings on the ephemeral wallet. Direct routes deposit
       // from the EOA and therefore omit the custody-transfer step.
-      if (!isEoaBridgeRoute(route) && asset.eoaBalance.gt(0)) {
+      if (!directEoaBridge && asset.eoaBalance.gt(0) && !isNativeAddress(asset.contractAddress)) {
+        if (authorization) {
+          const allowance = createAllowanceStep(
+            chainList,
+            {
+              reason: 'bridge',
+              chainId: asset.chainID,
+              token: getBridgeTokenMetadata(route, chainList, asset),
+              amountRaw: mulDecimals(asset.eoaBalance, asset.decimals),
+              humanAmount: asset.eoaBalance.toFixed(asset.decimals),
+              spender: authorization.safeAddress,
+            },
+            authorization
+          );
+          if (allowance) steps.push(allowance);
+        }
         steps.push(createBridgeTransferStep(chainList, asset));
       }
       steps.push(createBridgeDepositStep(chainList, asset));
@@ -215,6 +343,28 @@ export const createSwapPlan = (route: SwapRoute, chainList: ChainListType): Swap
 
   const destinationSwapStep = createDestinationSwapStep(chainList, route);
   if (destinationSwapStep) {
+    const transfer = route.destination.eoaToEphemeral;
+    if (authorization && transfer && !isNativeAddress(transfer.contractAddress)) {
+      const quoteInput =
+        route.destination.swap.tokenSwap?.quote.input ??
+        route.destination.swap.gasSwap?.quote.input;
+      const token =
+        quoteInput?.contractAddress.toLowerCase() === transfer.contractAddress.toLowerCase()
+          ? quoteInput
+          : chainList.getTokenByAddress(route.destination.chainId, transfer.contractAddress);
+      const allowance = createAllowanceStep(
+        chainList,
+        {
+          reason: 'destination',
+          chainId: route.destination.chainId,
+          token,
+          amountRaw: transfer.amount,
+          spender: authorization.safeAddress,
+        },
+        authorization
+      );
+      if (allowance) steps.push(allowance);
+    }
     steps.push(destinationSwapStep);
   }
 

--- a/src/swap/swap.md
+++ b/src/swap/swap.md
@@ -49,6 +49,7 @@ buildSwapPreflight
   -> createSwapIntent + createSwapPlan
   -> start allowance, permit-capability, and Safe-code cache reads
   -> await onIntent approval
+  -> await cache and confirm required allowance methods
   -> ensure missing Safes on every Safe execution chain
   -> prepareSwapExecution (await the accepted route's cache)
   -> executeSwapRoute
@@ -64,6 +65,9 @@ work overlaps the user's review time. It includes one bytecode lookup for the de
 Safe execution chain. Bridge source chains without source swaps do not require this lookup. A refreshed intent
 reuses the existing warmup when its query data is unchanged; a changed query set starts a new
 warmup. Wallet signatures, approvals, and transactions remain gated behind intent acceptance.
+Potential EOA ERC-20 authorization appears as a methodless `allowance` step in `plan_preview`.
+After acceptance, `plan_confirmed` drops already-satisfied allowances and labels the remainder as
+`approval` or `permit` using the warmed cache.
 
 ## Deployment-before-wallet-prompt invariant
 
@@ -208,7 +212,8 @@ inner values must equal the outer native value. The SDK rejects mismatches befor
 
 ### Source swaps
 
-Each chain groups its source legs into one Safe batch. ERC-20 legs prepend prepared funding and
+Source chains execute in ascending chain-ID order, and native input is listed and executed first
+within each chain. Each chain groups its source legs into one Safe batch. ERC-20 legs prepend prepared funding and
 aggregator allowance calls as needed. Native legs are EOA-submitted Safe transactions. Failed source
 execution may trigger a bounded requote when the failure is known to be safe to retry.
 

--- a/src/swap/wallet/ephemeral-permit.ts
+++ b/src/swap/wallet/ephemeral-permit.ts
@@ -1,9 +1,10 @@
-import { encodeFunctionData, erc20Abi, type Hex, type PublicClient, parseSignature } from 'viem';
+import { encodeFunctionData, type Hex, type PublicClient, parseSignature } from 'viem';
 import type { PrivateKeyAccount } from 'viem/accounts';
 import { ERC20PermitABI } from '../../abi/erc20';
 import type { Chain, ChainListType } from '../../domain';
 import { Errors } from '../../domain/errors';
 import { PermitVariant } from '../../domain/permits';
+import { getPermitDomainName } from '../../services/allowance-utils';
 
 export const buildEphemeralPermitCall = async (input: {
   tokenAddress: Hex;
@@ -29,11 +30,7 @@ export const buildEphemeralPermitCall = async (input: {
   }
 
   const [name, nonce] = (await Promise.all([
-    input.publicClient.readContract({
-      address: input.tokenAddress,
-      abi: erc20Abi,
-      functionName: 'name',
-    }),
+    getPermitDomainName(input.tokenAddress, input.publicClient),
     input.publicClient.readContract({
       address: input.tokenAddress,
       abi: ERC20PermitABI,

--- a/src/swap/wallet/transfer-authorization.ts
+++ b/src/swap/wallet/transfer-authorization.ts
@@ -9,7 +9,7 @@ import {
 } from 'viem';
 import { ERC20PermitABI } from '../../abi/erc20';
 import { type Chain, getLogger } from '../../domain';
-import { PermitVariant } from '../../domain/permits';
+import { type PermitDetails, PermitVariant } from '../../domain/permits';
 import { signPermitForAddressAndValue } from '../../services/allowance-utils';
 import { minutesFromNow } from '../../services/time';
 import type { PreparedAuthorizationCall, PublicClientList } from '../types';
@@ -198,9 +198,11 @@ export const buildTransferAuthorization = async (input: {
     chainId
   );
   const permit = input.cache.getPermit(input.tokenAddress, chainId);
-  const permitUnsupported = !permit || permit.permitVariant === PermitVariant.Unsupported;
-  const decision =
-    currentAllowance >= input.amount ? 'none' : permitUnsupported ? 'approve' : 'permit';
+  const decision = getTransferAuthorizationKind({
+    currentAllowance,
+    requiredAllowance: input.amount,
+    permit,
+  });
 
   logger.debug('swap.prepare.transfer_authorization.decision', {
     chainId,
@@ -210,13 +212,11 @@ export const buildTransferAuthorization = async (input: {
     permitVariant: permit?.permitVariant ?? PermitVariant.Unsupported,
     permitContractVersion: permit?.permitContractVersion ?? 0,
     eagerPermit: input.eagerPermit,
-    decision,
+    decision: decision ?? 'none',
   });
 
-  if (currentAllowance >= input.amount) {
-    return null;
-  }
-  if (permitUnsupported) {
+  if (!decision) return null;
+  if (decision === 'approve') {
     return {
       // Unsupported permits require a paid EOA approve(spender=Safe) before transferFrom.
       kind: 'approve',
@@ -232,6 +232,7 @@ export const buildTransferAuthorization = async (input: {
       permit: null,
     };
   }
+  if (!permit) return null;
 
   if (!input.eagerPermit) {
     return {
@@ -257,6 +258,18 @@ export const buildTransferAuthorization = async (input: {
     permitVariant: permit.permitVariant,
     permitContractVersion: permit.permitContractVersion,
   });
+};
+
+export const getTransferAuthorizationKind = (input: {
+  currentAllowance: bigint;
+  requiredAllowance: bigint;
+  permit: PermitDetails | undefined;
+  permitAllowed?: boolean;
+}): 'approve' | 'permit' | null => {
+  if (input.currentAllowance >= input.requiredAllowance) return null;
+  if (input.permitAllowed === false) return 'approve';
+  const { permit } = input;
+  return !permit || permit.permitVariant === PermitVariant.Unsupported ? 'approve' : 'permit';
 };
 
 export const materializePermitAuthorizationCall = async (input: {

--- a/tests/flows/characterization/swap-pipeline.test.ts
+++ b/tests/flows/characterization/swap-pipeline.test.ts
@@ -1661,7 +1661,7 @@ const assertScenario = (scenario: ExactOutScenario, result: HarnessResult) => {
   expect(result.emittedEvents).toEqual(
     expect.arrayContaining([
       expect.objectContaining({ type: 'plan_preview', plan: result.previewState.plan }),
-      expect.objectContaining({ type: 'plan_confirmed', plan: result.previewState.plan }),
+      expect.objectContaining({ type: 'plan_confirmed' }),
     ])
   );
 

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -11,6 +11,7 @@ import type {
   ListIntentsResult,
   OperationName,
   SwapAndExecuteResult,
+  SwapAllowanceStep,
   SwapMaxResult,
   SwapResult as SwapResultType,
   SwapResult,
@@ -29,6 +30,7 @@ describe('public api exports', () => {
     const txResult = {} as TxResult;
     const bridgeAndExecuteResult = {} as BridgeAndExecuteResult;
     const swapAndExecuteResult = {} as SwapAndExecuteResult;
+    const swapAllowanceStep = {} as SwapAllowanceStep;
 
     expect(IntentStatus.Created).toBe('created');
     expect(params).toEqual({ page: 1, status: 'created' });
@@ -40,6 +42,7 @@ describe('public api exports', () => {
     expectTypeOf(txResult).toMatchTypeOf<TxResult>();
     expectTypeOf(bridgeAndExecuteResult).toMatchTypeOf<BridgeAndExecuteResult>();
     expectTypeOf(swapAndExecuteResult).toMatchTypeOf<SwapAndExecuteResult>();
+    expectTypeOf(swapAllowanceStep.method).toEqualTypeOf<'approval' | 'permit' | undefined>();
 
     if (bridgeAndExecuteResult.bridgeSkipped) {
       expectTypeOf(bridgeAndExecuteResult.bridgeResult).toEqualTypeOf<undefined>();

--- a/tests/services/allowance-utils.test.ts
+++ b/tests/services/allowance-utils.test.ts
@@ -9,6 +9,7 @@ import { makeChain, makeChainList } from '../helpers/chains';
 import { makeMiddlewareClient } from '../helpers/middleware-client';
 
 const contractReads = vi.hoisted(() => ({
+  eip712Domain: vi.fn(),
   name: vi.fn(),
   nonces: vi.fn(),
 }));
@@ -28,6 +29,7 @@ const TOKEN = '0x0000000000000000000000000000000000000001' as Hex;
 const OWNER = '0x0000000000000000000000000000000000000002' as Hex;
 const SPENDER = '0x0000000000000000000000000000000000000003' as Hex;
 const SOURCE_CHAIN = makeChain(42161, 'Arbitrum');
+const MONAD = makeChain(143, 'Monad');
 
 describe('signPermitForAddressAndValue', () => {
   afterEach(() => {
@@ -36,8 +38,74 @@ describe('signPermitForAddressAndValue', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    contractReads.eip712Domain.mockRejectedValue(new Error('ERC-5267 unsupported'));
     contractReads.name.mockResolvedValue('USD Coin');
     contractReads.nonces.mockResolvedValue(7n);
+  });
+
+  it.each([
+    {
+      case: 'uses the ERC-5267 name when it differs from name()',
+      domainName: 'Agora Dollar',
+      tokenName: 'AUSD',
+      expected: 'Agora Dollar',
+    },
+    {
+      case: 'falls back to name() when ERC-5267 is unsupported',
+      domainName: null,
+      tokenName: 'AUSD',
+      expected: 'AUSD',
+    },
+    {
+      case: 'falls back to an empty name when both reads fail',
+      domainName: null,
+      tokenName: null,
+      expected: '',
+    },
+  ])('$case', async ({ domainName, tokenName, expected }) => {
+    if (domainName) {
+      contractReads.eip712Domain.mockResolvedValue([
+        '0x0f',
+        domainName,
+        '1',
+        143n,
+        TOKEN,
+        `0x${'00'.repeat(32)}`,
+        [],
+      ]);
+    }
+    if (tokenName === null) {
+      contractReads.name.mockRejectedValue(new Error('name unsupported'));
+    } else {
+      contractReads.name.mockResolvedValue(tokenName);
+    }
+    const walletClient = {
+      getChainId: vi.fn().mockResolvedValue(MONAD.id),
+      signTypedData: vi.fn().mockResolvedValue(`0x${'aa'.repeat(65)}` as Hex),
+    } as unknown as WalletClient & {
+      signTypedData: ReturnType<typeof vi.fn>;
+    };
+
+    await signPermitForAddressAndValue(
+      {
+        tokenAddress: TOKEN,
+        decimals: 6,
+        permitVariant: PermitVariant.EIP2612Canonical,
+        permitContractVersion: 1,
+      },
+      MONAD,
+      walletClient,
+      {} as PublicClient,
+      { address: OWNER, type: 'json-rpc' } as Account,
+      SPENDER,
+      123n,
+      456n
+    );
+
+    expect(walletClient.signTypedData.mock.calls[0]?.[0]?.domain).toMatchObject({
+      name: expected,
+      version: '1',
+    });
   });
 
   it('switches to the supplied chain before signing and uses that chain in the typed data domain', async () => {

--- a/tests/swap/characterization/lifecycle.test.ts
+++ b/tests/swap/characterization/lifecycle.test.ts
@@ -2,6 +2,7 @@
 // signing paths are real; only injected network boundaries are deterministic.
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Hex } from 'viem';
+import type { SwapEvent } from '../../../src/domain';
 import { swap } from '../../../src/flows/swap';
 import { SwapMode, type FlatBalance, type SwapIntent } from '../../../src/swap/types';
 import {
@@ -158,7 +159,26 @@ describe('top-level swap lifecycle characterization', () => {
     );
   });
 
-  it('skips Safe cache reads for a direct EOA bridge', async () => {
+  it('adds the allowance method only when the direct EOA bridge plan is confirmed', async () => {
+    const { deps } = makeHarness();
+    const events: SwapEvent[] = [];
+
+    await swap(input, deps, {
+      onEvent: (event) => events.push(event),
+      onIntent: ({ allow }) => allow(),
+    });
+
+    const preview = events.find((event) => event.type === 'plan_preview');
+    const confirmed = events.find((event) => event.type === 'plan_confirmed');
+    const previewAllowance = preview?.plan.steps.find((step) => step.type === 'allowance');
+    const confirmedAllowance = confirmed?.plan.steps.find((step) => step.type === 'allowance');
+
+    expect(previewAllowance).toBeDefined();
+    expect(previewAllowance).not.toHaveProperty('method');
+    expect(confirmedAllowance).toMatchObject({ type: 'allowance', method: 'approval' });
+  });
+
+  it('reads direct bridge allowance without reading Safe code', async () => {
     const { deps } = makeHarness();
     let cacheCallsAtApproval = 0;
     let safeCodeReadsAtApproval = 0;
@@ -171,7 +191,7 @@ describe('top-level swap lifecycle characterization', () => {
       },
     });
 
-    expect(cacheCallsAtApproval).toBe(0);
+    expect(cacheCallsAtApproval).toBe(1);
     expect(safeCodeReadsAtApproval).toBe(0);
     expect(hoisted.multicall).toHaveBeenCalledTimes(cacheCallsAtApproval);
     expect(hoisted.getCode).toHaveBeenCalledTimes(safeCodeReadsAtApproval);
@@ -205,7 +225,7 @@ describe('top-level swap lifecycle characterization', () => {
     );
   });
 
-  it('keeps Safe cache reads skipped when refreshing a direct EOA bridge', async () => {
+  it('reuses direct bridge allowance reads when refreshing the same route', async () => {
     const { deps } = makeHarness();
     let initialCacheCalls = 0;
     let refreshedCacheCalls = 0;
@@ -224,7 +244,7 @@ describe('top-level swap lifecycle characterization', () => {
       },
     });
 
-    expect(initialCacheCalls).toBe(0);
+    expect(initialCacheCalls).toBe(1);
     expect(refreshedCacheCalls).toBe(initialCacheCalls);
     expect(initialCodeReads).toBe(0);
     expect(refreshedCodeReads).toBe(initialCodeReads);

--- a/tests/swap/execution/bridge-contracts.test.ts
+++ b/tests/swap/execution/bridge-contracts.test.ts
@@ -21,6 +21,7 @@ vi.mock('../../../src/services/rff', () => ({
 }));
 
 vi.mock('../../../src/services/allowance-utils', () => ({
+  getPermitDomainName: vi.fn().mockResolvedValue('USD Coin'),
   signPermitForAddressAndValue: vi.fn(),
 }));
 

--- a/tests/swap/execution/source-contracts.test.ts
+++ b/tests/swap/execution/source-contracts.test.ts
@@ -213,6 +213,37 @@ describe('executeSourceSwaps contracts', () => {
     );
   });
 
+  it('dispatches source chains in the same ascending order used by the plan', async () => {
+    const arbitrumQuote = makeQuote();
+    const optimismQuote = makeQuote();
+    optimismQuote.chainID = 10;
+    optimismQuote.holding.chainID = 10;
+    const { context } = makeContext();
+    context.sourceExecutionPaths = new Map([
+      [CHAIN_ID, 'safe'],
+      [10, 'safe'],
+    ]);
+    const deployments = new Map(context.safeDeploymentPromises);
+    deployments.set(10, deployments.get(CHAIN_ID)!);
+    context.safeDeploymentPromises = deployments;
+
+    await executeSourceSwaps(
+      {
+        swaps: [arbitrumQuote, optimismQuote],
+        creationTime: Date.now(),
+        srcBuffer: new Decimal(0),
+      },
+      context,
+      metadata(),
+      [arbitrumQuote.aggregator]
+    );
+
+    expect(vi.mocked(createSafeExecuteTxFromCalls).mock.calls.map(([call]) => call.chainId)).toEqual([
+      10,
+      CHAIN_ID,
+    ]);
+  });
+
   it('groups repeated same-chain legs and consumes their prepared transfer only once', async () => {
     const quote = makeQuote();
     const { context, createSafeExecuteTx } = makeContext(makePreparedExecution(quote));

--- a/tests/swap/prepare.test.ts
+++ b/tests/swap/prepare.test.ts
@@ -304,7 +304,7 @@ describe('prepareSwapExecution', () => {
 
     expect(prepared.eoaToEphemeralTransfers).toEqual([]);
     expect(addSafeAccountQuery).not.toHaveBeenCalled();
-    expect(addAllowanceQuery).not.toHaveBeenCalled();
+    expect(addAllowanceQuery).toHaveBeenCalledTimes(1);
   });
 
   it('builds a source EOA->Safe funding transfer targeting the predicted Safe on Safe V2 source chains', async () => {

--- a/tests/swap/swap-steps-builder.test.ts
+++ b/tests/swap/swap-steps-builder.test.ts
@@ -1,6 +1,8 @@
 import Decimal from 'decimal.js';
 import { describe, expect, it } from 'vitest';
 import type { Hex } from 'viem';
+import { EADDRESS } from '../../src/domain';
+import { PermitVariant } from '../../src/domain/permits';
 import { createSwapPlan } from '../../src/swap/swap-steps-builder';
 import type { BridgeAsset, DestinationSwap, SwapRoute } from '../../src/swap/types';
 import { SwapMode } from '../../src/swap/types';
@@ -21,6 +23,9 @@ const chainA = makeChain(42161, 'Arbitrum');
 const chainB = makeChain(10, 'Optimism');
 const chainDst = makeChain(8453, 'Base');
 const chainList = makeChainList([chainA, chainB, chainDst], token);
+const EOA = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' as const;
+const SAFE = '0x5555555555555555555555555555555555555555' as const;
+const previewAuthorization = { eoaAddress: EOA, safeAddress: SAFE };
 
 const noSwap: DestinationSwap = { tokenSwap: null, gasSwap: null };
 const withTokenSwap: DestinationSwap = {
@@ -124,7 +129,182 @@ const makeBridgeAsset = (chainID: number, eoaBalance: number): BridgeAsset => ({
   ephemeralBalance: new Decimal(10),
 });
 
+const makeBridge = (
+  assets: BridgeAsset[],
+  amount: string | number,
+  overrides: Partial<NonNullable<SwapRoute['bridge']>> = {}
+): NonNullable<SwapRoute['bridge']> => {
+  const totalAmount = new Decimal(amount);
+  return {
+    provider: 'nexus',
+    amount: totalAmount,
+    amounts: { tokenAmount: totalAmount, gasInCot: new Decimal(0), totalAmount },
+    assets,
+    chainID: 8453,
+    decimals: 6,
+    tokenAddress: token.contractAddress,
+    estimatedFees: {
+      collection: new Decimal(0),
+      fulfilment: new Decimal(0),
+      caGas: new Decimal(0),
+      protocol: new Decimal(0),
+      solver: new Decimal(0),
+    },
+    ...overrides,
+  };
+};
+
 describe('createSwapPlan', () => {
+  it('places a methodless destination-funding allowance before its swap', () => {
+    const route = makeRoute({
+      destination: {
+        chainId: 8453,
+        eoaToEphemeral: {
+          amount: 100_000_000n,
+          contractAddress: token.contractAddress,
+        },
+        inputAmount: { min: new Decimal(100), max: new Decimal(100) },
+        swap: withTokenSwap,
+        getDstSwap: async () => null,
+      },
+    });
+
+    const plan = createSwapPlan(route, chainList, previewAuthorization);
+
+    expect(plan.steps).toHaveLength(2);
+    expect(plan.steps[0]).toMatchObject({
+      type: 'allowance',
+      spender: SAFE,
+      amount: { amountRaw: 100_000_000n },
+    });
+    expect(plan.steps[0]).not.toHaveProperty('method');
+    expect(plan.steps[1]).toMatchObject({ type: 'destination_swap' });
+  });
+
+  it('places a methodless bridge-funding allowance before its EOA transfer', () => {
+    const route = makeRoute({
+      source: {
+        swaps: [makeQuoteResponse(42161)],
+        creationTime: Date.now(),
+        srcBuffer: new Decimal(0),
+      },
+      bridge: makeBridge([makeBridgeAsset(42161, 5)], 5),
+      sourceExecutionPaths: new Map([[42161, 'safe']]),
+    });
+
+    const plan = createSwapPlan(route, chainList, previewAuthorization);
+    const transferIndex = plan.steps.findIndex(
+      (step) => step.type === 'eoa_to_ephemeral_transfer'
+    );
+
+    expect(plan.steps[transferIndex - 1]).toMatchObject({
+      type: 'allowance',
+      spender: SAFE,
+      token: { contractAddress: token.contractAddress },
+    });
+    expect(plan.steps[transferIndex - 1]).not.toHaveProperty('method');
+  });
+
+  it('does not preview an EOA-to-ephemeral transfer for native bridge funding', () => {
+    const nativeAsset = {
+      ...makeBridgeAsset(42161, 5),
+      contractAddress: EADDRESS,
+      decimals: 18,
+    };
+    const route = makeRoute({
+      source: {
+        swaps: [makeQuoteResponse(42161)],
+        creationTime: Date.now(),
+        srcBuffer: new Decimal(0),
+      },
+      bridge: makeBridge([nativeAsset], 5),
+      sourceExecutionPaths: new Map([[42161, 'safe']]),
+    });
+
+    const plan = createSwapPlan(route, chainList, previewAuthorization);
+
+    expect(plan.steps.map((step) => step.type)).not.toContain('eoa_to_ephemeral_transfer');
+  });
+
+  it('previews native source swaps before ERC-20 swaps on the same chain', () => {
+    const erc20 = makeQuoteResponse(42161);
+    const native = makeQuoteResponse(42161);
+    native.quote.input.contractAddress = EADDRESS;
+    native.quote.input.symbol = 'ETH';
+    const route = makeRoute({
+      source: {
+        swaps: [erc20, native],
+        creationTime: Date.now(),
+        srcBuffer: new Decimal(0),
+      },
+      sourceExecutionPaths: new Map([[42161, 'safe']]),
+    });
+
+    const plan = createSwapPlan(route, chainList);
+    const sourceStep = plan.steps.find((step) => step.type === 'source_swap');
+
+    expect(sourceStep?.swaps.map((swap) => swap.input.contractAddress)).toEqual([
+      EADDRESS,
+      erc20.quote.input.contractAddress,
+    ]);
+  });
+
+  it('adds a methodless source allowance to preview and resolves its confirmed method', () => {
+    const route = makeRoute({
+      source: {
+        swaps: [makeQuoteResponse(42161)],
+        creationTime: Date.now(),
+        srcBuffer: new Decimal(0),
+      },
+      sourceExecutionPaths: new Map([[42161, 'safe']]),
+    });
+
+    const preview = createSwapPlan(route, chainList, previewAuthorization);
+    const confirmed = createSwapPlan(route, chainList, {
+      cache: {
+        getAllowance: () => 0n,
+        getPermit: () => ({
+          permitVariant: PermitVariant.EIP2612Canonical,
+          permitContractVersion: 1,
+        }),
+      },
+      ...previewAuthorization,
+    });
+
+    expect(preview.steps[0]).toMatchObject({
+      type: 'allowance',
+      token: {
+        contractAddress: '0x00000000000000000000000000000000000000aa',
+        decimals: 6,
+        symbol: 'PEPE',
+      },
+    });
+    expect(preview.steps[0]).not.toHaveProperty('method');
+    expect(preview.steps[1]).toMatchObject({ type: 'source_swap', id: 'source_swap:42161' });
+    expect(confirmed.steps[0]).toMatchObject({ type: 'allowance', method: 'permit' });
+  });
+
+  it('drops a potential allowance from the confirmed plan when allowance is sufficient', () => {
+    const route = makeRoute({
+      source: {
+        swaps: [makeQuoteResponse(42161)],
+        creationTime: Date.now(),
+        srcBuffer: new Decimal(0),
+      },
+      sourceExecutionPaths: new Map([[42161, 'safe']]),
+    });
+
+    const confirmed = createSwapPlan(route, chainList, {
+      cache: {
+        getAllowance: () => 50_000_000_000n,
+        getPermit: () => undefined,
+      },
+      ...previewAuthorization,
+    });
+
+    expect(confirmed.steps.map((step) => step.type)).toEqual(['source_swap']);
+  });
+
   it('returns source-only steps without synthetic lifecycle markers', () => {
     const route = makeRoute({
       source: { swaps: [makeQuoteResponse(42161)], creationTime: Date.now(), srcBuffer: new Decimal(0) },
@@ -170,26 +350,7 @@ describe('createSwapPlan', () => {
           [10, { contractAddress: token.contractAddress, decimals: 6, currencyId: 1 }],
         ]),
       },
-      bridge: {
-        provider: 'nexus',
-        amount: new Decimal('2.2'),
-        amounts: {
-          tokenAmount: new Decimal('2.2'),
-          gasInCot: new Decimal(0),
-          totalAmount: new Decimal('2.2'),
-        },
-        assets: [makeBridgeAsset(42161, 5), makeBridgeAsset(10, 0)],
-        chainID: 8453,
-        decimals: 6,
-        tokenAddress: token.contractAddress,
-        estimatedFees: {
-          collection: new Decimal(0),
-          fulfilment: new Decimal(0),
-          caGas: new Decimal(0),
-          protocol: new Decimal(0),
-          solver: new Decimal(0),
-        },
-      },
+      bridge: makeBridge([makeBridgeAsset(42161, 5), makeBridgeAsset(10, 0)], '2.2'),
       destination: {
         chainId: 8453,
         eoaToEphemeral: null,
@@ -226,26 +387,7 @@ describe('createSwapPlan', () => {
         creationTime: Date.now(),
         srcBuffer: new Decimal(0),
       },
-      bridge: {
-        provider: 'nexus',
-        amount: new Decimal(50),
-        amounts: {
-          tokenAmount: new Decimal(50),
-          gasInCot: new Decimal(0),
-          totalAmount: new Decimal(50),
-        },
-        assets: [makeBridgeAsset(42161, 5), makeBridgeAsset(10, 0)],
-        chainID: 8453,
-        decimals: 6,
-        tokenAddress: token.contractAddress,
-        estimatedFees: {
-          collection: new Decimal(0),
-          fulfilment: new Decimal(0),
-          caGas: new Decimal(0),
-          protocol: new Decimal(0),
-          solver: new Decimal(0),
-        },
-      },
+      bridge: makeBridge([makeBridgeAsset(42161, 5), makeBridgeAsset(10, 0)], 50),
       destination: {
         chainId: 8453,
         eoaToEphemeral: null,
@@ -267,9 +409,10 @@ describe('createSwapPlan', () => {
 
   it('uses the destination token amount for an EOA bridge fill that also delivers gas', () => {
     const route = makeRoute({
-      bridge: {
-        provider: 'nexus',
-        amount: new Decimal(8),
+      bridge: makeBridge(
+        [{ ...makeBridgeAsset(42161, 8), ephemeralBalance: new Decimal(0) }],
+        8,
+        {
         amounts: {
           tokenAmount: new Decimal(5),
           gasInCot: new Decimal(0),
@@ -280,18 +423,8 @@ describe('createSwapPlan', () => {
           amountRaw: 1_000_000_000_000_000n,
           amountInToken: new Decimal('2.5'),
         },
-        assets: [{ ...makeBridgeAsset(42161, 8), ephemeralBalance: new Decimal(0) }],
-        chainID: 8453,
-        decimals: 6,
-        tokenAddress: token.contractAddress,
-        estimatedFees: {
-          collection: new Decimal(0),
-          fulfilment: new Decimal(0),
-          caGas: new Decimal(0),
-          protocol: new Decimal(0),
-          solver: new Decimal(0),
-        },
-      },
+        }
+      ),
     });
 
     const plan = createSwapPlan(route, chainList);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Align swap plans with runtime execution order and expose required EOA ERC-20 authorization as allowance steps. Also fix permit signing for tokens such as AUSD on Monad whose ERC-20 `name()` differs from their EIP-712 domain name.

## Changes
- Use the same source ordering for planning and execution: ascending chain ID, with native-token swaps first within each chain.
- Add the public `allowance` swap step for source, destination, composed-bridge, and direct EOA bridge authorization.
- Emit allowance steps without `method` in `plan_preview`, then omit satisfied allowances and set `method` to `approval` or `permit` in `plan_confirmed`.
- Keep native-token paths free of allowance steps and avoid staging native bridge funds through an EOA-to-ephemeral transfer.
- Render active and completed allowance steps in the browser example's swap progress modal.
- Resolve permit domain names through ERC-5267 `eip712Domain()`, falling back to ERC-20 `name()` and then `''` for unsupported tokens.
- Reuse the domain-name resolver for connected-wallet and ephemeral-wallet permits while keeping chain-list permit versions unchanged.
- Update public exports, SDK/browser documentation, and plan, execution, and permit regression coverage.

## Testing
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

## Risk / Impact

Medium. This adds a member to the public swap plan union, changes source-step ordering and confirmed-plan contents, and changes the domain name used in permit digests for ERC-5267 tokens. Wallet submission behavior remains gated behind intent acceptance, native transactions continue to be submitted by the EOA, and permit versions still come from the chain list. Tokens without ERC-5267 retain the existing `name()` and empty-string fallbacks. The primary risks are allowance classification, plan ordering, and permit-domain compatibility regressions; these paths are covered by plan-builder, lifecycle, execution-contract, public API, characterization, and permit fallback tests.