### PR TITLE
balances: expose usable amounts and prioritize non-Ethereum sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,14 +285,18 @@ const assets = await client.getBalancesForBridge();
 //   {
 //     symbol: 'USDC',
 //     name: 'USDC',
-//     balance: '1250.50',          // Total across all chains
+//     balance: '1250.50',          // Deprecated alias for usableBalance
+//     totalBalance: '1250.50',     // Total before native-token reservations
+//     usableBalance: '1250.50',    // Available after reservations
 //     value: '1250.50',            // USD value (string)
 //     decimals: 6,
 //     logo: 'https://...',
 //     currencyId: 1,
 //     chainBalances: [             // Per-chain balances
 //       {
-//         balance: '500.00',
+//         balance: '500.00',       // Deprecated alias for usableBalance
+//         totalBalance: '500.00',
+//         usableBalance: '500.00',
 //         value: '500.00',
 //         symbol: 'USDC',
 //         chain: { id: 1, name: 'Ethereum', logo: '...' },
@@ -330,7 +334,10 @@ type TokenBalance = {
   name: string;               // Display label (e.g. "USDC/USDM")
   symbol: string;             // Majority symbol by chain count
   logo: string;               // Token logo URL
-  balance: string;            // Total balance (human-readable)
+  /** @deprecated Use usableBalance instead. */
+  balance: string;            // Compatibility alias for usableBalance
+  totalBalance: string;       // Before native-token reservations
+  usableBalance: string;      // Available after reservations
   value: string;              // USD value (string for precision)
   decimals: number;
   currencyId?: number;        // Required on BridgeTokenBalance
@@ -338,7 +345,10 @@ type TokenBalance = {
 };
 
 type ChainBalance = {
-  balance: string;
+  /** @deprecated Use usableBalance instead. */
+  balance: string;            // Compatibility alias for usableBalance
+  totalBalance: string;       // Before native-token reservations
+  usableBalance: string;      // Available after reservations
   value: string;              // USD value (string)
   symbol: string;
   chain: { id: number; name: string; logo: string };
@@ -347,6 +357,10 @@ type ChainBalance = {
   universe: Universe;
 };
 ```
+
+For ERC-20 balances and bridge balances, `totalBalance` and `usableBalance` currently match. Swap
+native-token balances can differ because `totalBalance` preserves the middleware balance while
+`usableBalance` excludes the gas reserve used by source selection.
 
 ---
 

--- a/src/bridge/bridge.md
+++ b/src/bridge/bridge.md
@@ -163,14 +163,15 @@ createBridgeIntent(provider='mayan') → createMayanBridgeIntent:    # try/catch
   # Step 1: source inventory — keep only sources where source chain AND token are mayanEnabled
   #         depositFee looked up with 'depositMayan' → match.depositMayanFeeToken (not depositFeeToken)
   # Step 2: per-leg floor = $1.10 USD  (×2 for native ETH → Ethereum mainnet)
-  #         keep sources with usableUsd ≥ $1.10 ∧ usable ≥ minimumAmount; sort by usableUsd DESC
+  #         keep sources with usableUsd ≥ $1.10 ∧ usable ≥ minimumAmount;
+  #         sort Ethereum last, then usableUsd DESC within each group
   # Step 3: gas drop — capped per chain (ETH .05, BSC .02, Polygon .2, Avax .1, Arb .01);
   #         native destination + gas drop → throw; modelled INSIDE the Mayan route, not an RFF dest
 
   # Steps 4-7: quote once, then trim ONE leg — Mayan quotes are EXACT-IN, RFF is EXACT-OUT.
   # Step 4: ONE batched getMayanQuotes with every eligible leg at its FULL usable amount,
-  #         gas drop on the largest leg (index 0 after the usableUsd-desc sort). maxOut[i] = minReceived.
-  # Step 5: commit the largest legs in full until Σ maxOut ≥ amount; if even all legs maxed are short
+  #         gas drop on the first priority-ordered leg. maxOut[i] = minReceived.
+  # Step 5: commit priority-ordered legs in full until Σ maxOut ≥ amount; if even all legs maxed are short
   #         → throw Insufficient balance (detected in ONE round, not three).
   # Step 6: the last committed leg is the SWING. Keep the others at full; trim the swing to the
   #         residual needFromSwing = amount − Σ(other committed maxOut):
@@ -374,13 +375,14 @@ the quote source list and use an internal fee of `0`. The public `total` is `caG
 - **Mayan per‑leg floor `$1.10`** (×2 for native ETH → mainnet); sources below it are dropped before
   selection.
 - **Mayan convergence is quote‑once + swing‑leg.** One batched `getMayanQuotes` prices every eligible
-  leg at full usable; the largest legs are committed in full and only the **last (swing) leg** is
-  trimmed (≤ `MAYAN_SWING_MAX_QUOTES` re‑quotes) to the residual output. Convergence is guaranteed
+  leg at full usable; legs are ordered with Ethereum last, then usable USD descending within each
+  group. They are committed in that order and only the **last (swing) leg** is trimmed
+  (≤ `MAYAN_SWING_MAX_QUOTES` re‑quotes) to the residual output. Convergence is guaranteed
   (the swing at full usable already covers the residual), insufficiency is detected in **one** round
   (`Σ all‑max < amount`), and any overshoot is confined to the swing leg and bounded by one per‑leg
   minimum (accepted by design). Replaces the old ≤3‑round proportional‑rescale loop that could miss
   the target and fall back to Nexus.
-- **Mayan gas drop** is chain‑capped and rides the **largest** leg only; it lives in the route
+- **Mayan gas drop** is chain‑capped and rides the **first priority-ordered** leg only; it lives in the route
   payload, never as an RFF destination. Native destination + gas drop is rejected.
 - **Exact‑out source selection** (Nexus) is greedy over `usable = balance − depositFee`, Ethereum
   ordered last; a leftover `remainingPayable` throws `Insufficient balance`.

--- a/src/bridge/intent/creator.ts
+++ b/src/bridge/intent/creator.ts
@@ -419,13 +419,18 @@ const createMayanBridgeIntent = async (
       .filter((source) => {
         return source.usableUsd.gte(minimumPerLegUsd) && source.usable.gte(source.minimumAmount);
       })
-      .sort((a, b) => Decimal.sub(b.usableUsd, a.usableUsd).toNumber());
+      .sort((a, b) => {
+        const aIsEth = a.chain.id === 1 ? 1 : 0;
+        const bIsEth = b.chain.id === 1 ? 1 : 0;
+        if (aIsEth !== bIsEth) return aIsEth - bIsEth;
+        return Decimal.sub(b.usableUsd, a.usableUsd).toNumber();
+      });
     if (allowedSources.length === 0) {
       throw Errors.invalidInput('intent must include at least one allowed source');
     }
 
     // Step 3: Mayan quotes are exact-in while the SDK bridge request is exact-out. We quote
-    // every eligible leg once at its full usable amount, commit the largest legs in full,
+    // every eligible leg once at its full usable amount, commit priority-ordered legs in full,
     // and trim only the last (swing) leg to the residual output we still need. The swing leg
     // may overshoot by up to one per-leg minimum, which is accepted.
     let finalAmountOut = new Decimal(0);
@@ -487,8 +492,7 @@ const createMayanBridgeIntent = async (
     };
 
     // Step 4: quote every eligible leg once at its full usable amount. The destination gas
-    // drop rides the largest leg (index 0 after the usableUsd-desc sort) so a single quote
-    // pays for it.
+    // drop rides the first priority-ordered leg so a single quote pays for it.
     const maxQuotes = await quoteMayanLegs(middlewareClient, {
       legs: allowedSources.map((source, index) => ({
         chainId: source.chain.id,
@@ -505,7 +509,7 @@ const createMayanBridgeIntent = async (
       out: maxQuotes[index].minReceived,
     }));
 
-    // Step 5: commit the largest legs in full until their summed output covers the
+    // Step 5: commit the priority-ordered legs in full until their summed output covers the
     // requested amount.
     const committedLegs: typeof maxLegs = [];
     let cumulativeOut = new Decimal(0);

--- a/src/domain/types/index.ts
+++ b/src/domain/types/index.ts
@@ -628,7 +628,12 @@ export type UnifiedBalanceResponseData = {
 };
 
 export type ChainBalance = {
+  /** @deprecated Use `usableBalance` instead. */
   balance: string;
+  /** Balance before native-token reservations are deducted. */
+  totalBalance: string;
+  /** Balance available for SDK operations after reservations are deducted. */
+  usableBalance: string;
   value: string;
   symbol: string;
   chain: {
@@ -642,7 +647,12 @@ export type ChainBalance = {
 };
 
 export type TokenBalance = {
+  /** @deprecated Use `usableBalance` instead. */
   balance: string;
+  /** Total balance across chains before native-token reservations are deducted. */
+  totalBalance: string;
+  /** Balance available across chains after reservations are deducted. */
+  usableBalance: string;
   value: string;
   chainBalances: ChainBalance[];
   currencyId?: number;

--- a/src/services/balances.ts
+++ b/src/services/balances.ts
@@ -19,6 +19,7 @@ import type { FlatBalance } from '../swap/types';
 import type { MiddlewareBridgeBalanceClient, MiddlewareSwapBalanceClient } from '../transport';
 import { convertAddressByUniverse } from './addresses';
 import { estimateRepresentativeDepositTxFee } from './deposit-fee-estimation';
+import { createPublicClientWithFallback } from './evm';
 import { divDecimals } from './math';
 import { equalFold } from './strings';
 import { estimateRepresentativeSwapNativeReserveFee } from './swap-native-reserve-fee';
@@ -26,9 +27,13 @@ import { estimateRepresentativeSwapNativeReserveFee } from './swap-native-reserv
 const logger = getLogger();
 
 const USD_VALUE_DECIMALS = 2;
+const MONAD_CHAIN_ID = 143;
+const MONAD_DELEGATED_EOA_RESERVE = new Decimal(10);
+const EIP7702_DELEGATION_PREFIX = '0xef0100';
 
 type TokenBalanceGroup = {
   balance: Decimal;
+  totalBalance: Decimal;
   value: Decimal;
   currencyId?: number;
   chainBalances: ChainBalance[];
@@ -55,6 +60,8 @@ const finalizeTokenBalance = (group: TokenBalanceGroup): TokenBalance => {
 
   return {
     balance: group.balance.toFixed(),
+    totalBalance: group.totalBalance.toFixed(),
+    usableBalance: group.balance.toFixed(),
     value: toUsdValueString(group.value),
     chainBalances: orderBy(
       group.chainBalances,
@@ -85,6 +92,7 @@ const addChainBalanceToGroup = (
     groups.get(groupKey) ??
     ({
       balance: new Decimal(0),
+      totalBalance: new Decimal(0),
       value: new Decimal(0),
       currencyId: input.currencyId,
       chainBalances: [] as ChainBalance[],
@@ -92,6 +100,7 @@ const addChainBalanceToGroup = (
     } satisfies TokenBalanceGroup);
 
   group.balance = Decimal.add(group.balance, chainBalance.balance);
+  group.totalBalance = Decimal.add(group.totalBalance, chainBalance.totalBalance);
   group.value = Decimal.add(group.value, input.value);
   group.chainBalances.push(chainBalance);
 
@@ -150,7 +159,7 @@ export const getBalancesForSwap = async (input: {
   const adjusted =
     input.deductNativeReserve === false
       ? swapSupported
-      : await deductSwapNativeReserveFees(input.chainList, swapSupported);
+      : await deductSwapNativeReserveFees(input.chainList, swapSupported, input.evmAddress);
   return flatBalancesToAssets(input.chainList, adjusted);
 };
 
@@ -159,7 +168,8 @@ export const getBalancesForSwap = async (input: {
 // every-swap-supported-chain to 0-2 chains.
 export const deductSwapNativeReserveFees = async (
   chainList: ChainListType,
-  balances: FlatBalance[]
+  balances: FlatBalance[],
+  evmAddress: Hex
 ): Promise<FlatBalance[]> => {
   const nativeChainIds = new Set(
     balances
@@ -171,12 +181,31 @@ export const deductSwapNativeReserveFees = async (
   }
 
   const chainsNeedingFees = chainList.chains.filter((c) => nativeChainIds.has(c.id));
-  const feeByChain = new Map<number, Decimal>();
+  const reserveByChain = new Map<number, Decimal>();
   await Promise.all(
     chainsNeedingFees.map(async (chain) => {
       try {
-        const fee = await estimateRepresentativeSwapNativeReserveFee({ chain });
-        feeByChain.set(chain.id, divDecimals(fee, chain.nativeCurrency.decimals));
+        const publicClient =
+          chain.id === MONAD_CHAIN_ID ? createPublicClientWithFallback(chain) : undefined;
+        const [fee, isDelegatedOnMonad] = await Promise.all([
+          estimateRepresentativeSwapNativeReserveFee({ chain, publicClient }),
+          publicClient
+            ? publicClient
+                .getCode({ address: evmAddress })
+                .then((code) => code?.toLowerCase().startsWith(EIP7702_DELEGATION_PREFIX) === true)
+                .catch((error) => {
+                  logger.error('swap.balance.monad_delegation_check.failed', error, {
+                    chainId: chain.id,
+                  });
+                  return false;
+                })
+            : Promise.resolve(false),
+        ]);
+        const feeReserve = divDecimals(fee, chain.nativeCurrency.decimals);
+        reserveByChain.set(
+          chain.id,
+          isDelegatedOnMonad ? feeReserve.plus(MONAD_DELEGATED_EOA_RESERVE) : feeReserve
+        );
       } catch (error) {
         logger.error('swap-balance-fee-estimate', error, { chainID: chain.id });
       }
@@ -185,10 +214,10 @@ export const deductSwapNativeReserveFees = async (
 
   return balances.map((b) => {
     if (!equalFold(b.tokenAddress, EADDRESS)) return b;
-    const fee = feeByChain.get(b.chainID);
-    if (!fee) return b;
+    const reserve = reserveByChain.get(b.chainID);
+    if (!reserve) return b;
     const amount = new Decimal(b.amount);
-    const remaining = amount.sub(fee);
+    const remaining = amount.sub(reserve);
     // Actual amount removed from this native balance — the reserve fee, or the whole balance
     // when the fee exceeds it.
     const deducted = amount.sub(Decimal.max(remaining, 0));
@@ -197,12 +226,13 @@ export const deductSwapNativeReserveFees = async (
       deductedNativeAmount: `${deducted.toString()} ${b.symbol}`,
     });
     if (remaining.lte(0)) {
-      return { ...b, amount: '0', value: 0 };
+      return { ...b, amount: '0', totalAmount: b.totalAmount ?? b.amount, value: 0 };
     }
     const ratio = amount.gt(0) ? remaining.div(amount) : new Decimal(0);
     return {
       ...b,
       amount: remaining.toFixed(b.decimals, Decimal.ROUND_FLOOR),
+      totalAmount: b.totalAmount ?? b.amount,
       value: ratio.mul(b.value).toNumber(),
     };
   });
@@ -237,6 +267,8 @@ export const aggregateBalancesByCurrency = (
       const value = new Decimal(currency.value);
       const chainBalance: ChainBalance = {
         balance: normalizedBalance.toFixed(),
+        totalBalance: normalizedBalance.toFixed(),
+        usableBalance: normalizedBalance.toFixed(),
         value: toUsdValueString(value),
         symbol: token.symbol,
         chain: {
@@ -286,6 +318,8 @@ export const flatBalancesToAssets = (
     const value = new Decimal(balance.value);
     const chainBalance: ChainBalance = {
       balance: balance.amount,
+      totalBalance: balance.totalAmount ?? balance.amount,
+      usableBalance: balance.amount,
       value: toUsdValueString(value),
       symbol: balance.symbol,
       chain: {

--- a/src/swap/preflight.ts
+++ b/src/swap/preflight.ts
@@ -109,7 +109,11 @@ export const buildSwapPreflight = async (
   // router never sizes a swap against native it needs to execute. Applied here — the single swap
   // source-sizing chokepoint — regardless of whether balances were preloaded (composite flow
   // passes raw, keeping actual values for its own destination-gas shortfall) or freshly fetched.
-  const reserved = await deductSwapNativeReserveFees(options.chainList, rawBalances);
+  const reserved = await deductSwapNativeReserveFees(
+    options.chainList,
+    rawBalances,
+    options.eoaAddress
+  );
   const balances = selectSwapSources(reserved, input.data.toChainId, input.data.toTokenAddress);
 
   const candidateChainIds = getCandidateChainIds(input, balances);

--- a/src/swap/swap.md
+++ b/src/swap/swap.md
@@ -139,6 +139,11 @@ smaller of 0.5% or $0.25 for stable-only conversions, and the smaller of 2% or $
 non-stable conversion is required. Provider selection happens only for route-relevant remote value;
 direct destination routes do not request a bridge provider.
 
+Before source selection, native balances reserve the representative execution fee. On Monad
+(chain 143), a positive MON balance also starts an EIP-7702 delegation-code read in parallel with
+that fee estimate; a delegated EOA reserves an additional 10 MON. The usable balance is clamped at
+zero, while public balance results preserve the pre-reservation amount as `totalBalance`.
+
 An Exact Out same-token bridge can include a positive native-gas requirement in the bridge intent.
 Routing accounts for that gas in the selected source amount, omits a destination gas swap, and sets
 the bridge receiver to the EOA.

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -187,6 +187,7 @@ export type SwapData =
 
 export type FlatBalance = {
   amount: string; // human decimal string
+  totalAmount?: string; // human decimal string before native-token reservations
   chainID: number;
   decimals: number;
   logo: string;

--- a/tests/flows/bridge-intent-creator.test.ts
+++ b/tests/flows/bridge-intent-creator.test.ts
@@ -107,6 +107,8 @@ describe('createBridgeIntent', () => {
     value?: string;
   }) => ({
     balance: input.balance,
+    totalBalance: input.balance,
+    usableBalance: input.balance,
     value: input.value ?? '0.00',
     symbol: input.symbol ?? 'USDC',
     chain: { id: input.chainId, logo: '', name: input.chainName },
@@ -125,6 +127,8 @@ describe('createBridgeIntent', () => {
     value?: string;
   }): TokenBalance => ({
     balance: input.balance,
+    totalBalance: input.balance,
+    usableBalance: input.balance,
     value: input.value ?? '0.00',
     chainBalances: input.chainBalances,
     decimals: input.decimals ?? token.decimals,

--- a/tests/flows/bridge-intent-creator.test.ts
+++ b/tests/flows/bridge-intent-creator.test.ts
@@ -463,6 +463,61 @@ describe('createBridgeIntent', () => {
         }),
       });
 
+    it('selects non-Ethereum sources before a larger Ethereum source', async () => {
+      const ethChain = makeChain(1, 'Ethereum');
+      const baseChain = makeChain(8453, 'Base');
+      const dstChain = makeChain(10, 'Optimism');
+
+      const assets: TokenBalance[] = [
+        makeTokenBalance({
+          balance: '30',
+          value: '30.00',
+          chainBalances: [
+            makeChainBalance({
+              balance: '20',
+              value: '20.00',
+              chainId: ethChain.id,
+              chainName: ethChain.name,
+            }),
+            makeChainBalance({
+              balance: '10',
+              value: '10.00',
+              chainId: baseChain.id,
+              chainName: baseChain.name,
+            }),
+          ],
+        }),
+      ];
+
+      const chainList = makeChainList([ethChain, baseChain, dstChain], token);
+      const options = makeOptions(chainList);
+
+      const intent = await createBridgeIntent(
+        {
+          amount: new Decimal('15'),
+          assets: createUserAssets(assets),
+          gas: new Decimal('0'),
+          gasInToken: new Decimal('0'),
+          resolveUsdValue: ({ amount }) => amount,
+          sourceChains: [],
+          token,
+          dstChainId: dstChain.id,
+          dstChainUniverse: Universe.ETHEREUM,
+          dstChainNativeDecimals: 18,
+          recipient: options.evm.address,
+          quoteResponse: feeQuote([ethChain.id, baseChain.id], dstChain.id),
+          provider: 'mayan',
+        },
+        { ...createIntentContext(options), middlewareClient: makeRateMayanClient(1) }
+      );
+
+      expect(intent.provider).toBe('mayan');
+      expect(intent.selectedSources.map((source) => source.chain.id)).toEqual([
+        baseChain.id,
+        ethChain.id,
+      ]);
+    });
+
     it('commits the largest leg in full and trims only the last leg to the requested amount', async () => {
       const bigChain = makeChain(42161, 'Arbitrum');
       const swingChain = makeChain(8453, 'Base');

--- a/tests/flows/bridge-intent-values.test.ts
+++ b/tests/flows/bridge-intent-values.test.ts
@@ -25,10 +25,14 @@ const NATIVE_ADDRESS = '0x0000000000000000000000000000000000000000' as Hex;
 
 const USDC_ASSET: TokenBalance = {
   balance: '15',
+  totalBalance: '15',
+  usableBalance: '15',
   value: '15.00',
   chainBalances: [
     {
       balance: '10',
+      totalBalance: '10',
+      usableBalance: '10',
       value: '10.00',
       chain: { id: 1, logo: '', name: 'Ethereum' },
       contractAddress: TOKEN_ADDRESS,
@@ -38,6 +42,8 @@ const USDC_ASSET: TokenBalance = {
     },
     {
       balance: '5',
+      totalBalance: '5',
+      usableBalance: '5',
       value: '0.00',
       chain: { id: 10, logo: '', name: 'Optimism' },
       contractAddress: TOKEN_ADDRESS,
@@ -47,6 +53,8 @@ const USDC_ASSET: TokenBalance = {
     },
     {
       balance: '0',
+      totalBalance: '0',
+      usableBalance: '0',
       value: '0.00',
       chain: { id: 137, logo: '', name: 'Polygon' },
       contractAddress: TOKEN_ADDRESS,
@@ -63,10 +71,14 @@ const USDC_ASSET: TokenBalance = {
 
 const NATIVE_ASSET: TokenBalance = {
   balance: '1',
+  totalBalance: '1',
+  usableBalance: '1',
   value: '2500.00',
   chainBalances: [
     {
       balance: '1',
+      totalBalance: '1',
+      usableBalance: '1',
       value: '2500.00',
       chain: { id: 10, logo: '', name: 'Optimism' },
       contractAddress: NATIVE_ADDRESS,

--- a/tests/flows/characterization/bridge-and-execute-pipeline.test.ts
+++ b/tests/flows/characterization/bridge-and-execute-pipeline.test.ts
@@ -192,10 +192,14 @@ const makeUserAsset = (input: {
   value: number;
 }) => ({
   balance: input.balance,
+  totalBalance: input.balance,
+  usableBalance: input.balance,
   value: input.value.toFixed(2),
   chainBalances: [
     {
       balance: input.balance,
+      totalBalance: input.balance,
+      usableBalance: input.balance,
       value: input.value.toFixed(2),
       chain: {
         id: input.chain.id,

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -6,6 +6,7 @@ import type {
   BridgeAndExecuteResult,
   BridgeResult,
   BridgeSimulationResult,
+  ChainBalance,
   IntentRecord,
   ListIntentsParams,
   ListIntentsResult,
@@ -15,6 +16,7 @@ import type {
   SwapMaxResult,
   SwapResult as SwapResultType,
   SwapResult,
+  TokenBalance,
   TxResult,
 } from '../src';
 
@@ -31,6 +33,8 @@ describe('public api exports', () => {
     const bridgeAndExecuteResult = {} as BridgeAndExecuteResult;
     const swapAndExecuteResult = {} as SwapAndExecuteResult;
     const swapAllowanceStep = {} as SwapAllowanceStep;
+    const tokenBalance = {} as TokenBalance;
+    const chainBalance = {} as ChainBalance;
 
     expect(IntentStatus.Created).toBe('created');
     expect(params).toEqual({ page: 1, status: 'created' });
@@ -43,6 +47,10 @@ describe('public api exports', () => {
     expectTypeOf(bridgeAndExecuteResult).toMatchTypeOf<BridgeAndExecuteResult>();
     expectTypeOf(swapAndExecuteResult).toMatchTypeOf<SwapAndExecuteResult>();
     expectTypeOf(swapAllowanceStep.method).toEqualTypeOf<'approval' | 'permit' | undefined>();
+    expectTypeOf(tokenBalance.totalBalance).toEqualTypeOf<string>();
+    expectTypeOf(tokenBalance.usableBalance).toEqualTypeOf<string>();
+    expectTypeOf(chainBalance.totalBalance).toEqualTypeOf<string>();
+    expectTypeOf(chainBalance.usableBalance).toEqualTypeOf<string>();
 
     if (bridgeAndExecuteResult.bridgeSkipped) {
       expectTypeOf(bridgeAndExecuteResult.bridgeResult).toEqualTypeOf<undefined>();

--- a/tests/services/balances-monad-reserve.test.ts
+++ b/tests/services/balances-monad-reserve.test.ts
@@ -1,0 +1,158 @@
+import Decimal from 'decimal.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Hex } from 'viem';
+import type { Chain, ChainListType } from '../../src/domain';
+import { Universe } from '../../src/domain/chain-abstraction';
+import {
+  deductSwapNativeReserveFees,
+  getBalancesForSwap,
+} from '../../src/services/balances';
+import { EADDRESS } from '../../src/swap/constants';
+import type { FlatBalance } from '../../src/swap/types';
+import type { MiddlewareSwapBalanceClient } from '../../src/transport';
+
+const mocks = vi.hoisted(() => ({
+  estimateReserve: vi.fn(),
+  getCode: vi.fn(),
+}));
+
+vi.mock('../../src/services/evm', () => ({
+  createPublicClientWithFallback: vi.fn(() => ({ getCode: mocks.getCode })),
+}));
+
+vi.mock('../../src/services/swap-native-reserve-fee', () => ({
+  estimateRepresentativeSwapNativeReserveFee: mocks.estimateReserve,
+}));
+
+const MONAD_CHAIN_ID = 143;
+const EOA = '0x1111111111111111111111111111111111111111' as Hex;
+const DELEGATED_CODE = `0xef0100${'22'.repeat(20)}` as Hex;
+
+const monad: Chain = {
+  id: MONAD_CHAIN_ID,
+  name: 'Monad',
+  multicallAddress: '0x00000000000000000000000000000000000000aa',
+  rpcUrls: { default: { http: ['https://rpc.monad.example.com'], webSocket: [] } },
+  nativeCurrency: { decimals: 18, symbol: 'MON', name: 'Monad', logo: '' },
+  custom: { icon: '', knownTokens: [] },
+  blockExplorers: { default: { name: 'explorer', url: 'https://example.com' } },
+  universe: Universe.ETHEREUM,
+};
+
+const chainList = {
+  chains: [monad],
+  getChainByID: vi.fn(() => monad),
+} as unknown as ChainListType;
+
+const mon = (amount: string): FlatBalance => ({
+  amount,
+  chainID: MONAD_CHAIN_ID,
+  decimals: 18,
+  symbol: 'MON',
+  tokenAddress: EADDRESS,
+  value: new Decimal(amount).toNumber(),
+  logo: '',
+  name: 'Monad',
+});
+
+const erc20 = (): FlatBalance => ({
+  amount: '20',
+  chainID: MONAD_CHAIN_ID,
+  decimals: 18,
+  symbol: 'TEST',
+  tokenAddress: '0x3333333333333333333333333333333333333333',
+  value: 20,
+  logo: '',
+  name: 'Test',
+});
+
+const middleware = (balances: FlatBalance[]): MiddlewareSwapBalanceClient =>
+  ({ getSwapBalances: vi.fn().mockResolvedValue(balances) }) as MiddlewareSwapBalanceClient;
+
+describe('Monad delegated EOA native reserve', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.estimateReserve.mockResolvedValue(10_000_000_000_000_000n);
+    mocks.getCode.mockResolvedValue(undefined);
+  });
+
+  it('reserves an additional 10 MON and preserves the total balance when delegated', async () => {
+    mocks.getCode.mockResolvedValue(DELEGATED_CODE);
+
+    const [asset] = await getBalancesForSwap({
+      middlewareClient: middleware([mon('20')]),
+      evmAddress: EOA,
+      chainList,
+    });
+
+    expect(asset).toMatchObject({
+      balance: '9.99',
+      totalBalance: '20',
+      usableBalance: '9.99',
+      chainBalances: [
+        expect.objectContaining({
+          balance: '9.990000000000000000',
+          totalBalance: '20',
+          usableBalance: '9.990000000000000000',
+        }),
+      ],
+    });
+    expect(mocks.getCode).toHaveBeenCalledWith({ address: EOA });
+  });
+
+  it('clamps a delegated MON balance below the combined reserve to zero', async () => {
+    mocks.getCode.mockResolvedValue(DELEGATED_CODE);
+
+    const [asset] = await getBalancesForSwap({
+      middlewareClient: middleware([mon('5')]),
+      evmAddress: EOA,
+      chainList,
+    });
+
+    expect(asset).toMatchObject({
+      balance: '0',
+      totalBalance: '5',
+      usableBalance: '0',
+    });
+  });
+
+  it('does not reserve 10 MON when the EOA is not delegated', async () => {
+    const [asset] = await getBalancesForSwap({
+      middlewareClient: middleware([mon('20')]),
+      evmAddress: EOA,
+      chainList,
+    });
+
+    expect(asset).toMatchObject({
+      balance: '19.99',
+      totalBalance: '20',
+      usableBalance: '19.99',
+    });
+  });
+
+  it('does not check delegation without a positive MON balance', async () => {
+    await getBalancesForSwap({
+      middlewareClient: middleware([erc20()]),
+      evmAddress: EOA,
+      chainList,
+    });
+
+    expect(mocks.getCode).not.toHaveBeenCalled();
+    expect(mocks.estimateReserve).not.toHaveBeenCalled();
+  });
+
+  it('checks delegation without waiting for fee estimation to finish', async () => {
+    let resolveFee!: (fee: bigint) => void;
+    mocks.estimateReserve.mockReturnValue(
+      new Promise<bigint>((resolve) => {
+        resolveFee = resolve;
+      })
+    );
+
+    const deduction = deductSwapNativeReserveFees(chainList, [mon('20')], EOA);
+
+    await vi.waitFor(() => expect(mocks.getCode).toHaveBeenCalledWith({ address: EOA }));
+    resolveFee(10_000_000_000_000_000n);
+    await deduction;
+  });
+});

--- a/tests/services/balances-native-reserve.test.ts
+++ b/tests/services/balances-native-reserve.test.ts
@@ -63,6 +63,16 @@ describe('getBalancesForSwap deductNativeReserve flag', () => {
     });
     const eth = result.find((t) => t.symbol === 'ETH');
     expect(Number(eth!.chainBalances[0]!.balance)).toBeCloseTo(0.99, 6); // 1 - 0.01 reserve
+    expect(eth).toMatchObject({
+      balance: '0.99',
+      totalBalance: '1',
+      usableBalance: '0.99',
+    });
+    expect(eth!.chainBalances[0]).toMatchObject({
+      balance: '0.990000000000000000',
+      totalBalance: '1',
+      usableBalance: '0.990000000000000000',
+    });
   });
 
   it('returns the full native balance when deductNativeReserve=false', async () => {
@@ -74,5 +84,6 @@ describe('getBalancesForSwap deductNativeReserve flag', () => {
     });
     const eth = result.find((t) => t.symbol === 'ETH');
     expect(eth!.chainBalances[0]!.balance).toBe('1'); // full, no reserve deducted
+    expect(eth).toMatchObject({ balance: '1', totalBalance: '1', usableBalance: '1' });
   });
 });

--- a/tests/services/balances-normalization.test.ts
+++ b/tests/services/balances-normalization.test.ts
@@ -69,12 +69,20 @@ describe('aggregateBalancesByCurrency', () => {
 
     expect(assets).toHaveLength(1);
     expect(assets[0]?.balance).toBe('3.370802');
+    expect(assets[0]).toMatchObject({
+      totalBalance: '3.370802',
+      usableBalance: '3.370802',
+    });
     expect(assets[0]?.value).toBe('3.37');
     expect(assets[0]?.name).toBe('USDC/USDM');
     expect(assets[0]?.symbol).toBe('USDC');
     expect(assets[0]?.logo).toBe('https://cdn.example/usdc.png');
     expect(assets[0]?.chainBalances.map((entry) => entry.chain.id)).toEqual([1, 10]);
     expect(assets[0]?.chainBalances[0]?.balance).toBe('2.370802');
+    expect(assets[0]?.chainBalances[0]).toMatchObject({
+      totalBalance: '2.370802',
+      usableBalance: '2.370802',
+    });
   });
 });
 
@@ -139,11 +147,15 @@ describe('flatBalancesToAssets', () => {
         name: 'WETH',
         symbol: 'WETH',
         balance: '2.5',
+        totalBalance: '2.5',
+        usableBalance: '2.5',
         value: '5000.00',
         logo: 'https://cdn.example/weth.png',
         chainBalances: [
           expect.objectContaining({
             balance: '2.5',
+            totalBalance: '2.5',
+            usableBalance: '2.5',
             value: '5000.00',
             symbol: 'WETH',
             contractAddress: weth.contractAddress,


### PR DESCRIPTION
## Summary

Make source funding safer and more explicit by prioritizing non-Ethereum Mayan bridge sources and exposing balances before and after native-token reservations. Delegated EOAs on Monad now retain an additional 10 MON without adding a sequential RPC wait to swap preflight.

## Changes
- Order eligible Mayan bridge sources with Ethereum last, while retaining usable USD descending order within the non-Ethereum and Ethereum groups.
- Keep Mayan gas drop and swing-leg selection aligned with the new priority order.
- Add required `totalBalance` and `usableBalance` fields to public `TokenBalance` and `ChainBalance` results, with `balance` retained as a deprecated alias for `usableBalance`.
- Preserve pre-reservation native amounts through swap balance normalization; ERC-20 and bridge balances currently report matching total and usable amounts.
- On Monad (chain 143), check EIP-7702 delegation only when the user has a positive MON balance and reserve an additional 10 MON for delegated EOAs, clamped at zero.
- Run the Monad delegation-code read concurrently with representative native-fee estimation using the same public client.
- Update public documentation, bridge/swap flow documentation, type-surface coverage, balance normalization tests, and Monad reservation regression tests.

## Testing
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

## Risk / Impact

Medium. Mayan may now consume smaller non-Ethereum balances before a larger Ethereum balance, which can change selected legs and which leg carries destination gas drop. The public balance shape gains required fields, while the existing `balance` field remains available as a deprecated compatibility alias. Monad native source capacity is reduced by an additional 10 MON only for delegated EOAs; delegation detection and fee estimation are concurrent, and low balances are clamped to zero. Regression coverage exercises source ordering, public type shape, total/usable normalization, delegated and undelegated Monad accounts, low-balance clamping, and concurrent RPC startup.